### PR TITLE
chore(examples): fix version bumping of examples

### DIFF
--- a/examples/cdk/package-lock.json
+++ b/examples/cdk/package-lock.json
@@ -6,12 +6,12 @@
   "packages": {
     "": {
       "name": "cdk-app",
-      "version": "0.3.1",
+      "version": "0.4.0",
       "dependencies": {
-        "@aws-lambda-powertools/commons": "^0.3.1",
-        "@aws-lambda-powertools/logger": "^0.3.1",
-        "@aws-lambda-powertools/metrics": "^0.3.1",
-        "@aws-lambda-powertools/tracer": "^0.3.1",
+        "@aws-lambda-powertools/commons": "^0.4.0",
+        "@aws-lambda-powertools/logger": "^0.4.0",
+        "@aws-lambda-powertools/metrics": "^0.4.0",
+        "@aws-lambda-powertools/tracer": "^0.4.0",
         "@aws-sdk/client-sts": "^3.43.0",
         "@middy/core": "^2.5.3",
         "@middy/http-error-handler": "^2.5.3",
@@ -114,17 +114,17 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-lambda-powertools/commons": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/commons/-/commons-0.3.1.tgz",
-      "integrity": "sha512-DVU3CMgpkxyDJapIBLNq8Ks7y0eLdiT+2j9sjghpjr7nh4D4Xu5lfpyPssxMRp4GH83VBWDna7mHf9VE1at2Zw==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/commons/-/commons-0.4.0.tgz",
+      "integrity": "sha512-6jszWPdgjUWFSKbaA3UdDNb/+0hmU15rH2e5itCKJ06bVpOwXNQESxA8kJmT5BTxrUVNJrgSelH+dwAP9Dm0Xw==",
       "dependencies": {
         "@types/aws-lambda": "^8.10.72"
       }
     },
     "node_modules/@aws-lambda-powertools/logger": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/logger/-/logger-0.3.1.tgz",
-      "integrity": "sha512-5hCdNmfsC0G+wtpGvEoZPJHoUFo/i+O+Lf+nvXkDl9K5GfT53gIeK7Iq8lEaqFyVrNm4JWH4H+PRAyKS3HJxAg==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/logger/-/logger-0.4.0.tgz",
+      "integrity": "sha512-G+kIOxRNBUesuFzjvVwCWMvoY7f/wATYQKqK/+bEcLBeg4Ez7eY5eX7wHXJKEz6PU3Qmqp2CDOalKkaW300K1A==",
       "dependencies": {
         "@aws-lambda-powertools/commons": "^0.2.0",
         "@middy/core": "^2.5.3",
@@ -153,9 +153,9 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
     },
     "node_modules/@aws-lambda-powertools/metrics": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/metrics/-/metrics-0.3.1.tgz",
-      "integrity": "sha512-7hzHxkHZMm0mN+vIgV7G1EOBXiKz5WYs5o2HcYABIdjM5WynV4hntT1LB3CLGUxSuMlJdE4FoMruGPHAhcDPfg==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/metrics/-/metrics-0.4.0.tgz",
+      "integrity": "sha512-d11+EKdzEgo8DOfQANaQEq6r/0LLU6XhHJicTdIm7Rkeav5hahvxnC8CzWwEFVnpnkZWXgCnWphQ9jwBJ3bmAQ==",
       "dependencies": {
         "@aws-lambda-powertools/commons": "^0.2.0",
         "@types/aws-lambda": "^8.10.72"
@@ -170,9 +170,9 @@
       }
     },
     "node_modules/@aws-lambda-powertools/tracer": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/tracer/-/tracer-0.3.1.tgz",
-      "integrity": "sha512-UhUtER0Oc3mjBCeJZQg4gl+4Hw/CPDkSHQvh6Mj5qlZ3qdtB80IOQDnRQ0rIONV7e4xcVHX9JEFzFwt2THnBIA==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/tracer/-/tracer-0.4.0.tgz",
+      "integrity": "sha512-kIEiqjJcT7ecijJiV3FcJMMtQlQ+Wyzy9Z32fciMenO2mongK5S3Wjnqxq0eNS7tvsccYB1wVozKtU/1DOlTgA==",
       "dependencies": {
         "@aws-lambda-powertools/commons": "^0.2.0",
         "@middy/core": "^2.5.3",
@@ -9518,17 +9518,17 @@
       }
     },
     "@aws-lambda-powertools/commons": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/commons/-/commons-0.3.1.tgz",
-      "integrity": "sha512-DVU3CMgpkxyDJapIBLNq8Ks7y0eLdiT+2j9sjghpjr7nh4D4Xu5lfpyPssxMRp4GH83VBWDna7mHf9VE1at2Zw==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/commons/-/commons-0.4.0.tgz",
+      "integrity": "sha512-6jszWPdgjUWFSKbaA3UdDNb/+0hmU15rH2e5itCKJ06bVpOwXNQESxA8kJmT5BTxrUVNJrgSelH+dwAP9Dm0Xw==",
       "requires": {
         "@types/aws-lambda": "^8.10.72"
       }
     },
     "@aws-lambda-powertools/logger": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/logger/-/logger-0.3.1.tgz",
