### PR TITLE
docs: updated tenets section to conform w other runtimes

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@ AWS Lambda Powertools TypeScript provides a suite of utilities for AWS Lambda fu
 
 ## Tenets
 
-This project separates core utilities that will be available in other runtimes vs general utilities that might not be available across all runtimes.
+Core utilities such as Tracing, Logging, Metrics, and Event Handler will be available across all Lambda Powertools runtimes. Additional utilities are subjective to each language ecosystem and customer demand.
 
 * **AWS Lambda only**. We optimise for AWS Lambda function environments and supported runtimes only. Utilities might work with web frameworks and non-Lambda environments, though they are not officially supported.
 * **Eases the adoption of best practices**. The main priority of the utilities is to facilitate best practices adoption, as defined in the AWS Well-Architected Serverless Lens; all other functionality is optional.

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@ AWS Lambda Powertools TypeScript provides a suite of utilities for AWS Lambda fu
 
 ## Tenets
 
-Core utilities such as Tracing, Logging, Metrics, and Event Handler will be available across all Lambda Powertools runtimes. Additional utilities are subjective to each language ecosystem and customer demand.
+Core utilities such as Tracer, Logger, Metrics, and Event Handler will be available across all Lambda Powertools runtimes. Additional utilities are subjective to each language ecosystem and customer demand.
 
 * **AWS Lambda only**. We optimise for AWS Lambda function environments and supported runtimes only. Utilities might work with web frameworks and non-Lambda environments, though they are not officially supported.
 * **Eases the adoption of best practices**. The main priority of the utilities is to facilitate best practices adoption, as defined in the AWS Well-Architected Serverless Lens; all other functionality is optional.


### PR DESCRIPTION
## Description of your changes

This PR aims at clarifying our explanation about core/non-core utility availability. It follows [this change](https://github.com/awslabs/aws-lambda-powertools-python/commit/3e4e1abaebea360c01752726b62af8b805bbe3ac) made in the Python's Powertools repo.

BEFORE: This project separates core utilities that will be available in other runtimes vs general utilities that might not be available across all runtimes
AFTER: Core utilities such as Tracing, Logging, Metrics, and Event Handler will be available across all Lambda Powertools runtimes. Additional utilities are subjective to each language ecosystem and customer demand.

### How to verify this change

Checkout branch, run docs locally.

### Related issues, RFCs

N/A

### PR status

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have made corresponding changes to the *documentation*
- [x] My changes generate *no new warnings*
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

N/A

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
