### PR TITLE
feat(tracer): adopted Utility class & updated unit tests

### DIFF
--- a/docs/core/tracer.md
+++ b/docs/core/tracer.md
@@ -48,6 +48,8 @@ For a **complete list** of supported environment variables, refer to [this secti
 
 #### Example using AWS Serverless Application Model (SAM)
 
+The `Tracer` utility is instantiated outside of the Lambda handler. In doing this, the same instance can be used across multiple invocations inside the same execution environment. This allows `Metrics` to be aware of things like whether or not a given invocation had a cold start or not.
+
 === "handler.ts"
 
     ```typescript hl_lines="1 4"

--- a/packages/tracing/package-lock.json
+++ b/packages/tracing/package-lock.json
@@ -6,10 +6,10 @@
   "packages": {
     "": {
       "name": "@aws-lambda-powertools/tracer",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "MIT-0",
       "dependencies": {
-        "@aws-lambda-powertools/commons": "^0.2.0",
+        "@aws-lambda-powertools/commons": "^0.6.0",
         "aws-xray-sdk-core": "^3.3.3"
       },
       "devDependencies": {
@@ -1025,9 +1025,9 @@
       }
     },
     "node_modules/@aws-lambda-powertools/commons": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/commons/-/commons-0.2.0.tgz",
-      "integrity": "sha512-h0YItiAkJkTTbKBJxR2Xe5iQMjkyZq7eLPJe4Dpm4RaiwzXG2Ejwt1jt/QoDcaJoxqWPrUnWteNtQzpEB8u2qQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/commons/-/commons-0.6.0.tgz",
+      "integrity": "sha512-8flZn/gH1l5u1UzcSM+MI5euEVmcpZRn2GXypgh/2OEKaTKqIZL7eH6NbbcP8hjbsvyGg5PKBdyLeVBK0IqcwQ==",
       "dependencies": {
         "@types/aws-lambda": "^8.10.72"
       }
@@ -3833,23 +3833,6 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.9.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.9.1.tgz",
-      "integrity": "sha512-8BwvWkho3B/UOtzRyW07ffJXPaLSUKFBjpq8aqsRvu6HdEuzCY57+ffT7QoV4QXJXWSU1+7g3wE4AlgImmQ9pQ==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "5.9.1",
-        "@typescript-eslint/visitor-keys": "5.9.1"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
     "node_modules/@typescript-eslint/type-utils": {
       "version": "5.11.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.11.0.tgz",
@@ -3869,46 +3852,6 @@
       },
       "peerDependencies": {
         "eslint": "*"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@typescript-eslint/types": {
-      "version": "5.9.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.9.1.tgz",
-      "integrity": "sha512-SsWegWudWpkZCwwYcKoDwuAjoZXnM1y2EbEerTHho19Hmm+bQ56QG4L4jrtCu0bI5STaRTvRTZmjprWlTw/5NQ==",
-      "dev": true,
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.9.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.9.1.tgz",
-      "integrity": "sha512-gL1sP6A/KG0HwrahVXI9fZyeVTxEYV//6PmcOn1tD0rw8VhUWYeZeuWHwwhnewnvEMcHjhnJLOBhA9rK4vmb8A==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "5.9.1",
-        "@typescript-eslint/visitor-keys": "5.9.1",
-        "debug": "^4.3.2",
-        "globby": "^11.0.4",
-        "is-glob": "^4.0.3",
-        "semver": "^7.3.5",
-        "tsutils": "^3.21.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -4004,23 +3947,6 @@
       "dev": true,
       "dependencies": {
         "@typescript-eslint/types": "5.11.0",
-        "eslint-visitor-keys": "^3.0.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.9.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.9.1.tgz",
-      "integrity": "sha512-Xh37pNz9e9ryW4TVdwiFzmr4hloty8cFj8GTWMXh3Z8swGwyQWeCcNgF0hm6t09iZd6eiZmIf4zHedQVP6TVtg==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "5.9.1",
         "eslint-visitor-keys": "^3.0.0"
       },
       "engines": {
@@ -11216,9 +11142,9 @@
       }
     },
     "@aws-lambda-powertools/commons": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/commons/-/commons-0.2.0.tgz",
-      "integrity": "sha512-h0YItiAkJkTTbKBJxR2Xe5iQMjkyZq7eLPJe4Dpm4RaiwzXG2Ejwt1jt/QoDcaJoxqWPrUnWteNtQzpEB8u2qQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/commons/-/commons-0.6.0.tgz",
+      "integrity": "sha512-8flZn/gH1l5u1UzcSM+MI5euEVmcpZRn2GXypgh/2OEKaTKqIZL7eH6NbbcP8hjbsvyGg5PKBdyLeVBK0IqcwQ==",
       "requires": {
         "@types/aws-lambda": "^8.10.72"
       }
@@ -13565,16 +13491,6 @@
         }
       }
     },
-    "@typescript-eslint/scope-manager": {
-      "version": "5.9.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.9.1.tgz",
-      "integrity": "sha512-8BwvWkho3B/UOtzRyW07ffJXPaLSUKFBjpq8aqsRvu6HdEuzCY57+ffT7QoV4QXJXWSU1+7g3wE4AlgImmQ9pQ==",
-      "dev": true,
-      "requires": {
-        "@typescript-eslint/types": "5.9.1",
-        "@typescript-eslint/visitor-keys": "5.9.1"
-      }
-    },
     "@typescript-eslint/type-utils": {
       "version": "5.11.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.11.0.tgz",
@@ -13583,27 +13499,6 @@
       "requires": {
         "@typescript-eslint/utils": "5.11.0",
         "debug": "^4.3.2",
-        "tsutils": "^3.21.0"
-      }
-    },
-    "@typescript-eslint/types": {
-      "version": "5.9.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.9.1.tgz",
-      "integrity": "sha512-SsWegWudWpkZCwwYcKoDwuAjoZXnM1y2EbEerTHho19Hmm+bQ56QG4L4jrtCu0bI5STaRTvRTZmjprWlTw/5NQ==",
-      "dev": true
-    },
-    "@typescript-eslint/typescript-estree": {
-      "version": "5.9.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.9.1.tgz",
-      "integrity": "sha512-gL1sP6A/KG0HwrahVXI9fZyeVTxEYV//6PmcOn1tD0rw8VhUWYeZeuWHwwhnewnvEMcHjhnJLOBhA9rK4vmb8A==",
-      "dev": true,
-      "requires": {
-        "@typescript-eslint/types": "5.9.1",
-        "@typescript-eslint/visitor-keys": "5.9.1",
-        "debug": "^4.3.2",
-        "globby": "^11.0.4",
-        "is-glob": "^4.0.3",
-        "semver": "^7.3.5",
         "tsutils": "^3.21.0"
       }
     },
@@ -13662,16 +13557,6 @@
             "eslint-visitor-keys": "^3.0.0"
           }
         }
-      }
-    },
-    "@typescript-eslint/visitor-keys": {
-      "version": "5.9.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.9.1.tgz",
-      "integrity": "sha512-Xh37pNz9e9ryW4TVdwiFzmr4hloty8cFj8GTWMXh3Z8swGwyQWeCcNgF0hm6t09iZd6eiZmIf4zHedQVP6TVtg==",
-      "dev": true,
-      "requires": {
-        "@typescript-eslint/types": "5.9.1",
-        "eslint-visitor-keys": "^3.0.0"
       }
     },
     "abab": {

--- a/packages/tracing/package.json
+++ b/packages/tracing/package.json
@@ -64,7 +64,7 @@
     "url": "https://github.com/awslabs/aws-lambda-powertools-typescript/issues"
   },
   "dependencies": {
-    "@aws-lambda-powertools/commons": "^0.2.0",
+    "@aws-lambda-powertools/commons": "^0.6.0",
     "aws-xray-sdk-core": "^3.3.3"
   }
 }

--- a/packages/tracing/tests/unit/Tracer.test.ts
+++ b/packages/tracing/tests/unit/Tracer.test.ts
@@ -40,7 +40,6 @@ describe('Class: Tracer', () => {
   };
 
   beforeEach(() => {
-    Tracer.coldStart = true;
     jest.clearAllMocks();
     jest.resetModules();
     process.env = { ...ENVIRONMENT_VARIABLES };
@@ -257,20 +256,6 @@ describe('Class: Tracer', () => {
 
     });
 
-  });
-
-  describe('Method: getColdStart', () => {
-
-    test('when called, it returns false the first time and always true after that', () => {
-    
-      // Assess
-      expect(Tracer.getColdStart()).toBe(true);
-      expect(Tracer.getColdStart()).toBe(false);
-      expect(Tracer.getColdStart()).toBe(false);
-      expect(Tracer.getColdStart()).toBe(false);
-    
-    });
-    
   });
 
   describe('Method: getSegment', () => {

--- a/packages/tracing/tests/unit/middy.test.ts
+++ b/packages/tracing/tests/unit/middy.test.ts
@@ -32,7 +32,6 @@ describe('Middy middleware', () => {
   };
 
   beforeEach(() => {
-    Tracer.coldStart = true;
     jest.clearAllMocks();
     jest.resetModules();
     process.env = { ...ENVIRONMENT_VARIABLES };


### PR DESCRIPTION
## Description of your changes

This PR introduces changes to the `Tracer` module to adopt the forthcoming `Utility` class that will be released in the `@aws-lambda-powertools/commons` package.

- [x] Install released `@aws-lambda-powertools/commons` package
- [x] Make changes to the code to use the `Utility` class
- [x] Run unit & e2e tests
- [x] Add note in the docs about initialising utility outside of function handler ([ref](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/25fd4a0c2f40ff5af5ee6ec08a40a08f3e2dc22d/packages/commons/src/Utility.ts#L26))

### How to verify this change

See the checks in the PR, see the screenshot below that shows a successful e2e test run (locally):
![Screenshot 2022-02-17 at 16 20 38](https://user-images.githubusercontent.com/7353869/154512796-461f44a9-de19-4a16-9571-7c874cff8a78.png)

Optionally re-run the e2e tests on GitHub Actions.

### Related issues, RFCs

[#484](https://github.com/awslabs/aws-lambda-powertools-typescript/issues/484)  
[#547](https://github.com/awslabs/aws-lambda-powertools-typescript/pull/547)

### PR status

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] My changes generate *no new warnings*
- [x] The *code coverage* hasn't decreased
- [x] I have *added tests* that prove my change is effective and works
- [x] New and existing *unit tests pass* locally and in Github Actions
- [x] Any *dependent changes have been merged and published* in downstream module
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

N/A

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
