### PR TITLE
fix(logger): fix handling of additional log keys

### DIFF
--- a/docs/core/logger.md
+++ b/docs/core/logger.md
@@ -276,10 +276,12 @@ You can append additional persistent keys and values in the logs generated durin
 ### Appending additional log keys and values to a single log item
 
 You can append additional keys and values in a single log item passing them as parameters.
+Pass a string for logging it with default key name `extra`. Alternatively, pass one or multiple objects with custom keys.
+If you already have an object containing a `message` key and an additional property, you can pass this object directly.
 
 === "handler.ts"
 
-    ```typescript hl_lines="14 18-19"
+    ```typescript hl_lines="14 18-19 23 31"
     import { Logger } from '@aws-lambda-powertools/logger';
 
     const logger = new Logger();
@@ -300,6 +302,17 @@ You can append additional keys and values in a single log item passing them as p
             { data: myImportantVariable },
             { correlationIds: { myCustomCorrelationId: 'foo-bar-baz' } }
         );
+
+        // Simply pass a string for logging additional data
+        logger.info('This is a log with additional string value', 'string value');
+
+        // Directly passing an object containing both the message and the additional info
+        const logObject = {
+            message: 'This is a log message',
+            additionalValue: 42
+        };
+
+        logger.info(logObject);
         
         return {
             foo: 'bar'
@@ -309,7 +322,7 @@ You can append additional keys and values in a single log item passing them as p
     ```
 === "Example CloudWatch Logs excerpt"
 
-    ```json hl_lines="7 15-16"
+    ```json hl_lines="7 15-16 24 32"
     {
         "level": "INFO",
         "message": "This is a log with an extra variable",
@@ -326,6 +339,22 @@ You can append additional keys and values in a single log item passing them as p
         "xray_trace_id": "abcdef123456abcdef123456abcdef123456",
         "data": { "foo": "bar" },
         "correlationIds": { "myCustomCorrelationId": "foo-bar-baz" }
+    }
+    {
+        "level": "INFO",
+        "message": "This is a log with additional string value",
+        "service": "serverlessAirline",
+        "timestamp": "2021-12-12T22:06:17.463Z",
+        "xray_trace_id": "abcdef123456abcdef123456abcdef123456",
+        "extra": "string value"
+    }
+    {
+        "level": "INFO",
+        "message": "This is a log message",
+        "service": "serverlessAirline",
+        "timestamp": "2021-12-12T22:06:17.463Z",
+        "xray_trace_id": "abcdef123456abcdef123456abcdef123456",
+        "additionalValue": 42
     }
     ```
 
@@ -347,14 +376,14 @@ The error will be logged with default key name `error`, but you can also pass yo
             throw new Error('Unexpected error #1');
         } catch (error) {
             // Log information about the error using the default "error" key
-            logger.error('This is the first error', error);
+            logger.error('This is the first error', error as Error);
         }
 
         try {
             throw new Error('Unexpected error #2');
         } catch (error) {
             // Log information about the error using a custom "myCustomErrorKey" key
-            logger.error('This is the second error', { myCustomErrorKey: error } );
+            logger.error('This is the second error', { myCustomErrorKey: error as Error } );
         }
     
     };