-      "integrity": "sha512-5hCdNmfsC0G+wtpGvEoZPJHoUFo/i+O+Lf+nvXkDl9K5GfT53gIeK7Iq8lEaqFyVrNm4JWH4H+PRAyKS3HJxAg==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/logger/-/logger-0.4.0.tgz",
+      "integrity": "sha512-G+kIOxRNBUesuFzjvVwCWMvoY7f/wATYQKqK/+bEcLBeg4Ez7eY5eX7wHXJKEz6PU3Qmqp2CDOalKkaW300K1A==",
       "requires": {
         "@aws-lambda-powertools/commons": "^0.2.0",
         "@middy/core": "^2.5.3",
@@ -9559,9 +9559,9 @@
       }
     },
     "@aws-lambda-powertools/metrics": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/metrics/-/metrics-0.3.1.tgz",
-      "integrity": "sha512-7hzHxkHZMm0mN+vIgV7G1EOBXiKz5WYs5o2HcYABIdjM5WynV4hntT1LB3CLGUxSuMlJdE4FoMruGPHAhcDPfg==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/metrics/-/metrics-0.4.0.tgz",
+      "integrity": "sha512-d11+EKdzEgo8DOfQANaQEq6r/0LLU6XhHJicTdIm7Rkeav5hahvxnC8CzWwEFVnpnkZWXgCnWphQ9jwBJ3bmAQ==",
       "requires": {
         "@aws-lambda-powertools/commons": "^0.2.0",
         "@types/aws-lambda": "^8.10.72"
@@ -9578,9 +9578,9 @@
       }
     },
     "@aws-lambda-powertools/tracer": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/tracer/-/tracer-0.3.1.tgz",
-      "integrity": "sha512-UhUtER0Oc3mjBCeJZQg4gl+4Hw/CPDkSHQvh6Mj5qlZ3qdtB80IOQDnRQ0rIONV7e4xcVHX9JEFzFwt2THnBIA==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/tracer/-/tracer-0.4.0.tgz",
+      "integrity": "sha512-kIEiqjJcT7ecijJiV3FcJMMtQlQ+Wyzy9Z32fciMenO2mongK5S3Wjnqxq0eNS7tvsccYB1wVozKtU/1DOlTgA==",
       "requires": {
         "@aws-lambda-powertools/commons": "^0.2.0",
         "@middy/core": "^2.5.3",

--- a/examples/cdk/package.json
+++ b/examples/cdk/package.json
@@ -11,7 +11,7 @@
     "package": "echo 'Not applicable'",
     "test:unit": "npm run build && jest",
     "test:e2e": "echo 'To be implemented ...'",
-    "version": "npm install @aws-lambda-powertools/commons@0.4.0 @aws-lambda-powertools/logger@0.4.0 @aws-lambda-powertools/tracer@0.4.0 @aws-lambda-powertools/metrics@0.4.0",
+    "version": "npm install @aws-lambda-powertools/commons@0.4.0 @aws-lambda-powertools/logger@0.4.0 @aws-lambda-powertools/tracer@0.4.0 @aws-lambda-powertools/metrics@0.4.0 && git add package.json",
     "cdk": "cdk"
   },
   "devDependencies": {

--- a/examples/cdk/package.json
+++ b/examples/cdk/package.json
@@ -11,6 +11,7 @@
     "package": "echo 'Not applicable'",
     "test:unit": "npm run build && jest",
     "test:e2e": "echo 'To be implemented ...'",
+    "version": "npm install @aws-lambda-powertools/commons@0.4.0 @aws-lambda-powertools/logger@0.4.0 @aws-lambda-powertools/tracer@0.4.0 @aws-lambda-powertools/metrics@0.4.0",
     "cdk": "cdk"
   },
   "devDependencies": {


### PR DESCRIPTION
## Description of your changes

Currently when a version are bumped, examples cdk package got his dependencies bumped as well to match latest package that are going to be released.
1. This can't be control due to this https://github.com/lerna/lerna/issues/2326 bug.
2. Bumping dependencies can make example code buggy since it won't be updated to go around potential breaking changes ...

This PR leverage [versionning life cycle](https://github.com/lerna/lerna/tree/6cb8ab2d4af7ce25c812e8fb05cd04650105705f/commands/version#lifecycle-scripts) to force versioning of deps and workaround https://github.com/lerna/lerna/issues/2326 .

NB: Examples will always be behind if we don't update manually the dependencies.

### Alternative

Remove `examples/cdk` from lerna.json and add lint, build and test specific scripts to either root `package.json` or in github actions and husky scripts ...

### How to verify this change

1. Bump version `npx lerna version --force-publish=\* --no-git-tag-version --no-push  --conventional-commits`
2. Check that examples package.json and lock for no change on deps

Build is passing https://github.com/awslabs/aws-lambda-powertools-typescript/runs/4898015010 so package-lock.json is fixed.

Next bump then run e2e tests will demonstrate the fix

### Related issues, RFCs

#494

### PR status

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [x] I have made corresponding changes to the *documentation*
- [x] My changes generate *no new warnings*
- [x] The *code coverage* hasn't decreased
- [x] I have *added tests* that prove my change is effective and works
- [x] New and existing *unit tests pass* locally and in Github Actions
- [x] Any *dependent changes have been merged and published* in downstream module
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
