### PR TITLE
docs: fixed naming notes

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -33,7 +33,7 @@ Core utilities such as Tracer, Logger, Metrics, and Event Handler will be availa
 
 ## Installation
 
-The AWS Lambda Powertools for TypeScript utilities follow a modular approach, similar to the official [AWS SDK v3 for JavaScript](https://github.com/aws/aws-sdk-js-v3){target="_blank"}.
+The AWS Lambda Powertools for TypeScript utilities (which from here will be referred as Powertools) follow a modular approach, similar to the official [AWS SDK v3 for JavaScript](https://github.com/aws/aws-sdk-js-v3).
 Each TypeScript utility is installed as standalone NPM package.
 
 [Installation guide for the **Tracer** utility](./core/tracer.md#getting-started)

--- a/packages/commons/README.md
+++ b/packages/commons/README.md
@@ -23,7 +23,7 @@ Find the complete project's [documentation here](https://awslabs.github.io/aws-l
 
 ### Installation
 
-The AWS Lambda Powertools for TypeScript utilities (which from here will be referred as Powertools) follow a modular approach, similar to the official [AWS SDK v3 for JavaScript](https://github.com/aws/aws-sdk-js-v3).
+The AWS Lambda Powertools for TypeScript utilities follow a modular approach, similar to the official [AWS SDK v3 for JavaScript](https://github.com/aws/aws-sdk-js-v3){target="_blank"}.
 Each TypeScript utility is installed as standalone NPM package.
 
 👉 [Installation guide for the **Tracer** utility](https://awslabs.github.io/aws-lambda-powertools-typescript/latest/core/tracer#getting-started)


### PR DESCRIPTION
## Description of your changes

Fix to correct the wrong placement of the naming clarification on the docs.

### How to verify this change

Confirm that the change has now been applied to the "Install" section of the main docs page.

### Related issues, RFCs

[#628](https://github.com/awslabs/aws-lambda-powertools-typescript/pull/628)  

### PR status

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have made corresponding changes to the *documentation*
- [x] My changes generate *no new warnings*
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

N/A

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
