### PR TITLE
fix(build): Fix linting issue and add linting to the pre-push hook

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,5 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
+npm run lerna-lint
 npm run test

--- a/packages/metrics/src/Metrics.ts
+++ b/packages/metrics/src/Metrics.ts
@@ -282,27 +282,6 @@ class Metrics implements MetricsInterface {
   }
 
   /**
-   * Throw an Error if the metrics buffer is empty.
-   *
-   * @example
-   *
-   * ```typescript
-   * import { Metrics, MetricUnits } from '@aws-lambda-powertools/metrics';
-   * import { Context } from 'aws-lambda';
-   *
-   * const metrics = new Metrics({namespace:"serverlessAirline", serviceName:"orders"});
-   *
-   * export const handler = async (event: any, context: Context) => {
-   *     metrics.throwOnEmptyMetrics();
-   *     metrics.publishStoredMetrics(); // will throw since no metrics added.
-   * }
-   * ```
-   */
-  public throwOnEmptyMetrics(): void {
-    this.shouldThrowOnEmptyMetrics = true;
-  }
-
-  /**
    * Function to create the right object compliant with Cloudwatch EMF (Event Metric Format).
    * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Embedded_Metric_Format_Specification.html for more details
    * @returns {string}
@@ -384,6 +363,27 @@ class Metrics implements MetricsInterface {
       defaultDimensions: this.defaultDimensions,
       singleMetric: true,
     });
+  }
+
+  /**
+   * Throw an Error if the metrics buffer is empty.
+   *
+   * @example
+   *
+   * ```typescript
+   * import { Metrics, MetricUnits } from '@aws-lambda-powertools/metrics';
+   * import { Context } from 'aws-lambda';
+   *
+   * const metrics = new Metrics({namespace:"serverlessAirline", serviceName:"orders"});
+   *
+   * export const handler = async (event: any, context: Context) => {
+   *     metrics.throwOnEmptyMetrics();
+   *     metrics.publishStoredMetrics(); // will throw since no metrics added.
+   * }
+   * ```
+   */
+  public throwOnEmptyMetrics(): void {
+    this.shouldThrowOnEmptyMetrics = true;
   }
 
   private getCurrentDimensionsCount(): number {


### PR DESCRIPTION
## Description of your changes
1. Fix linting issue that is breaking the build > https://github.com/awslabs/aws-lambda-powertools-typescript/actions/runs/1666735269 
2. Add pre-push hook to run linting

### How to verify this change
`npm run lerna-lint`

### Related issues, RFCs
N/A

### PR status

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [x] I have made corresponding changes to the *documentation*
- [x] My changes generate *no new warnings*
- [x] The *code coverage* hasn't decreased
- [x] I have *added tests* that prove my change is effective and works
- [x] New and existing *unit tests pass* locally and in Github Actions
- [x] Any *dependent changes have been merged and published* in downstream module
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

- [ ] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
