### PR TITLE
feat(commons): centralize cold start heuristic

### DIFF
--- a/packages/commons/src/Utility.ts
+++ b/packages/commons/src/Utility.ts
@@ -16,7 +16,7 @@
  * 
  * As a Powertools user you probably won't be using this class directly, in fact if you use other Powertools utilities the cold start heuristic found here is already used to:
  * * Add a `coldStart` key to the structured logs when injecting context information in `Logger`
- * * Emit a metric during a cold start function invocation in ``Metrics`
+ * * Emit a metric during a cold start function invocation in `Metrics`
  * * Annotate the invocation segment with a `coldStart` key in `Tracer`
  * 
  * If you want to use this logic in your own utilities, `Utility` provides two methods:

--- a/packages/commons/src/Utility.ts
+++ b/packages/commons/src/Utility.ts
@@ -19,7 +19,7 @@
  * * Emit a metric during a cold start function invocation in ``Metrics`
  * * Annotate the invocation segment with a `coldStart` key in `Tracer`
  * 
- * If instead you want use this logic in your own utilities, `Utility` provides two methdos:
+ * If you want to use this logic in your own utilities, `Utility` provides two methods:
  * 
  * #### `getColdStart()`
  * 

--- a/packages/commons/src/Utility.ts
+++ b/packages/commons/src/Utility.ts
@@ -1,0 +1,76 @@
+/**
+ * ## Intro
+ * Utility is a base class that other Powertools utilites can extend to inherit shared logic.
+ * 
+ * 
+ * ## Key features
+ *   * Cold Start heuristic to determine if the current 
+ * 
+ * ## Usage
+ * 
+ * ### Cold Start
+ * 
+ * Cold start is a term commonly used to describe the `Init` phase of a Lambda function. In this phase, Lambda creates or unfreezes an execution environment with the configured resources, downloads the code for the function and all layers, initializes any extensions, initializes the runtime, and then runs the function’s initialization code (the code outside the main handler). The Init phase happens either during the first invocation, or in advance of function invocations if you have enabled provisioned concurrency.
+ * 
+ * To learn more about the Lambda execution environment lifecycle, see the [Execution environment section](https://docs.aws.amazon.com/lambda/latest/dg/runtimes-context.html) of the AWS Lambda documentation.
+ * 
+ * As a Powertools user you probably won't be using this class directly, in fact if you use other Powertools utilities the cold start heuristic found here is already used to:
+ * * Add a `coldStart` key to the structured logs when injecting context information in `Logger`
+ * * Emit a metric during a cold start function invocation in ``Metrics`
+ * * Annotate the invocation segment with a `coldStart` key in `Tracer`
+ * 
+ * If instead you want use this logic in your own utilities, `Utility` provides two methdos:
+ * 
+ * #### `getColdStart()`
+ * 
+ * Since the `Utility` class is instantiated outside of the Lambda handler it will persist across invocations of the same execution environment. This means that if you call `getColdStart()` multiple times, it will return `true` during the first invocation, and `false` afterwards.
+ * 
+ * @example
+ * ```typescript
+ * import { Utility } from '@aws-lambda-powertools/commons';
+ * 
+ * const utility = new Utility();
+ * 
+ * export const handler = async (_event: any, _context: any) => {
+ *   utility.getColdStart();
+ * };
+ * ```
+ * 
+ * #### `isColdStart()`
+ * 
+ * This method is an alias of `getColdStart()` and is exposed for convenience and better readability in certain usages.
+ * 
+ * @example
+ * ```typescript
+ * import { Utility } from '@aws-lambda-powertools/commons';
+ * 
+ * const utility = new Utility();
+ * 
+ * export const handler = async (_event: any, _context: any) => {
+ *   if (utility.isColdStart()) {
+ *     // do something, this block is only executed on the first invocation of the function
+ *   } else {
+ *     // do something else, this block gets executed on all subsequent invocations
+ *   }
+ * };
+ * ```
+ */
+export class Utility {
+  
+  private coldStart: boolean = true;
+
+  public getColdStart(): boolean {
+    if (this.coldStart) {
+      this.coldStart = false;
+
+      return true;
+    }
+
+    return false;
+  }
+
+  public isColdStart(): boolean {
+    return this.getColdStart();
+  }
+
+}

--- a/packages/commons/src/index.ts
+++ b/packages/commons/src/index.ts
@@ -1,3 +1,4 @@
 export * from './utils/lambda';
+export * from './Utility';
 export * as ContextExamples from './tests/resources/contexts';
 export * as Events from './tests/resources/events';

--- a/packages/commons/tests/unit/LambdaInterface.test.ts
+++ b/packages/commons/tests/unit/LambdaInterface.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Test LambdaInterface interface
+ *
+ * @group unit/commons/lambdaInterface
+ */
 import { Handler } from 'aws-lambda';
 import { Callback, Context } from 'aws-lambda';
 import { ContextExamples, SyncHandler, AsyncHandler, LambdaInterface } from '../../src';
