### PR TITLE
chore: add middy like interfaces to commons package

### DIFF
--- a/packages/commons/src/index.ts
+++ b/packages/commons/src/index.ts
@@ -1,3 +1,4 @@
 export * from './utils/lambda';
+export * from './utils/middy';
 export * as ContextExamples from './tests/resources/contexts';
 export * as Events from './tests/resources/events';

--- a/packages/commons/src/utils/middy/MiddyInterfaces.ts
+++ b/packages/commons/src/utils/middy/MiddyInterfaces.ts
@@ -1,0 +1,19 @@
+import { Context } from 'aws-lambda';
+
+interface MiddyLikeRequest<TEvent = unknown, TResult = unknown, TErr = Error, TContext extends Context = Context> {
+  event: TEvent
+  context: TContext
+  response: TResult | null
+  error: TErr | null
+  internal: {
+    [key: string]: unknown
+  }
+}
+
+declare type MiddlewareFn<TEvent = unknown, TResult = unknown, TErr = Error, TContext extends Context = Context> = (request: MiddyLikeRequest<TEvent, TResult, TErr, TContext>) => unknown;
+
+export interface MiddyLikeMiddlewareObj<TEvent = unknown, TResult = unknown, TErr = Error, TContext extends Context = Context> {
+  before?: MiddlewareFn<TEvent, TResult, TErr, TContext>
+  after?: MiddlewareFn<TEvent, TResult, TErr, TContext>
+  onError?: MiddlewareFn<TEvent, TResult, TErr, TContext>
+}

--- a/packages/commons/src/utils/middy/index.ts
+++ b/packages/commons/src/utils/middy/index.ts
@@ -1,0 +1,1 @@
+export * from './MiddyInterfaces';


### PR DESCRIPTION
## Description of your changes

This PR is a pre-requisite to be able to start working on issue #373 and it proposes to add two interfaces and one type that mirror the ones defined in `@middy/core` [here](https://github.com/middyjs/middy/blob/main/packages/core/index.d.ts#L21-L37).

Before going on and adding our own interfaces in `@aws-lambda-powertools/commons` I have attempted to search for existing ones in the npm registry and in the DefinitelyTyped repo but found none.

### How to verify this change

Check out this branch, run `npm pack` in `packages/commons` and try to import `MiddyLikeMiddlewareObj` or `MiddyLikeRequest` in your code after installing the tar archive.

### Related issues, RFCs

[#373](https://github.com/awslabs/aws-lambda-powertools-typescript/issues/373)  

### PR status

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] My changes generate *no new warnings*
- [x] New and existing *unit tests pass* locally and in Github Actions
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

N/A

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
