### PR TITLE
feat(tracer): improved manual tracing

### DIFF
--- a/packages/tracing/src/types/Tracer.ts
+++ b/packages/tracing/src/types/Tracer.ts
@@ -34,8 +34,14 @@ type HandlerMethodDecorator = (
 // eslint-disable-next-line  @typescript-eslint/no-explicit-any
 type MethodDecorator = (target: any, propertyKey: string | symbol, descriptor: TypedPropertyDescriptor<any>) => any;
 
+type ManualTracingOptions = {
+  annotateColdStart?: boolean
+  annotateServiceName?: boolean
+};
+
 export {
   TracerOptions,
   HandlerMethodDecorator,
-  MethodDecorator
+  MethodDecorator,
+  ManualTracingOptions
 };

--- a/packages/tracing/tests/unit/Tracer.test.ts
+++ b/packages/tracing/tests/unit/Tracer.test.ts
@@ -1289,7 +1289,11 @@ describe('Class: Tracer', () => {
         configurable: true,
         writable: true
       });
-      Object.defineProperty(tracer, 'currentSubsegment', { value: subsegment, configurable: true, writable: true });
+      Object.defineProperty(tracer, 'currentSubsegment', {
+        value: subsegment,
+        configurable: true,
+        writable: true
+      });
       
       // Act
       tracer.stopTracing();


### PR DESCRIPTION
## Description of your changes

This PR aims at streamlining the DX for manual tracing of functions by reducing boilerplate code needed to instrument them.

**Before:**
```typescript
import { Tracer } from '@aws-lambda-powertools/tracer';

const tracer = new Tracer({ serviceName: 'serverlessAirline' });

export const handler = async (_event: any, context: any) => {
  const segment = tracer.getSegment(); // This is the facade segment (the one that is created by AWS Lambda)
  // Create subsegment for the function & set it as active
  const subsegment = segment.addNewSubsegment(`## ${process.env._HANDLER}`);
  tracer.setSegment(subsegment);

  // Annotate the subsegment with the cold start & serviceName
  tracer.annotateColdStart();
  tracer.addServiceNameAnnotation();

  let res;
  try {
    // ...
  } catch (err) {
    // ...
  } finally {
    // Close the subsegment
    subsegment.close();
    // Set the facade segment as active again
    tracer.setSegment(segment);
  }

  return res;
}
```

As shown in the example above customers are expected to manually retrieve, create, and set a new segment and then explicitly call two additional methods to annotate the segment. Likewise, closing the trace requires customer to close the segment & then set the original one back again. All this requires a significant cognitive load and is extremely error prone.

The proposal is to add two new methods:
- `Tracer.startTracing` that customers are expected to call at the beginning of the handler function, this function takes care of:
- - Retrieving the Lambda-defined `facade` segment (& perform some check on its existence)
- - Create a new subsegment on it called `## index.handler` (names depends on actual handler name, similar to middleware & decorator)
- - Keep this segment/subsegment pair in memory to later be able to close & restore
- - Annotate subsegment with cold start bool by default (configurable via param)
- - Annotate subsegment with service name by default (configurable via param)
- - Return the segment so that customer can optionally use it in their business logic
- `Tracer.stopTracing` that customers are expected to call towards the end of the handler (or in case of errors), this method will:
- - Close the `## index.handler` subsegment previously created
- - Restore the `facade` segment as active one so that subsequent invocations are traced correctly

**After:**
```typescript
import { Tracer } from '@aws-lambda-powertools/tracer';

const tracer = new Tracer({ serviceName: 'serverlessAirline' });

export const handler = async (_event: any, context: any) => {
  // This opens a subsegment created for you by Tracer (i.e. "## index.handler")
  tracer.startTracing({
    annotateColdStart: true, // optional, default: true 
    annotateServiceName: true // optional, default: true
  });

  let res;
  try {
    // ...
  } catch (err) {
    // ...
  } finally {
    // Stop tracing
    tracer.stopTracing();
  }

  return res;
}
```
  
### How to verify this change

See unit tests implemented + e2e tests (**not done yet**)

But a test ran on a demo function of the code above already results in this:

![Screenshot 2022-02-25 at 16 28 04](https://user-images.githubusercontent.com/7353869/155741886-050cd539-89bf-4337-b1a2-0bd32ba9eb01.png)

### Related issues, RFCs

N/A

### PR status

***Is this ready for review?:*** NO  
***Is it a breaking change?:*** NO

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [ ] I have made corresponding changes to the *documentation*
- [ ] I have made corresponding changes to the *examples*
- [x] My changes generate *no new warnings*
- [x] The *code coverage* hasn't decreased
- [x] I have *added tests* that prove my change is effective and works
- [ ] New and existing *unit tests pass* locally and in Github Actions
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

N/A

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
