### PR TITLE
docs: Add usage sub-section in docs

### DIFF
--- a/docs/core/logger.md
+++ b/docs/core/logger.md
@@ -31,7 +31,7 @@ npm install @aws-lambda-powertools/logger
 
 ### Usage
 
-The `Logger` utility should always be instantiated outside of the Lambda handler. In doing this, subsequent invocations processed by the same instance of your function can reuse these resources. This saves cost by reducing function run time. In addition to this, `Logger` can also be aware of things like whether or not a given invocation had a cold start or not and inject the appropriate fields into the log.
+The `Logger` utility must always be instantiated outside of the Lambda handler. In doing this, subsequent invocations processed by the same instance of your function can reuse these resources. This saves cost by reducing function run time. In addition, `Logger` can keep track of a cold start and inject the appropriate fields into logs.
 
 === "handler.ts"
 

--- a/docs/core/logger.md
+++ b/docs/core/logger.md
@@ -29,6 +29,22 @@ Install the library in your project:
 npm install @aws-lambda-powertools/logger
 ```
 
+### Usage
+
+The `Logger` utility should always be instantiated outside of the Lambda handler. In doing this, subsequent invocations processed by the same instance of your function can reuse these resources. This saves cost by reducing function run time. In addition to this, `Logger` can also be aware of things like whether or not a given invocation had a cold start or not and inject the appropriate fields into the log.
+
+=== "handler.ts"
+
+    ```typescript hl_lines="1 3"
+    import { Logger } from '@aws-lambda-powertools/logger';
+
+    const logger = new Logger({ serviceName: 'serverlessAirline' });
+
+    export const handler = async (_event, _context): Promise<void> => {
+        // ...
+    };
+    ```
+
 ### Utility settings
 
 The library requires two settings. You can set them as environment variables, or pass them in the constructor.
@@ -44,8 +60,6 @@ For a **complete list** of supported environment variables, refer to [this secti
 
 #### Example using AWS Serverless Application Model (SAM)
 
-The `Logger` utility is instantiated outside of the Lambda handler. In doing this, the same instance can be used across multiple invocations inside the same execution environment. This allows `Metrics` to be aware of things like whether or not a given invocation had a cold start or not.
-
 === "handler.ts"
 
     ```typescript hl_lines="1 4"
@@ -56,8 +70,8 @@ The `Logger` utility is instantiated outside of the Lambda handler. In doing thi
 
     // You can also pass the parameters in the constructor
     // const logger = new Logger({
-    //     logLevel: "WARN",
-    //     serviceName: "serverlessAirline"
+    //     logLevel: 'WARN',
+    //     serviceName: 'serverlessAirline'
     // });
     ```
 

--- a/docs/core/metrics.md
+++ b/docs/core/metrics.md
@@ -43,6 +43,22 @@ Install the library in your project:
 npm install @aws-lambda-powertools/metrics
 ```
 
+### Usage
+
+The `Metrics` utility should always be instantiated outside of the Lambda handler. In doing this, subsequent invocations processed by the same instance of your function can reuse these resources. This saves cost by reducing function run time. In addition to this, `Metrics` can also be aware of things like whether or not a given invocation had a cold start or not and emit the appropriate metrics.
+
+=== "handler.ts"
+
+    ```typescript hl_lines="1 3"
+    import { Metrics } from '@aws-lambda-powertools/metrics';
+
+    const metrics = new Metrics({ namespace: 'serverlessAirline', serviceName: 'orders' });
+
+    export const handler = async (_event, _context): Promise<void> => {
+        // ...
+    };
+    ```
+
 ### Utility settings
 
 The library requires two settings. You can set them as environment variables, or pass them in the constructor.  

--- a/docs/core/metrics.md
+++ b/docs/core/metrics.md
@@ -45,7 +45,7 @@ npm install @aws-lambda-powertools/metrics
 
 ### Usage
 
-The `Metrics` utility should always be instantiated outside of the Lambda handler. In doing this, subsequent invocations processed by the same instance of your function can reuse these resources. This saves cost by reducing function run time. In addition to this, `Metrics` can also be aware of things like whether or not a given invocation had a cold start or not and emit the appropriate metrics.
+The `Metrics` utility must always be instantiated outside of the Lambda handler. In doing this, subsequent invocations processed by the same instance of your function can reuse these resources. This saves cost by reducing function run time. In addition, `Metrics` can track cold start and emit the appropriate metrics.
 
 === "handler.ts"
 

--- a/docs/core/tracer.md
+++ b/docs/core/tracer.md
@@ -31,6 +31,22 @@ Install the library in your project:
 npm install @aws-lambda-powertools/tracer
 ```
 
+### Usage
+
+The `Tracer` utility should always be instantiated outside of the Lambda handler. In doing this, subsequent invocations processed by the same instance of your function can reuse these resources. This saves cost by reducing function run time. In addition to this, `Tracer` can also be aware of things like whether or not a given invocation had a cold start or not and annotate your traces accordingly.
+
+=== "handler.ts"
+
+    ```typescript hl_lines="1 3"
+    import { Tracer } from '@aws-lambda-powertools/tracer';
+
+    const tracer = new Tracer({ serviceName: 'serverlessAirline' });
+
+    export const handler = async (_event, _context): Promise<void> => {
+        // ...
+    };
+    ```
+
 ### Utility settings
 
 The library has one optional setting. You can set it as environment variable, or pass it in the constructor.

--- a/docs/core/tracer.md
+++ b/docs/core/tracer.md
@@ -33,7 +33,7 @@ npm install @aws-lambda-powertools/tracer
 
 ### Usage
 
-The `Tracer` utility should always be instantiated outside of the Lambda handler. In doing this, subsequent invocations processed by the same instance of your function can reuse these resources. This saves cost by reducing function run time. In addition to this, `Tracer` can also be aware of things like whether or not a given invocation had a cold start or not and annotate your traces accordingly.
+The `Tracer` utility must always be instantiated outside of the Lambda handler. In doing this, subsequent invocations processed by the same instance of your function can reuse these resources. This saves cost by reducing function run time. In addition, `Tracer` can track cold start and annotate the traces accordingly.
 
 === "handler.ts"
 


### PR DESCRIPTION
## Description of your changes

Following the changes introduced in #550 and [this comment](https://github.com/awslabs/aws-lambda-powertools-typescript/pull/550#discussion_r815790620) from @saragerion, this PR introduces a new short "Usage" sub-section under the "Getting Started" section of each utility's page.

The goal of this section is to give a very basic example of the library's usage (just import & initialisation outside of handler) and point out why the utility has to be instantiated outside of the handler, explaining also benefits of doing so.

This wording was initially under the SAM section because that was the first code snippet but given that this _disclaimer_ is not SAM-specific it deserves its own section.

### How to verify this change

### Tracer
![Screenshot 2022-02-28 at 16 06 05](https://user-images.githubusercontent.com/7353869/156006646-f5763c73-ae31-4b64-a4c2-33c6cd130068.png)

### Logger
![image](https://user-images.githubusercontent.com/7353869/156006756-b7f4654a-4656-40e6-be8b-68d50ae1b58f.png)

### Metrics
![image](https://user-images.githubusercontent.com/7353869/156006846-7e94cc3b-191a-4453-ad02-bec9cd24e7ce.png)


### Related issues, RFCs

[#550](https://github.com/awslabs/aws-lambda-powertools-typescript/pull/550)  

### PR status

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have made corresponding changes to the *documentation*
- [x] My changes generate *no new warnings*
- [x] The *code coverage* hasn't decreased
- [x] New and existing *unit tests pass* locally and in Github Actions
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

N/A

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