@@ -102,6 +107,8 @@ describe('LambdaInterface with decorator', () => {
     class LambdaFunction implements LambdaInterface {
       
       @dummyModule.dummyDecorator()
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
       public async handler(_event: unknown, context: Context): Promise<unknown> {
         context.getRemainingTimeInMillis();
         
@@ -118,6 +125,8 @@ describe('LambdaInterface with decorator', () => {
     class LambdaFunction implements LambdaInterface {
       
       @dummyModule.dummyDecorator()
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
       public handler(_event: unknown, context: Context, _callback: Callback): void {
         context.getRemainingTimeInMillis();
       }

--- a/packages/commons/tests/unit/Utility.test.ts
+++ b/packages/commons/tests/unit/Utility.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Test Utility class
+ *
+ * @group unit/commons/utility
+ */
+import { Utility } from '../../src';
+
+describe('Class: Utility', () => {
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.resetModules();
+  });
+
+  describe('Method: getColdStart', () => {
+
+    test('when called multiple times on the parent class, it returns true the first time, then false afterwards', () => {
+
+      // Prepare
+      const utility = new Utility();
+      const getColdStartSpy = jest.spyOn(utility, 'getColdStart');
+
+      // Act
+      utility.getColdStart();
+      utility.getColdStart();
+      utility.getColdStart();
+      utility.getColdStart();
+      utility.getColdStart();
+    
+      // Assess
+      expect(getColdStartSpy).toHaveBeenCalledTimes(5);
+      expect(getColdStartSpy.mock.results).toEqual([
+        expect.objectContaining({ value: true }),
+        expect.objectContaining({ value: false }),
+        expect.objectContaining({ value: false }),
+        expect.objectContaining({ value: false }),
+        expect.objectContaining({ value: false }),
+      ]);
+
+    });
+
+    test('when called multiple times on a child class, it returns true the first time, then false afterwards', () => {
+
+      // Prepare
+      class PowerTool extends Utility {
+        public constructor() {
+          super();
+        }
+
+        public dummyMethod(): boolean {
+          return this.getColdStart();
+        }
+      }
+      const powertool = new PowerTool();
+      const dummyMethodSpy = jest.spyOn(powertool, 'dummyMethod');
+      const getColdStartSpy = jest.spyOn(powertool, 'getColdStart');
+
+      // Act
+      powertool.dummyMethod();
+      powertool.dummyMethod();
+      powertool.dummyMethod();
+      powertool.dummyMethod();
+      powertool.dummyMethod();
+
+      // Assess
+      expect(dummyMethodSpy).toHaveBeenCalledTimes(5);
+      expect(getColdStartSpy).toHaveBeenCalledTimes(5);
+      expect(dummyMethodSpy.mock.results).toEqual([
+        expect.objectContaining({ value: true }),
+        expect.objectContaining({ value: false }),
+        expect.objectContaining({ value: false }),
+        expect.objectContaining({ value: false }),
+        expect.objectContaining({ value: false }),
+      ]);
+      
+    });
+
+  });
+
+  describe('Method: isColdStart', () => {
+
+    test('when called multiple times on the parent class, it returns true the first time, then false afterwards', () => {
+
+      // Prepare
+      const utility = new Utility();
+      const isColdStartSpy = jest.spyOn(utility, 'isColdStart');
+
+      // Act
+      utility.isColdStart();
+      utility.isColdStart();
+      utility.isColdStart();
+      utility.isColdStart();
+      utility.isColdStart();
+
+      // Assess
+      expect(isColdStartSpy).toHaveBeenCalledTimes(5);
+      expect(isColdStartSpy.mock.results).toEqual([
+        expect.objectContaining({ value: true }),
+        expect.objectContaining({ value: false }),
+        expect.objectContaining({ value: false }),
+        expect.objectContaining({ value: false }),
+        expect.objectContaining({ value: false }),
+      ]);
+
+    });
+
+    test('when called multiple times on a child class, it returns true the first time, then false afterwards', () => {
+
+      // Prepare
+      class PowerTool extends Utility {
+        public constructor() {
+          super();
+        }
+
+        public dummyMethod(): boolean {
+          return this.isColdStart();
+        }
+      }
+      const powertool = new PowerTool();
+      const dummyMethodSpy = jest.spyOn(powertool, 'dummyMethod');
+      const isColdStartSpy = jest.spyOn(powertool, 'isColdStart');
+
+      // Act
+      powertool.dummyMethod();
+      powertool.dummyMethod();
+      powertool.dummyMethod();
+      powertool.dummyMethod();
+      powertool.dummyMethod();
+
+      // Assess
+      expect(dummyMethodSpy).toHaveBeenCalledTimes(5);
+      expect(isColdStartSpy).toHaveBeenCalledTimes(5);
+      expect(dummyMethodSpy.mock.results).toEqual([
+        expect.objectContaining({ value: true }),
+        expect.objectContaining({ value: false }),
+        expect.objectContaining({ value: false }),
+        expect.objectContaining({ value: false }),
+        expect.objectContaining({ value: false }),
+      ]);
+
+    });
+
+  });
+
+});


### PR DESCRIPTION
## Description of your changes

This PR introduces a new `Utility` class in the `@aws-lambda-powertools/commons` package. This class is designed to be extended by other Powertools utilities that will inherit its shared methods.

In this iteration the `Utility` class brings a centralised cold start heuristic to be shared by all core packages.

The changes in this PR have already been discussed in an internal RFC document reviewed by at least two other maintainers as per `CONTRIBUTING` guidelines.

### How to verify this change

Clone the repo & check newly introduced unit tests.
Also check the JSDoc documentation written in the class file.

### Related issues, RFCs

[#484](https://github.com/awslabs/aws-lambda-powertools-typescript/issues/484)  

### PR status

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [x] I have made corresponding changes to the *documentation*
- [x] My changes generate *no new warnings*
- [x] The *code coverage* hasn't decreased
- [x] I have *added tests* that prove my change is effective and works
- [x] New and existing *unit tests pass* locally and in Github Actions
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

N/A

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
