### PR TITLE
chore(cicd): fix package-lock.json messed up by lerna version

### DIFF
--- a/packages/logger/package-lock.json
+++ b/packages/logger/package-lock.json
@@ -6,10 +6,10 @@
   "packages": {
     "": {
       "name": "@aws-lambda-powertools/logger",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
-        "@aws-lambda-powertools/commons": "0.2.0",
+        "@aws-lambda-powertools/commons": "^0.3.0",
         "@middy/core": "^2.5.3",
         "@types/aws-lambda": "^8.10.72",
         "lodash.clonedeep": "^4.5.0",
@@ -36,9 +36,9 @@
       }
     },
     "node_modules/@aws-lambda-powertools/commons": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/commons/-/commons-0.2.0.tgz",
-      "integrity": "sha512-h0YItiAkJkTTbKBJxR2Xe5iQMjkyZq7eLPJe4Dpm4RaiwzXG2Ejwt1jt/QoDcaJoxqWPrUnWteNtQzpEB8u2qQ==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/commons/-/commons-0.3.0.tgz",
+      "integrity": "sha512-pyHaX3j0+CcGCEusRLKJeYoxd4ZFrT4L2+TQBdhS6fVNru+uVJwCcXtzzHz8ePut8q7fqwZwD7HBOL2Pvq5BRA==",
       "dependencies": {
         "@types/aws-lambda": "^8.10.72"
       }
@@ -6020,9 +6020,9 @@
   },
   "dependencies": {
     "@aws-lambda-powertools/commons": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/commons/-/commons-0.2.0.tgz",
-      "integrity": "sha512-h0YItiAkJkTTbKBJxR2Xe5iQMjkyZq7eLPJe4Dpm4RaiwzXG2Ejwt1jt/QoDcaJoxqWPrUnWteNtQzpEB8u2qQ==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/commons/-/commons-0.3.0.tgz",
+      "integrity": "sha512-pyHaX3j0+CcGCEusRLKJeYoxd4ZFrT4L2+TQBdhS6fVNru+uVJwCcXtzzHz8ePut8q7fqwZwD7HBOL2Pvq5BRA==",
       "requires": {
         "@types/aws-lambda": "^8.10.72"
       }

--- a/packages/metrics/package-lock.json
+++ b/packages/metrics/package-lock.json
@@ -6,10 +6,10 @@
   "packages": {
     "": {
       "name": "@aws-lambda-powertools/metrics",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT-0",
       "dependencies": {
-        "@aws-lambda-powertools/commons": "0.2.0",
+        "@aws-lambda-powertools/commons": "^0.3.0",
         "@types/aws-lambda": "^8.10.72"
       },
       "devDependencies": {
@@ -810,9 +810,9 @@
       }
     },
     "node_modules/@aws-lambda-powertools/commons": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/commons/-/commons-0.2.0.tgz",
-      "integrity": "sha512-h0YItiAkJkTTbKBJxR2Xe5iQMjkyZq7eLPJe4Dpm4RaiwzXG2Ejwt1jt/QoDcaJoxqWPrUnWteNtQzpEB8u2qQ==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/commons/-/commons-0.3.0.tgz",
+      "integrity": "sha512-pyHaX3j0+CcGCEusRLKJeYoxd4ZFrT4L2+TQBdhS6fVNru+uVJwCcXtzzHz8ePut8q7fqwZwD7HBOL2Pvq5BRA==",
       "dependencies": {
         "@types/aws-lambda": "^8.10.72"
       }
@@ -9989,9 +9989,9 @@
       "dev": true
     },
     "@aws-lambda-powertools/commons": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/commons/-/commons-0.2.0.tgz",
-      "integrity": "sha512-h0YItiAkJkTTbKBJxR2Xe5iQMjkyZq7eLPJe4Dpm4RaiwzXG2Ejwt1jt/QoDcaJoxqWPrUnWteNtQzpEB8u2qQ==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/commons/-/commons-0.3.0.tgz",
+      "integrity": "sha512-pyHaX3j0+CcGCEusRLKJeYoxd4ZFrT4L2+TQBdhS6fVNru+uVJwCcXtzzHz8ePut8q7fqwZwD7HBOL2Pvq5BRA==",
       "requires": {
         "@types/aws-lambda": "^8.10.72"
       }

--- a/packages/tracing/package-lock.json
+++ b/packages/tracing/package-lock.json
@@ -6,10 +6,10 @@
   "packages": {
     "": {
       "name": "@aws-lambda-powertools/tracer",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT-0",
       "dependencies": {
-        "@aws-lambda-powertools/commons": "0.2.0",
+        "@aws-lambda-powertools/commons": "^0.3.0",
         "@middy/core": "^2.5.3",
         "aws-xray-sdk-core": "^3.3.3"
       },
@@ -866,9 +866,9 @@
       }
     },
     "node_modules/@aws-lambda-powertools/commons": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/commons/-/commons-0.2.0.tgz",
-      "integrity": "sha512-h0YItiAkJkTTbKBJxR2Xe5iQMjkyZq7eLPJe4Dpm4RaiwzXG2Ejwt1jt/QoDcaJoxqWPrUnWteNtQzpEB8u2qQ==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/commons/-/commons-0.3.0.tgz",
+      "integrity": "sha512-pyHaX3j0+CcGCEusRLKJeYoxd4ZFrT4L2+TQBdhS6fVNru+uVJwCcXtzzHz8ePut8q7fqwZwD7HBOL2Pvq5BRA==",
       "dependencies": {
         "@types/aws-lambda": "^8.10.72"
       }
@@ -10284,9 +10284,9 @@
       }
     },
     "@aws-lambda-powertools/commons": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/commons/-/commons-0.2.0.tgz",
-      "integrity": "sha512-h0YItiAkJkTTbKBJxR2Xe5iQMjkyZq7eLPJe4Dpm4RaiwzXG2Ejwt1jt/QoDcaJoxqWPrUnWteNtQzpEB8u2qQ==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/commons/-/commons-0.3.0.tgz",
+      "integrity": "sha512-pyHaX3j0+CcGCEusRLKJeYoxd4ZFrT4L2+TQBdhS6fVNru+uVJwCcXtzzHz8ePut8q7fqwZwD7HBOL2Pvq5BRA==",
       "requires": {
         "@types/aws-lambda": "^8.10.72"
       }


### PR DESCRIPTION
## Description of your changes

`package-lock.json` are not matching `package.json` which breaks `npm ci` commands. This PR fix it.
 
### How to verify this change

GH actions should pass and especially `npm run lerna-ci`

### Related issues, RFCs

#468 

### PR status

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [x] I have made corresponding changes to the *documentation*
- [x] My changes generate *no new warnings*
- [x] The *code coverage* hasn't decreased
- [x] I have *added tests* that prove my change is effective and works
- [x] New and existing *unit tests pass* locally and in Github Actions
- [x] Any *dependent changes have been merged and published* in downstream module
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)


---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
