### PR TITLE
build(deps-dev): bump typedoc from 0.22.10 to 0.22.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "jest": "^27.0.4",
         "lerna": "^4.0.0",
         "ts-jest": "^27.0.3",
-        "typedoc": "0.22.10",
+        "typedoc": "^0.22.11",
         "typedoc-plugin-missing-exports": "^0.22.6",
         "typescript": "^4.1.3"
       },
@@ -11998,12 +11998,12 @@
       }
     },
     "node_modules/marked": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-3.0.8.tgz",
-      "integrity": "sha512-0gVrAjo5m0VZSJb4rpL59K1unJAMb/hm8HRXqasD8VeC8m91ytDPMritgFSlKonfdt+rRYYpP/JfLxgIX8yoSw==",
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.10.tgz",
+      "integrity": "sha512-+QvuFj0nGgO970fySghXGmuw+Fd0gD2x3+MqCWLIPf5oxdv1Ka6b2q+z9RP01P/IaKPMEramy+7cNy/Lw8c3hw==",
       "dev": true,
       "bin": {
-        "marked": "bin/marked"
+        "marked": "bin/marked.js"
       },
       "engines": {
         "node": ">= 12"
@@ -14207,9 +14207,9 @@
       }
     },
     "node_modules/shiki": {
-      "version": "0.9.15",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.9.15.tgz",
-      "integrity": "sha512-/Y0z9IzhJ8nD9nbceORCqu6NgT9X6I8Fk8c3SICHI5NbZRLdZYFaB233gwct9sU0vvSypyaL/qaKvzyQGJBZSw==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.10.0.tgz",
+      "integrity": "sha512-iczxaIYeBFHTFrQPb9DVy2SKgYxC4Wo7Iucm7C17cCh2Ge/refnvHscUOxM85u57MfLoNOtjoEFUWt9gBexblA==",
       "dev": true,
       "dependencies": {
         "jsonc-parser": "^3.0.0",
@@ -15077,16 +15077,16 @@
       }
     },
     "node_modules/typedoc": {
-      "version": "0.22.10",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.10.tgz",
-      "integrity": "sha512-hQYZ4WtoMZ61wDC6w10kxA42+jclWngdmztNZsDvIz7BMJg7F2xnT+uYsUa7OluyKossdFj9E9Ye4QOZKTy8SA==",
+      "version": "0.22.11",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.11.tgz",
+      "integrity": "sha512-pVr3hh6dkS3lPPaZz1fNpvcrqLdtEvXmXayN55czlamSgvEjh+57GUqfhAI1Xsuu/hNHUT1KNSx8LH2wBP/7SA==",
       "dev": true,
       "dependencies": {
         "glob": "^7.2.0",
         "lunr": "^2.3.9",
-        "marked": "^3.0.8",
+        "marked": "^4.0.10",
         "minimatch": "^3.0.4",
-        "shiki": "^0.9.12"
+        "shiki": "^0.10.0"
       },
       "bin": {
         "typedoc": "bin/typedoc"
@@ -15763,7 +15763,7 @@
     },
     "packages/commons": {
       "name": "@aws-lambda-powertools/commons",
-      "version": "0.2.0",
+      "version": "0.3.3",
       "license": "MIT-0",
       "dependencies": {
         "@types/aws-lambda": "^8.10.72"
@@ -15787,10 +15787,10 @@
     },
     "packages/logger": {
       "name": "@aws-lambda-powertools/logger",
-      "version": "0.2.0",
+      "version": "0.3.3",
       "license": "MIT",
       "dependencies": {
-        "@aws-lambda-powertools/commons": "0.2.0",
+        "@aws-lambda-powertools/commons": "^0.2.0",
         "@middy/core": "^2.5.3",
         "@types/aws-lambda": "^8.10.72",
         "lodash.clonedeep": "^4.5.0",
@@ -15810,17 +15810,26 @@
         "eslint-import-resolver-typescript": "^2.5.0",
         "eslint-plugin-import": "^2.25.3",
         "jest": "^27.0.4",
+        "jest-runner-groups": "^2.1.0",
         "ts-jest": "^27.0.3",
         "ts-node": "^10.0.0",
         "typescript": "^4.1.3"
       }
     },
+    "packages/logger/node_modules/@aws-lambda-powertools/commons": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/commons/-/commons-0.2.0.tgz",
+      "integrity": "sha512-h0YItiAkJkTTbKBJxR2Xe5iQMjkyZq7eLPJe4Dpm4RaiwzXG2Ejwt1jt/QoDcaJoxqWPrUnWteNtQzpEB8u2qQ==",
+      "dependencies": {
+        "@types/aws-lambda": "^8.10.72"
+      }
+    },
     "packages/metrics": {
       "name": "@aws-lambda-powertools/metrics",
-      "version": "0.2.0",
+      "version": "0.3.3",
       "license": "MIT-0",
       "dependencies": {
-        "@aws-lambda-powertools/commons": "0.2.0",
+        "@aws-lambda-powertools/commons": "^0.2.0",
         "@types/aws-lambda": "^8.10.72"
       },
       "devDependencies": {
@@ -15847,12 +15856,20 @@
         "typescript": "^4.1.3"
       }
     },
+    "packages/metrics/node_modules/@aws-lambda-powertools/commons": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/commons/-/commons-0.2.0.tgz",
+      "integrity": "sha512-h0YItiAkJkTTbKBJxR2Xe5iQMjkyZq7eLPJe4Dpm4RaiwzXG2Ejwt1jt/QoDcaJoxqWPrUnWteNtQzpEB8u2qQ==",
+      "dependencies": {
+        "@types/aws-lambda": "^8.10.72"
+      }
+    },
     "packages/tracing": {
       "name": "@aws-lambda-powertools/tracer",
-      "version": "0.2.0",
+      "version": "0.3.3",
       "license": "MIT-0",
       "dependencies": {
-        "@aws-lambda-powertools/commons": "0.2.0",
+        "@aws-lambda-powertools/commons": "^0.2.0",
         "@middy/core": "^2.5.3",
         "aws-xray-sdk-core": "^3.3.3"
       },
@@ -15877,6 +15894,14 @@
         "ts-jest": "^27.0.5",
         "ts-node": "^10.0.0",
         "typescript": "^4.1.3"
+      }
+    },
+    "packages/tracing/node_modules/@aws-lambda-powertools/commons": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/commons/-/commons-0.2.0.tgz",
+      "integrity": "sha512-h0YItiAkJkTTbKBJxR2Xe5iQMjkyZq7eLPJe4Dpm4RaiwzXG2Ejwt1jt/QoDcaJoxqWPrUnWteNtQzpEB8u2qQ==",
+      "dependencies": {
+        "@types/aws-lambda": "^8.10.72"
       }
     }
   },