@@ -390,6 +419,9 @@ The error will be logged with default key name `error`, but you can also pass yo
         }
     }
     ```
+
+!!! tip "Logging errors and log level"
+    You can also log errors using the `warn`, `info`, and `debug` methods. Be aware of the log level though, you might miss those  errors when analyzing the log later depending on the log level configuration.
 
 ## Advanced
 

--- a/packages/logger/examples/additional-keys.ts
+++ b/packages/logger/examples/additional-keys.ts
@@ -20,6 +20,9 @@ const lambdaHandler: Handler = async () => {
   // Pass an error that occurred
   logger.error('This is an ERROR log', new Error('Something bad happened!'));
 
+  // Pass a simple string as additional data
+  logger.info('This is an INFO log', 'Extra log data');
+
   return {
     foo: 'bar'
   };

--- a/packages/logger/examples/errors.ts
+++ b/packages/logger/examples/errors.ts
@@ -17,13 +17,13 @@ const lambdaHandler: Handler = async () => {
   try {
     throw new Error('Unexpected error #1');
   } catch (error) {
-    logger.error('This is an ERROR log #1', error);
+    logger.error('This is an ERROR log #1', error as Error);
   }
 
   try {
     throw new Error('Unexpected error #2');
   } catch (error) {
-    logger.error('This is an ERROR log #2', { myCustomErrorKey: error } );
+    logger.error('This is an ERROR log #2', { myCustomErrorKey: error as Error } );
   }
 
   return {

--- a/packages/logger/src/Logger.ts
+++ b/packages/logger/src/Logger.ts
@@ -200,7 +200,7 @@ class Logger extends Utility implements ClassThatLogs {
    * It prints a log item with level DEBUG.
    *
    * @param {LogItemMessage} input
-   * @param {Error | LogAttributes | unknown} extraInput
+   * @param {Error | LogAttributes | string} extraInput
    * @returns {void}
    */
   public debug(input: LogItemMessage, ...extraInput: LogItemExtraInput): void {
@@ -211,7 +211,7 @@ class Logger extends Utility implements ClassThatLogs {
    * It prints a log item with level ERROR.
    *
    * @param {LogItemMessage} input
-   * @param {Error | LogAttributes | unknown} extraInput
+   * @param {Error | LogAttributes | string} extraInput
    * @returns {void}
    */
   public error(input: LogItemMessage, ...extraInput: LogItemExtraInput): void {
@@ -231,7 +231,7 @@ class Logger extends Utility implements ClassThatLogs {
    * It prints a log item with level INFO.
    *
    * @param {LogItemMessage} input
-   * @param {Error | LogAttributes | unknown} extraInput
+   * @param {Error | LogAttributes | string} extraInput
    * @returns {void}
    */
   public info(input: LogItemMessage, ...extraInput: LogItemExtraInput): void {
@@ -288,7 +288,7 @@ class Logger extends Utility implements ClassThatLogs {
    * It prints a log item with level WARN.
    *
    * @param {LogItemMessage} input
-   * @param {Error | LogAttributes | unknown} extraInput
+   * @param {Error | LogAttributes | string} extraInput
    * @returns {void}
    */
   public warn(input: LogItemMessage, ...extraInput: LogItemExtraInput): void {
@@ -336,9 +336,13 @@ class Logger extends Utility implements ClassThatLogs {
     if (typeof input !== 'string') {
       logItem.addAttributes(input);
     }
-    extraInput.forEach((item: Error | LogAttributes | unknown) => {
-      const attributes = item instanceof Error ? { error: item } : item;
-      logItem.addAttributes(<LogAttributes>attributes);
+    extraInput.forEach((item: Error | LogAttributes | string) => {
+      const attributes: LogAttributes =
+        item instanceof Error ? { error: item } :
+          typeof item === 'string' ? { extra: item } :
+            item;
+
+      logItem.addAttributes(attributes);
     });
 
     return logItem;

--- a/packages/logger/src/types/Logger.ts
+++ b/packages/logger/src/types/Logger.ts
@@ -50,7 +50,7 @@ type UnformattedAttributes = {
 };
 
 type LogItemMessage = string | LogAttributesWithMessage;
-type LogItemExtraInput = Array<Error | LogAttributes | unknown>;
+type LogItemExtraInput = [Error | string] | LogAttributes[];
 
 type HandlerMethodDecorator = (
   target: LambdaInterface,

--- a/packages/logger/tests/e2e/basicFeatures.middy.test.FunctionCode.ts
+++ b/packages/logger/tests/e2e/basicFeatures.middy.test.FunctionCode.ts
@@ -30,7 +30,7 @@ const testFunction = async (event: APIGatewayProxyEvent, context: Context): Prom
   try {
     throw new Error(ERROR_MSG);
   } catch (e) {
-    logger.error(ERROR_MSG, e);
+    logger.error(ERROR_MSG, e as Error);
   }
 
   return {

--- a/packages/logger/tests/unit/Logger.test.ts
+++ b/packages/logger/tests/unit/Logger.test.ts
@@ -288,6 +288,7 @@ describe('Class: Logger', () => {
             logger[methodOfLogger]( { message: 'A log item with an object as first parameters', extra: 'parameter' });
             logger[methodOfLogger]('A log item with a string as first parameter, and an error as second parameter', new Error('Something happened!') );
             logger[methodOfLogger]('A log item with a string as first parameter, and an error with custom key as second parameter', { myCustomErrorKey: new Error('Something happened!') });
+            logger[methodOfLogger]('A log item with a string as first parameter, and a string as second parameter', 'parameter');
           }
 
           // Assess
@@ -350,6 +351,14 @@ describe('Class: Logger', () => {
               name: 'Error',
               stack: expect.stringMatching(/Logger.test.ts:[0-9]+:[0-9]+/),
             },
+          }));
+          expect(console[methodOfConsole]).toHaveBeenNthCalledWith(7, JSON.stringify({
+            level: method.toUpperCase(),
+            message: 'A log item with a string as first parameter, and a string as second parameter',
+            service: 'hello-world',
+            timestamp: '2016-06-20T12:08:10.000Z',
+            xray_trace_id: 'abcdef123456abcdef123456abcdef123456',
+            extra: 'parameter',
           }));
         });
       });


### PR DESCRIPTION
## Description of your changes

`Logger` accepts a second parameter that allows to append additional keys and values to a single log item.
Currently, there are 5 use cases that are supported for this:

```ts
// 1) object
logger.info('This is the message value', { extra: 'parameter' });

