### PR TITLE
fix(metrics): Rename leftover reference to purgeStoredMetrics() function

### DIFF
--- a/examples/cdk/lib/example-function.MyFunction.ts
+++ b/examples/cdk/lib/example-function.MyFunction.ts
@@ -37,7 +37,7 @@ export const handler = async (_event: unknown, context: Context): Promise<void> 
   metricWithItsOwnDimensions.addDimension('InnerDimension', 'true');
   metricWithItsOwnDimensions.addMetric('single-metric', MetricUnits.Percent, 50);
 
-  metrics.purgeStoredMetrics();
+  metrics.publishStoredMetrics();
   metrics.raiseOnEmptyMetrics();
 
   // ### Experiment tracer

--- a/packages/metrics/tests/unit/Metrics.test.ts
+++ b/packages/metrics/tests/unit/Metrics.test.ts
@@ -511,7 +511,7 @@ describe('Class: Metrics', () => {
       await new LambdaFunction().handler(dummyEvent, dummyContext.helloworldContext, () => console.log('Lambda invoked!'));
     });
 
-    test('Purge Stored Metrics should log and clear', async () => {
+    test('Publish Stored Metrics should log and clear', async () => {
       const metrics = new Metrics({ namespace: 'test' });
       class LambdaFunction implements LambdaInterface {
         @metrics.logMetrics()


### PR DESCRIPTION
## Description of your changes
Rename the term "purge" that was missed by the PR #377 

This will solve issue #423 

### How to verify this change
```
cd examples/cdk
# switch to target aws account
cdk deploy 
aws lambda invoke --function-name <function_name_should_start_with_CdkAppStack-MyFunction>
# check that the EMF is published on CloudWatch log
```
![image](https://user-images.githubusercontent.com/61999/148413695-654fe395-7d30-45f3-81d5-b6b436db0d17.png)

### Related issues, RFCs

<!--- Add here the link to one or more Github Issues or RFCs that are related to this PR. -->
#377 
#423

### PR status

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [x] I have made corresponding changes to the *documentation*
- [x] My changes generate *no new warnings*
- [x] The *code coverage* hasn't decreased
- [x] I have *added tests* that prove my change is effective and works
- [x] New and existing *unit tests pass* locally and in Github Actions
- [x] Any *dependent changes have been merged and published* in downstream module
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

- [ ] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
