### PR TITLE
chore: update actions to npm8

### DIFF
--- a/.github/workflows/on-merge-to-main.yml
+++ b/.github/workflows/on-merge-to-main.yml
@@ -26,13 +26,19 @@ jobs:
       uses: actions/setup-node@v2
       with:
         node-version: '14'
+    - name: Install npm@8.x
+      run: npm i -g npm@next-8
     - name: "Setup npm"
       run: |
         npm set "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}"
-    - name: Install packages
-      run: |
-        npm ci
-        npm run lerna-ci
+    - name: Install monorepo packages
+      # This installs all the dependencies of ./packages/*
+      run: npm ci
+    - name: Install example packages
+      # Since we are not managing the cdk examples with npm workspaces we install
+      # the dependencies in a separate step
+      working-directory: ./examples/cdk
+      run: npm ci 
     - name: Run lint
       run: npm run lerna-lint
     - name: Run tests

--- a/.github/workflows/on-release-prod.yml
+++ b/.github/workflows/on-release-prod.yml
@@ -23,13 +23,19 @@ jobs:
       uses: actions/setup-node@v2
       with:
         node-version: '14'
+    - name: Install npm@8.x
+      run: npm i -g npm@next-8
     - name: "Setup npm"
       run: |
         npm set "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}"
-    - name: Install packages
-      run: |
-        npm ci
-        npm run lerna-ci
+    - name: Install monorepo packages
+      # This installs all the dependencies of ./packages/*
+      run: npm ci
+    - name: Install example packages
+      # Since we are not managing the cdk examples with npm workspaces we install
+      # the dependencies in a separate step
+      working-directory: ./examples/cdk
+      run: npm ci 
     - name: Run lint
       run: npm run lerna-lint
     - name: Run tests

--- a/.github/workflows/pr_lint_and_test.yml
+++ b/.github/workflows/pr_lint_and_test.yml
@@ -13,13 +13,19 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: '14'
+      - name: Install npm@8.x
+        run: npm i -g npm@next-8
       - name: "Setup npm"
         run: |
           npm set "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}"
-      - name: Install packages
-        run: |
-          npm ci
-          npm run lerna-ci
+      - name: Install monorepo packages
+        # This installs all the dependencies of ./packages/*
+        run: npm ci
+      - name: Install example packages
+        # Since we are not managing the cdk examples with npm workspaces we install
+        # the dependencies in a separate step
+        working-directory: ./examples/cdk
+        run: npm ci 
       - name: Run lint
         run: npm run lerna-lint
       - name: Run tests

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -23,10 +23,16 @@ jobs:
       uses: actions/setup-node@v2
       with:
         node-version: '14'
-    - name: Install packages
-      run: |
-        npm ci
-        npm run lerna-ci
+    - name: Install npm@8.x
+      run: npm i -g npm@next-8
+    - name: Install monorepo packages
+      # This installs all the dependencies of ./packages/*
+      run: npm ci
+    - name: Install example packages
+      # Since we are not managing the cdk examples with npm workspaces we install
+      # the dependencies in a separate step
+      working-directory: ./examples/cdk
+      run: npm ci
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v1.6.1
       with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,7 +127,9 @@ First [fork](https://docs.github.com/en/get-started/quickstart/fork-a-repo) the 
 ```console
 git clone https://github.com/{your-account}/aws-lambda-powertools-typescript.git
 cd aws-lambda-powertools-typescript
-npm ci; npm run lerna-ci
+npm ci;
+cd examples/cdk; npm ci
+cd ../
 npm run init-environment
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,7 +129,7 @@ git clone https://github.com/{your-account}/aws-lambda-powertools-typescript.git
 cd aws-lambda-powertools-typescript
 npm ci;
 cd examples/cdk; npm ci
-cd ../
+cd ../..
 npm run init-environment
 ```
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "test": "npm run lerna-test",
     "commit": "commit",
     "package": "npm run package",
-    "lerna-ci": "lerna exec -- npm ci",
     "lerna-test": "lerna exec -- npm run test",
     "lerna-test:e2e": "lerna exec -- npm run test:e2e",
     "lerna-package": "lerna exec -- npm run package",


### PR DESCRIPTION
## Description of your changes

This PR introduces changes in the workflows ran on GitHub Actions so that they make use of `npm@8.x` which we introduced as recommended version for the project in #492. This means that:
- We don't need to run `npm i` in the `packages/*` folders (which makes redundant the `npm run lerna-ci` step)
- We don't need a `package-lock.json` in each one of them as they are managed in the one at the root of the project

### How to verify this change

See this test run that I made on a fork of this repo, it uses the changes in this PR and also the ones in the #569 one: https://github.com/dreamorosi/aws-lambda-powertools-typescript/runs/5289484522?check_suite_focus=true

### Related issues, RFCs

[#569](https://github.com/awslabs/aws-lambda-powertools-typescript/pull/569)

### PR status

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [x] I have made corresponding changes to the *documentation*
- [x] I have made corresponding changes to the *examples*
- [x] My changes generate *no new warnings*
- [x] The *code coverage* hasn't decreased
- [x] New and existing *unit tests pass* locally and in Github Actions
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

N/A

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