// 2) object, object, ...
logger.info('This is the message value', { parameterOne: 'foo' }, { parameterTwo: 'bar' });

// 3) Object (that contains the message key)
logger.info( { message: 'This is the message value', extra: 'parameter' });

// 4) error
logger.info('This is the message value', new Error('Something happened!') );

// 5) error with custom key
logger.info('This is the message value', { myCustomErrorKey: new Error('Something happened!') });
```

However, the current implementation allows passing simple strings, arrays, and any other `unknown` objects (single or multiple) as a second (third, fourth, ...) parameter, causing unwanted side effects.

This PR addresses this issue by aligning the implementation to other AWS Lambda Powertools flavors like e.g. Python.
So, one more use cases is allowed:

```ts
// 6) simple string
logger.info('This is the message value', 'Additional string value');
```

Additionally:
- passing multiple objects is restricted to only `{ key: 'value' }` (key-value) kind of ones
- in general, passing arrays and other `unknown` objects is not supported anymore (**BREAKING**)
- passing multiple strings and `Error`s is not supported anymore (**BREAKING**)


### How to verify this change

See the unit tests.
Check the updated documentation (section "Appending additional log keys and values to a single log item").
Try to pass unsupported objects, e.g.:
```ts
logger.info('foo', 'bar', 'baz');
logger.info('foo', ['bar', 'baz']);
```

### Related issues, RFCs

[#565](https://github.com/awslabs/aws-lambda-powertools-typescript/issues/565)  

### PR status

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** YES

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [x] I have made corresponding changes to the *documentation*
- [x] I have made corresponding changes to the *examples*
- [x] My changes generate *no new warnings*
- [x] The *code coverage* hasn't decreased
- [x] I have *added tests* that prove my change is effective and works
- [x] New and existing *unit tests pass* locally and in Github Actions
- [ ] Any *dependent changes have been merged and published* in downstream module
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

The TypeScript type system / compiler will produce errors for any unsupported API usage.
Users will have to fix those errors by converting any unsupported objects into strings or supported key-value objects.

- [ ] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
