### PR TITLE
fix(tracer): avoid throwing errors in manual instrumentation when running outside of AWS Lambda 

### DIFF
--- a/packages/tracing/tests/unit/Tracer.test.ts
+++ b/packages/tracing/tests/unit/Tracer.test.ts
@@ -299,7 +299,7 @@ describe('Class: Tracer', () => {
 
     });
 
-    test('when called outside of a namespace or without parent segment, and Tracer is NOT active, it returns a dummy subsegment', () => {
+    test('when called outside of a namespace or without parent segment, and tracing is disabled, it returns a dummy subsegment', () => {
 
       // Prepare
       delete process.env.AWS_EXECUTION_ENV; // This will disable the tracer, simulating local execution

--- a/packages/tracing/tests/unit/Tracer.test.ts
+++ b/packages/tracing/tests/unit/Tracer.test.ts
@@ -274,7 +274,7 @@ describe('Class: Tracer', () => {
 
   describe('Method: getSegment', () => {
 
-    test('when called outside of a namespace or without parent segment, it throws an error', () => {
+    test('when called outside of a namespace or without parent segment, and Tracer is active, it throws an error', () => {
 
       // Prepare
       const tracer: Tracer = new Tracer();
@@ -286,7 +286,7 @@ describe('Class: Tracer', () => {
 
     });
 
-    test('when called outside of a namespace or without parent segment, it throws an error', () => {
+    test('when called and no segment is returned, while Tracer is active, it throws an error', () => {
 
       // Prepare
       const tracer: Tracer = new Tracer();
@@ -298,7 +298,22 @@ describe('Class: Tracer', () => {
       }).toThrow('Failed to get the current sub/segment from the context.');
 
     });
-    
+
+    test('when called outside of a namespace or without parent segment, and Tracer is NOT active, it returns a dummy subsegment', () => {
+
+      // Prepare
+      delete process.env.AWS_EXECUTION_ENV; // This will disable the tracer, simulating local execution
+      const tracer: Tracer = new Tracer();
+
+      // Act
+      const segment = tracer.getSegment();
+
+      // Assess
+      expect(segment).toBeInstanceOf(Subsegment);
+      expect(segment.name).toBe('## Dummy segment');
+
+    });
+
     test('when called within a namespace, it returns the parent segment', () => {
 
       // Prepare
@@ -320,7 +335,7 @@ describe('Class: Tracer', () => {
   });
 
   describe('Method: setSegment', () => {
-    test('when called outside of a namespace or without parent segment, it throws an error', () => {
+    test('when called outside of a namespace or without parent segment, and Tracer is enabled, it throws an error', () => {
       
       // Prepare
       const tracer: Tracer = new Tracer();
@@ -330,6 +345,22 @@ describe('Class: Tracer', () => {
         const newSubsegment = new Subsegment('## foo.bar');
         tracer.setSegment(newSubsegment);
       }).toThrow('No context available. ns.run() or ns.bind() must be called first.');
+    });
+
+    test('when called outside of a namespace or without parent segment, and Tracer is NOT enabled, it does nothing', () => {
+      
+      // Prepare
+      delete process.env.AWS_EXECUTION_ENV; // This will disable the tracer, simulating local execution
+      const tracer: Tracer = new Tracer();
+      const setSegmentSpy = jest.spyOn(tracer.provider, 'setSegment');
+    
+      // Act
+      const newSubsegment = new Subsegment('## foo.bar');
+      tracer.setSegment(newSubsegment);
+      
+      // Assess
+      expect(setSegmentSpy).toBeCalledTimes(0);
+
     });
 
     test('when called within a namespace, it sets the segment', () => {

--- a/packages/tracing/tests/unit/Tracer.test.ts
+++ b/packages/tracing/tests/unit/Tracer.test.ts
@@ -274,7 +274,7 @@ describe('Class: Tracer', () => {
 
   describe('Method: getSegment', () => {
 
-    test('when called outside of a namespace or without parent segment, and Tracer is active, it throws an error', () => {
+    test('when called outside of a namespace or without parent segment, and tracing is enabled, it throws an error', () => {
 
       // Prepare
       const tracer: Tracer = new Tracer();

--- a/packages/tracing/tests/unit/Tracer.test.ts
+++ b/packages/tracing/tests/unit/Tracer.test.ts
@@ -347,7 +347,7 @@ describe('Class: Tracer', () => {
       }).toThrow('No context available. ns.run() or ns.bind() must be called first.');
     });
 
-    test('when called outside of a namespace or without parent segment, and Tracer is NOT enabled, it does nothing', () => {
+    test('when called outside of a namespace or without parent segment, and tracing is disabled, it does nothing', () => {
       
       // Prepare
       delete process.env.AWS_EXECUTION_ENV; // This will disable the tracer, simulating local execution

--- a/packages/tracing/tests/unit/Tracer.test.ts
+++ b/packages/tracing/tests/unit/Tracer.test.ts
@@ -286,7 +286,7 @@ describe('Class: Tracer', () => {
 
     });
 
-    test('when called and no segment is returned, while Tracer is active, it throws an error', () => {
+    test('when called and no segment is returned, while tracing is enabled, it throws an error', () => {
 
       // Prepare
       const tracer: Tracer = new Tracer();


### PR DESCRIPTION
## Description of your changes

As reporded by @ijemmy during manual tests manually instrumenting a function with `Tracer` outside of AWS Lambda was throwing an error due to the lack of traces & context.

This was a bug since `Tracer` should automatically detect its running outside of Lambda and deactivate itself. The bug affected only manual instrumentation while the Middy middleware and Class decorator were unaffected.

Changes:
- Now leveraging the `setContextMissingStrategy()` method [from the Node.js x-ray-sdk](https://github.com/willarmiros/aws-lambda-developer-guide/blob/cb769974339cd46b7264301ab4dbf45cdb7c51df/doc_source/nodejs-tracing.md?plain=1#L41-L42) to disable throwing errors when tracing is disabled.
- Changed behaviour of `Tracer.setSegment()` & `Tracer.getSegment()` to respect value of `Tracer. tracingEnabled`
- Now `Tracer.getSegment()` returns a dummy segment when tracing is disabled
- Uniformed usage of `Tracer.isTracingEnabled()` over accessing attribute directly throughout class
- Added additional unit test cases to cover new behaviours

### How to verify this change

Check that all checks are successful, OR:
1. Checkout branch locally
2. `cd packages/tracing && npm run package`
3. Init new project & install version packaged at previous step
4. Run the lambda below (in Javascript, no TS needed) & you should not see any error

```js
const { Tracer } = require('@aws-lambda-powertools/tracer');

const tracer = new Tracer({ serviceName: 'serverlessAirline' });

const handler = async (_event, context) => {
    const segment = tracer.getSegment(); // This is the facade segment (the one that is created by AWS Lambda)
    // Create subsegment for the function & set it as active
    const subsegment = segment.addNewSubsegment(`## ${process.env._HANDLER}`);
    tracer.setSegment(subsegment);

    // Annotate the subsegment with the cold start & serviceName
    tracer.annotateColdStart();
    tracer.addServiceNameAnnotation();

    let res;
    try {
        /* ... */
        // Add the response as metadata 
        tracer.addResponseAsMetadata(res, process.env._HANDLER);
    } catch (err) {
        // Add the error as metadata
        tracer.addErrorAsMetadata(err);
        throw err;
    } finally {
        // Close subsegment (the AWS Lambda one is closed automatically)
        subsegment.close();
        // Set back the facade segment as active again
        tracer.setSegment(segment);
    }
    console.log('ALL GOOD');
    return res;
};

handler();
```

### Related issues, RFCs

N/A

### PR status

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [x] My changes generate *no new warnings*
- [x] The *code coverage* hasn't decreased
- [x] I have *added tests* that prove my change is effective and works
- [x] New and existing *unit tests pass* locally and in Github Actions
- [x] Any *dependent changes have been merged and published* in downstream module
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

N/A

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
