### PR TITLE
build(dev-deps): add mermaid plugin to docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,7 +62,11 @@ markdown_extensions:
   - attr_list
   - pymdownx.emoji
   - pymdownx.inlinehilite
-  - pymdownx.superfences
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
 
 copyright: Copyright &copy; 2022 Amazon Web Services
 


### PR DESCRIPTION
## Description of your changes

This PR adds [the plugin](https://squidfunk.github.io/mkdocs-material/reference/diagrams/) that allows to use mermaid diagrams in the MKDocs documentation as discussed in our last meeting.

### How to verify this change

<img width="687" alt="image" src="https://user-images.githubusercontent.com/7353869/157207279-86be62ba-9377-40f9-b3b0-2dcdbea9420d.png">
**Note:** the diagram above is just an example to verify that the plugin works, it is not part of the changes.

### Related issues, RFCs

N/A

### PR status

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have made corresponding changes to the *documentation*
- [x] My changes generate *no new warnings*
- [x] The *code coverage* hasn't decreased
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

N/A

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