@@ -16428,7 +16453,7 @@
     "@aws-lambda-powertools/logger": {
       "version": "file:packages/logger",
       "requires": {
-        "@aws-lambda-powertools/commons": "0.2.0",
+        "@aws-lambda-powertools/commons": "^0.2.0",
         "@middy/core": "^2.5.3",
         "@types/aws-lambda": "^8.10.72",
         "@types/jest": "^27.0.0",
@@ -16443,12 +16468,23 @@
         "eslint-import-resolver-typescript": "^2.5.0",
         "eslint-plugin-import": "^2.25.3",
         "jest": "^27.0.4",
+        "jest-runner-groups": "^2.1.0",
         "lodash.clonedeep": "^4.5.0",
         "lodash.merge": "^4.6.2",
         "lodash.pickby": "^4.6.0",
         "ts-jest": "^27.0.3",
         "ts-node": "^10.0.0",
         "typescript": "^4.1.3"
+      },
+      "dependencies": {
+        "@aws-lambda-powertools/commons": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/commons/-/commons-0.2.0.tgz",
+          "integrity": "sha512-h0YItiAkJkTTbKBJxR2Xe5iQMjkyZq7eLPJe4Dpm4RaiwzXG2Ejwt1jt/QoDcaJoxqWPrUnWteNtQzpEB8u2qQ==",
+          "requires": {
+            "@types/aws-lambda": "^8.10.72"
+          }
+        }
       }
     },
     "@aws-lambda-powertools/metrics": {
@@ -16456,7 +16492,7 @@
       "requires": {
         "@aws-cdk/aws-lambda-nodejs": "^1.137.0",
         "@aws-cdk/core": "^1.137.0",
-        "@aws-lambda-powertools/commons": "0.2.0",
+        "@aws-lambda-powertools/commons": "^0.2.0",
         "@commitlint/cli": "^16.0.1",
         "@middy/core": "^2.5.3",
         "@types/aws-lambda": "^8.10.72",
@@ -16476,6 +16512,16 @@
         "ts-jest": "^27.0.5",
         "ts-node": "^10.0.0",
         "typescript": "^4.1.3"
+      },
+      "dependencies": {
+        "@aws-lambda-powertools/commons": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/commons/-/commons-0.2.0.tgz",
+          "integrity": "sha512-h0YItiAkJkTTbKBJxR2Xe5iQMjkyZq7eLPJe4Dpm4RaiwzXG2Ejwt1jt/QoDcaJoxqWPrUnWteNtQzpEB8u2qQ==",
+          "requires": {
+            "@types/aws-lambda": "^8.10.72"
+          }
+        }
       }
     },
     "@aws-lambda-powertools/tracer": {
@@ -16483,7 +16529,7 @@
       "requires": {
         "@aws-cdk/aws-lambda-nodejs": "^1.137.0",
         "@aws-cdk/core": "^1.137.0",
-        "@aws-lambda-powertools/commons": "0.2.0",
+        "@aws-lambda-powertools/commons": "^0.2.0",
         "@aws-sdk/client-sts": "^3.45.0",
         "@middy/core": "^2.5.3",
         "@types/aws-lambda": "^8.10.72",
@@ -16504,6 +16550,16 @@
         "ts-jest": "^27.0.5",
         "ts-node": "^10.0.0",
         "typescript": "^4.1.3"
+      },
+      "dependencies": {
+        "@aws-lambda-powertools/commons": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/commons/-/commons-0.2.0.tgz",
+          "integrity": "sha512-h0YItiAkJkTTbKBJxR2Xe5iQMjkyZq7eLPJe4Dpm4RaiwzXG2Ejwt1jt/QoDcaJoxqWPrUnWteNtQzpEB8u2qQ==",
+          "requires": {
+            "@types/aws-lambda": "^8.10.72"
+          }
+        }
       }
     },
     "@aws-sdk/abort-controller": {
@@ -25755,9 +25811,9 @@
       "dev": true
     },
     "marked": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-3.0.8.tgz",
