### PR TITLE
fix(logger|metrics): return decorated class

### DIFF
--- a/packages/logger/src/Logger.ts
+++ b/packages/logger/src/Logger.ts
@@ -112,13 +112,13 @@ class Logger implements ClassThatLogs {
   }
 
   public injectLambdaContext(): HandlerMethodDecorator {
-    return (target, propertyKey, descriptor) => {
+    return (target, _propertyKey, descriptor) => {
       const originalMethod = descriptor.value;
 
       descriptor.value = (event, context, callback) => {
         this.addContext(context);
 
-        return originalMethod?.apply(this, [ event, context, callback ]);
+        return originalMethod?.apply(target, [ event, context, callback ]);
       };
     };
   }

--- a/packages/logger/types/LambdaInterface.ts
+++ b/packages/logger/types/LambdaInterface.ts
@@ -1,9 +1,0 @@
-import type { Handler } from 'aws-lambda';
-
-interface LambdaInterface {
-  handler: Handler
-}
-
-export {
-  LambdaInterface
-};

--- a/packages/metrics/src/Metrics.ts
+++ b/packages/metrics/src/Metrics.ts
@@ -244,7 +244,7 @@ class Metrics implements MetricsInterface {
           
         let result: unknown;
         try {
-          result = await originalMethod?.apply(this, [ event, context, callback ]);
+          result = await originalMethod?.apply(target, [ event, context, callback ]);
         } catch (error) {
           throw error;
         } finally {


### PR DESCRIPTION
## Description of your changes

As evidenced in #399 `Logger` and `Metrics` were not correctly returning the decorated class when used as decorators. This PR aims at correcting that behaviour and add unit tests to check that to avoid future regressions.

Additionally this PR removes two unused & leftover files in the `Logger` package.

### How to verify this change

Checkout the branch & run tests or check the GitHub checks results.

### Related issues, RFCs

[#399](https://github.com/awslabs/aws-lambda-powertools-typescript/issues/399)  

### PR status

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [x] I have made corresponding changes to the *documentation*
- [x] My changes generate *no new warnings*
- [x] The *code coverage* hasn't decreased
- [x] I have *added tests* that prove my change is effective and works
- [x] New and existing *unit tests pass* locally and in Github Actions
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

N/A

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
