### PR TITLE
fix(logger): correctly export LogFormatter

### DIFF
--- a/docs/core/logger.md
+++ b/docs/core/logger.md
@@ -625,13 +625,13 @@ This is how the `MyCompanyLogFormatter` (dummy name) would look like:
 === "utils/formatters/MyCompanyLogFormatter.ts"
 
     ```typescript
-    import { LogFormatter } from "@aws-lambda-powertools/logger";
-    import { LogAttributes, UnformattedAttributes } from "@aws-lambda-powertools/logger/types";
+    import { LogFormatter } from '@aws-lambda-powertools/logger';
+    import { LogAttributes, UnformattedAttributes } from '@aws-lambda-powertools/logger/lib/types';
     
     // Replace this line with your own type
     type MyCompanyLog = LogAttributes;
     
-    class MyCompanyLogFormatter implements LogFormatter {
+    class MyCompanyLogFormatter extends LogFormatter {
     
         public formatAttributes(attributes: UnformattedAttributes): MyCompanyLog {
             return {

--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -1,3 +1,4 @@
 export * from './helpers';
 export * from './Logger';
 export * from './middleware';
+export * from './formatter';


### PR DESCRIPTION
## Description of your changes

This PR aims at resolving the issue highlighted in #393 that prevented customers to use `LogFormatter` (from `Logger`) as described in the docs.


### How to verify this change

Build the utility with `npm pack` & install it in other project/examples, then try to use  to see exported class.

See below:
![Screenshot 2022-01-17 at 14 47 18](https://user-images.githubusercontent.com/7353869/149780786-8e50375f-5ac0-404f-8e5c-4f71ca8c82f6.png)


### Related issues, RFCs

[#393](https://github.com/awslabs/aws-lambda-powertools-typescript/issues/393)  

### PR status

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [x] I have made corresponding changes to the *documentation*
- [x] My changes generate *no new warnings*
- [x] The *code coverage* hasn't decreased
- [x] New and existing *unit tests pass* locally and in Github Actions
- [x] Any *dependent changes have been merged and published* in downstream module
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

N/A

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
