### PR TITLE
fix(all): fix latest release broken by change of npm pack result on common

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,6 @@ Please read through this document before submitting any issues or pull requests 
 information to effectively respond to your bug report or contribution.
 
 ## Security issue notifications
-
 If you discover a potential security issue in this project we ask that you notify AWS/Amazon Security via our [vulnerability reporting page](http://aws.amazon.com/security/vulnerability-reporting/). Please do **not** create a public GitHub issue.
 
 ## Reporting Bugs/Feature Requests
@@ -36,7 +35,7 @@ Contributions via pull requests are much appreciated. Before sending us a pull r
 To send us a pull request, please follow these steps:
 
 1. Fork the repository.
-2. Install dependencies: `npm ci`
+2. Install dependencies: `npm install`
 3. Prepare utilities like commit hooks: `npm run init-environment`
 4. Create a new branch to focus on the specific change you are contributing e.g. `git checkout -b improv/logger-debug-sampling`
 5. Run all tests, and code baseline checks: `npm run test`
@@ -55,9 +54,8 @@ You might find useful to run both the documentation website and the API referenc
 * **Docs website**:
 
 You can build and start a local docs website by running these two commands.
-
-* `npm run docs-buildDockerImage` OR `docker build -t squidfunk/mkdocs-material ./docs/`
-* `npm run docs-runLocalDocker` OR `docker run --rm -it -p 8000:8000 -v ${PWD}:/docs squidfunk/mkdocs-material`
+  - `npm run docs-buildDockerImage` OR `docker build -t squidfunk/mkdocs-material ./docs/`
+  - `npm run docs-runLocalDocker` OR `docker run --rm -it -p 8000:8000 -v ${PWD}:/docs squidfunk/mkdocs-material`
 
 ### Tests
 

--- a/packages/commons/tsconfig.json
+++ b/packages/commons/tsconfig.json
@@ -1,6 +1,5 @@
 {
     "compilerOptions": {
-        "composite": true,
         "experimentalDecorators": true,
         "noImplicitAny": true,
         "target": "ES2020",

--- a/packages/logger/package-lock.json
+++ b/packages/logger/package-lock.json
@@ -6,10 +6,10 @@
   "packages": {
     "": {
       "name": "@aws-lambda-powertools/logger",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
-        "@aws-lambda-powertools/commons": "0.2.0",
+        "@aws-lambda-powertools/commons": "^0.2.0",
         "@middy/core": "^2.5.3",
         "@types/aws-lambda": "^8.10.72",
         "lodash.clonedeep": "^4.5.0",

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -71,7 +71,7 @@
     "url": "https://github.com/awslabs/aws-lambda-powertools-typescript/issues"
   },
   "dependencies": {
-    "@aws-lambda-powertools/commons": "^0.3.0",
+    "@aws-lambda-powertools/commons": "^0.2.0",
     "@middy/core": "^2.5.3",
     "@types/aws-lambda": "^8.10.72",
     "lodash.clonedeep": "^4.5.0",

--- a/packages/logger/tsconfig.json
+++ b/packages/logger/tsconfig.json
@@ -26,10 +26,5 @@
     "types": [
         "jest",
         "node"
-    ],
-    "references": [
-        {
-            "path": "../commons"
-        }
     ]
 }

--- a/packages/metrics/package-lock.json
+++ b/packages/metrics/package-lock.json
@@ -6,10 +6,10 @@
   "packages": {
     "": {
       "name": "@aws-lambda-powertools/metrics",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT-0",
       "dependencies": {
-        "@aws-lambda-powertools/commons": "0.2.0",
+        "@aws-lambda-powertools/commons": "^0.2.0",
         "@types/aws-lambda": "^8.10.72"
       },
       "devDependencies": {

--- a/packages/metrics/package.json
+++ b/packages/metrics/package.json
@@ -84,7 +84,7 @@
     "url": "https://github.com/awslabs/aws-lambda-powertools-typescript/issues"
   },
   "dependencies": {
-    "@aws-lambda-powertools/commons": "^0.3.0",
+    "@aws-lambda-powertools/commons": "^0.2.0",
     "@types/aws-lambda": "^8.10.72"
   }
 }

--- a/packages/metrics/tsconfig.json
+++ b/packages/metrics/tsconfig.json
@@ -28,10 +28,5 @@
     "types": [
         "jest",
         "node"
-    ],
-    "references": [
-        {
-            "path": "../commons"
-        }
     ]
 }

--- a/packages/tracing/package-lock.json
+++ b/packages/tracing/package-lock.json
@@ -6,10 +6,10 @@
   "packages": {
     "": {
       "name": "@aws-lambda-powertools/tracer",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT-0",
       "dependencies": {
-        "@aws-lambda-powertools/commons": "0.2.0",
+        "@aws-lambda-powertools/commons": "^0.2.0",
         "@middy/core": "^2.5.3",
         "aws-xray-sdk-core": "^3.3.3"
       },

--- a/packages/tracing/package.json
+++ b/packages/tracing/package.json
@@ -62,7 +62,7 @@
     "url": "https://github.com/awslabs/aws-lambda-powertools-typescript/issues"
   },
   "dependencies": {
-    "@aws-lambda-powertools/commons": "^0.3.0",
+    "@aws-lambda-powertools/commons": "^0.2.0",
     "@middy/core": "^2.5.3",
     "aws-xray-sdk-core": "^3.3.3"
   }

--- a/packages/tracing/tsconfig.json
+++ b/packages/tracing/tsconfig.json
@@ -28,10 +28,5 @@
     "types": [
         "jest",
         "node"
-    ],
-    "references": [
-        {
-            "path": "../commons"
-        }
     ]
 }


### PR DESCRIPTION
## Description of your changes

This commit was modifying the way `npm pack` structures `commons` package ... which break all deps.

### How to verify this change

```
cd packages/commons
npm pack
```
check stdout structure and check `/lib/index.js` match package.json `main` path. 

E2E tests:

```  
npm run lerna-package
cd examples/cdk
npm run build
npm install aws-sdk
 npm run build
```

### Related issues, RFCs

TBD

### PR status

***Is this ready for review?:*** NO  
***Is it a breaking change?:*** NO

## Checklist

- [ ] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
- [ ] I have performed a *self-review* of my own code
- [ ] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [ ] I have made corresponding changes to the *documentation*
- [ ] My changes generate *no new warnings*
- [ ] The *code coverage* hasn't decreased
- [ ] I have *added tests* that prove my change is effective and works
- [ ] New and existing *unit tests pass* locally and in Github Actions
- [ ] Any *dependent changes have been merged and published* in downstream module
- [ ] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

- [ ] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
