### PR TITLE
fix(tracer): properly return DynamoDB.DocumentClient

### DIFF
--- a/packages/tracing/src/Tracer.ts
+++ b/packages/tracing/src/Tracer.ts
@@ -261,7 +261,9 @@ class Tracer implements TracerInterface {
       return this.provider.captureAWSClient(service);
     } catch (error) {
       try {
-        return this.provider.captureAWSClient((service as unknown as T & { service: T }).service);
+        this.provider.captureAWSClient((service as unknown as T & { service: T }).service);
+        
+        return service;
       } catch {
         throw error;
       }

--- a/packages/tracing/src/Tracer.ts
+++ b/packages/tracing/src/Tracer.ts
@@ -264,7 +264,7 @@ class Tracer implements TracerInterface {
         // This is needed because some aws-sdk clients like AWS.DynamoDB.DocumentDB don't comply with the same
         // instrumentation contract like most base clients. 
         // For detailed explanation see: https://github.com/awslabs/aws-lambda-powertools-typescript/issues/524#issuecomment-1024493662
-        this.provider.captureAWSClient((service as unknown as T & { service: T }).service);
+        this.provider.captureAWSClient((service as T & { service: T }).service);
         
         return service;
       } catch {

--- a/packages/tracing/src/Tracer.ts
+++ b/packages/tracing/src/Tracer.ts
@@ -261,6 +261,9 @@ class Tracer implements TracerInterface {
       return this.provider.captureAWSClient(service);
     } catch (error) {
       try {
+        // This is needed because some aws-sdk clients like AWS.DynamoDB.DocumentDB don't comply with the same
+        // instrumentation contract like most base clients. 
+        // For detailed explanation see: https://github.com/awslabs/aws-lambda-powertools-typescript/issues/524#issuecomment-1024493662
         this.provider.captureAWSClient((service as unknown as T & { service: T }).service);
         
         return service;

--- a/packages/tracing/tests/e2e/tracer.test.Decorator.ts
+++ b/packages/tracing/tests/e2e/tracer.test.Decorator.ts
@@ -1,6 +1,6 @@
 import { Tracer } from '../../src';
 import { Callback, Context } from 'aws-lambda';
-import { DynamoDBClient, ScanCommand } from '@aws-sdk/client-dynamodb';
+import { DynamoDBClient, PutItemCommand } from '@aws-sdk/client-dynamodb';
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 let AWS = require('aws-sdk');
 
@@ -52,8 +52,8 @@ export class MyFunctionWithDecorator {
     }
     
     return Promise.all([
-      dynamoDBv2.scan({ TableName: testTableName }).promise(),
-      dynamoDBv3.send(new ScanCommand({ TableName: testTableName })),
+      dynamoDBv2.put({ TableName: testTableName, Item: { id: `${serviceName}-${event.invocation}-sdkv2` } }).promise(),
+      dynamoDBv3.send(new PutItemCommand({ TableName: testTableName, Item: { id: { 'S': `${serviceName}-${event.invocation}-sdkv3` } } })),
       new Promise((resolve, reject) => {
         setTimeout(() => {
           const res = this.myMethod();

--- a/packages/tracing/tests/e2e/tracer.test.DecoratorWithAsyncHandler.ts
+++ b/packages/tracing/tests/e2e/tracer.test.DecoratorWithAsyncHandler.ts
@@ -1,6 +1,6 @@
 import { Tracer } from '../../src';
 import { Context } from 'aws-lambda';
-import { DynamoDBClient, ScanCommand } from '@aws-sdk/client-dynamodb';
+import { DynamoDBClient, PutItemCommand } from '@aws-sdk/client-dynamodb';
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 let AWS = require('aws-sdk');
 
@@ -52,13 +52,13 @@ export class MyFunctionWithDecorator {
     }
 
     try {
-      await dynamoDBv2.scan({ TableName: testTableName }).promise();
+      await dynamoDBv2.put({ TableName: testTableName, Item: { id: `${serviceName}-${event.invocation}-sdkv2` } }).promise();
     } catch (err) {
       console.error(err);
     }
 
     try {
-      await dynamoDBv3.send(new ScanCommand({ TableName: testTableName }));
+      await dynamoDBv3.send(new PutItemCommand({ TableName: testTableName, Item: { id: { 'S': `${serviceName}-${event.invocation}-sdkv3` } } }));
     } catch (err) {
       console.error(err);
     }

--- a/packages/tracing/tests/e2e/tracer.test.Manual.ts
+++ b/packages/tracing/tests/e2e/tracer.test.Manual.ts
@@ -1,6 +1,6 @@
 import { Tracer } from '../../src';
 import { Context } from 'aws-lambda';
-import { DynamoDBClient, ScanCommand } from '@aws-sdk/client-dynamodb';
+import { DynamoDBClient, PutItemCommand } from '@aws-sdk/client-dynamodb';
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 let AWS = require('aws-sdk');
 
@@ -55,13 +55,13 @@ export const handler = async (event: CustomEvent, _context: Context): Promise<vo
     dynamoDBv2 = new AWS.DynamoDB.DocumentClient();
   }
   try {
-    await dynamoDBv2.scan({ TableName: testTableName }).promise();
+    await dynamoDBv2.put({ TableName: testTableName, Item: { id: `${serviceName}-${event.invocation}-sdkv2` } }).promise();
   } catch (err) {
     console.error(err);
   }
 
   try {
-    await dynamoDBv3.send(new ScanCommand({ TableName: testTableName }));
+    await dynamoDBv3.send(new PutItemCommand({ TableName: testTableName, Item: { id: { 'S': `${serviceName}-${event.invocation}-sdkv3` } } }));
   } catch (err) {
     console.error(err);
   }

--- a/packages/tracing/tests/e2e/tracer.test.Middleware.ts
+++ b/packages/tracing/tests/e2e/tracer.test.Middleware.ts
@@ -1,7 +1,7 @@
 import middy from '@middy/core';
 import { captureLambdaHandler, Tracer } from '../../src';
 import { Context } from 'aws-lambda';
-import { DynamoDBClient, ScanCommand } from '@aws-sdk/client-dynamodb';
+import { DynamoDBClient, PutItemCommand } from '@aws-sdk/client-dynamodb';
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 let AWS = require('aws-sdk');
 
@@ -49,13 +49,13 @@ export const handler = middy(async (event: CustomEvent, _context: Context): Prom
     dynamoDBv2 = new AWS.DynamoDB.DocumentClient();
   }
   try {
-    await dynamoDBv2.scan({ TableName: testTableName }).promise();
+    await dynamoDBv2.put({ TableName: testTableName, Item: { id: `${serviceName}-${event.invocation}-sdkv2` } }).promise();
   } catch (err) {
     console.error(err);
   }
 
   try {
-    await dynamoDBv3.send(new ScanCommand({ TableName: testTableName }));
+    await dynamoDBv3.send(new PutItemCommand({ TableName: testTableName, Item: { id: { 'S': `${serviceName}-${event.invocation}-sdkv3` } } }));
   } catch (err) {
     console.error(err);
   }

--- a/packages/tracing/tests/e2e/tracer.test.ts
+++ b/packages/tracing/tests/e2e/tracer.test.ts
@@ -92,7 +92,7 @@ describe('Tracer integration tests', () => {
         },
         timeout: Duration.seconds(30),
       });
-      table.grantReadData(fn);
+      table.grantWriteData(fn);
       invocationsMap[functionName] = {
         serviceName: expectedServiceName,
         resourceArn: `arn:aws:lambda:${region}:${account}:function:${functionName}`, // ARN is still a token at this point, so we construct the ARN manually


### PR DESCRIPTION
## Description of your changes

This PR aims at fixing the bug identified in #524.

### How to verify this change

Check GitHub actions execution results, the unit tests now include test cases to assert on the type of client being returned.

### Related issues, RFCs

[#524](https://github.com/awslabs/aws-lambda-powertools-typescript/issues/524)  

### PR status

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [x] My changes generate *no new warnings*
- [x] The *code coverage* hasn't decreased
- [x] I have *added tests* that prove my change is effective and works
- [ ] New and existing *unit tests pass* locally and in Github Actions
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

N/A

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
