### PR TITLE
chore(cicd): fix trigger for gh actions linting andctesting PR from fork

### DIFF
--- a/.github/workflows/pr_lint_and_test.yml
+++ b/.github/workflows/pr_lint_and_test.yml
@@ -1,9 +1,7 @@
 name: on-push-event
 on:
-  push:
-    branches:    
-          - '**'        # matches every branch
-          - '!main' 
+  pull_request:
+    types: [opened, synchronize]
 jobs:
   on_push:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr_lint_and_test.yml
+++ b/.github/workflows/pr_lint_and_test.yml
@@ -1,4 +1,4 @@
-name: on-push-event
+name: pr-lint-and-test
 on:
   pull_request:
     types: [opened, synchronize]


### PR DESCRIPTION
## Description of your changes
 
PRs from fork are not lint or tested properly with our current workflow. This PR change the trigger to make sure it runs on opened or synchronize (details below).

> `synchronize`: Triggered when a pull request's head branch is updated. For example, when the head branch is updated from the base branch, when new commits are pushed to the head branch, or when the base branch is changed.
(cf. https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#pull_request)

### How to verify this change

check tests on this PR: https://github.com/devfest-bugbust/aws-lambda-powertools-typescript/pull/3 (don't look at the changes, what matters are the actions run).

### PR status

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [x] I have made corresponding changes to the *documentation*
- [x] My changes generate *no new warnings*
- [x] The *code coverage* hasn't decreased
- [x] I have *added tests* that prove my change is effective and works
- [x] New and existing *unit tests pass* locally and in Github Actions
- [x] Any *dependent changes have been merged and published* in downstream module
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)


---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