-      "integrity": "sha512-0gVrAjo5m0VZSJb4rpL59K1unJAMb/hm8HRXqasD8VeC8m91ytDPMritgFSlKonfdt+rRYYpP/JfLxgIX8yoSw==",
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.10.tgz",
+      "integrity": "sha512-+QvuFj0nGgO970fySghXGmuw+Fd0gD2x3+MqCWLIPf5oxdv1Ka6b2q+z9RP01P/IaKPMEramy+7cNy/Lw8c3hw==",
       "dev": true
     },
     "meow": {
@@ -27446,9 +27502,9 @@
       "dev": true
     },
     "shiki": {
-      "version": "0.9.15",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.9.15.tgz",
-      "integrity": "sha512-/Y0z9IzhJ8nD9nbceORCqu6NgT9X6I8Fk8c3SICHI5NbZRLdZYFaB233gwct9sU0vvSypyaL/qaKvzyQGJBZSw==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.10.0.tgz",
+      "integrity": "sha512-iczxaIYeBFHTFrQPb9DVy2SKgYxC4Wo7Iucm7C17cCh2Ge/refnvHscUOxM85u57MfLoNOtjoEFUWt9gBexblA==",
       "dev": true,
       "requires": {
         "jsonc-parser": "^3.0.0",
@@ -28093,16 +28149,16 @@
       }
     },
     "typedoc": {
-      "version": "0.22.10",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.10.tgz",
-      "integrity": "sha512-hQYZ4WtoMZ61wDC6w10kxA42+jclWngdmztNZsDvIz7BMJg7F2xnT+uYsUa7OluyKossdFj9E9Ye4QOZKTy8SA==",
+      "version": "0.22.11",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.11.tgz",
+      "integrity": "sha512-pVr3hh6dkS3lPPaZz1fNpvcrqLdtEvXmXayN55czlamSgvEjh+57GUqfhAI1Xsuu/hNHUT1KNSx8LH2wBP/7SA==",
       "dev": true,
       "requires": {
         "glob": "^7.2.0",
         "lunr": "^2.3.9",
-        "marked": "^3.0.8",
+        "marked": "^4.0.10",
         "minimatch": "^3.0.4",
-        "shiki": "^0.9.12"
+        "shiki": "^0.10.0"
       }
     },
     "typedoc-plugin-missing-exports": {

--- a/package.json
+++ b/package.json
@@ -54,9 +54,9 @@
     "jest": "^27.0.4",
     "lerna": "^4.0.0",
     "ts-jest": "^27.0.3",
-    "typedoc": "0.22.10",
-    "typescript": "^4.1.3",
-    "typedoc-plugin-missing-exports": "^0.22.6"
+    "typedoc": "^0.22.11",
+    "typedoc-plugin-missing-exports": "^0.22.6",
+    "typescript": "^4.1.3"
   },
   "files": [
     "lib/**/*"


### PR DESCRIPTION
## Description of your changes

Following security advisory [GHSA-5v2h-r2cx-5xgj](https://github.com/advisories/GHSA-5v2h-r2cx-5xgj) that impacted `marked` a dependency of `typedoc` which we use to generate the docs for the project's API, this PR bumps the version of `typedoc` to `v0.22.11` which in turn uses `marked@4.0.10` (see [PR](https://github.com/TypeStrong/typedoc/pull/1851)) that patches the vulnerability. 

### How to verify this change

Checkout branch, run `npm ci` while in root & then run `npm run docs-generateApiDoc` + `npm run docs-runLocalApiDoc`.

### Related issues, RFCs

N/A

### PR status

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] My changes generate *no new warnings*
- [x] The *code coverage* hasn't decreased
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

N/A

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
