### PR TITLE
fix(tracer, metrics): use polling instead of fixed wait in e2e tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4781,6 +4781,21 @@
       "integrity": "sha512-ReVR2rLTV1kvtlWFyuot+d1pkpG2Fw/XKE3PDAdj57rbM97ttSp9JZ2UsP+2EHTylra9cUf6JA7tGwW1INzUrA==",
       "dev": true
     },
+    "node_modules/@types/promise-retry": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@types/promise-retry/-/promise-retry-1.1.3.tgz",
+      "integrity": "sha512-LxIlEpEX6frE3co3vCO2EUJfHIta1IOmhDlcAsR4GMMv9hev1iTI9VwberVGkePJAuLZs5rMucrV8CziCfuJMw==",
+      "dev": true,
+      "dependencies": {
+        "@types/retry": "*"
+      }
+    },
+    "node_modules/@types/retry": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
+      "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g==",
+      "dev": true
+    },
     "node_modules/@types/stack-utils": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
@@ -16066,7 +16081,9 @@
         "aws-xray-sdk-core": "^3.3.3"
       },
       "devDependencies": {
-        "@aws-sdk/client-dynamodb": "^3.52.0"
+        "@aws-sdk/client-dynamodb": "^3.52.0",
+        "@types/promise-retry": "^1.1.3",
+        "promise-retry": "^2.0.1"
       }
     }
   },
@@ -16765,7 +16782,9 @@
       "requires": {
         "@aws-lambda-powertools/commons": "^0.7.0",
         "@aws-sdk/client-dynamodb": "^3.52.0",
-        "aws-xray-sdk-core": "^3.3.3"
+        "@types/promise-retry": "^1.1.3",
+        "aws-xray-sdk-core": "^3.3.3",
+        "promise-retry": "^2.0.1"
       }
     },
     "@aws-sdk/abort-controller": {
@@ -19792,6 +19811,21 @@
       "version": "2.4.4",
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.4.4.tgz",
       "integrity": "sha512-ReVR2rLTV1kvtlWFyuot+d1pkpG2Fw/XKE3PDAdj57rbM97ttSp9JZ2UsP+2EHTylra9cUf6JA7tGwW1INzUrA==",
+      "dev": true
+    },
+    "@types/promise-retry": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@types/promise-retry/-/promise-retry-1.1.3.tgz",
+      "integrity": "sha512-LxIlEpEX6frE3co3vCO2EUJfHIta1IOmhDlcAsR4GMMv9hev1iTI9VwberVGkePJAuLZs5rMucrV8CziCfuJMw==",
+      "dev": true,
+      "requires": {
+        "@types/retry": "*"
+      }
+    },
+    "@types/retry": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
+      "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g==",
       "dev": true
     },
     "@types/stack-utils": {

--- a/packages/metrics/package.json
+++ b/packages/metrics/package.json
@@ -50,6 +50,10 @@
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "typedocMain": "src/index.ts",
+  "devDependencies": {
+    "@types/promise-retry": "^1.1.3",
+    "promise-retry": "^2.0.1"
+  },
   "files": [
     "lib"
   ],

--- a/packages/metrics/tests/e2e/standardFunctions.test.ts
+++ b/packages/metrics/tests/e2e/standardFunctions.test.ts
@@ -15,6 +15,9 @@ import { SdkProvider } from 'aws-cdk/lib/api/aws-auth';
 import { CloudFormationDeployments } from 'aws-cdk/lib/api/cloudformation-deployments';
 import * as AWS from 'aws-sdk';
 import { MetricUnits } from '../../src';
+import { getMetrics } from '../helpers/metricsUtils';
+
+const ONE_MINUTE = 1000 * 60;
 
 const cloudwatchClient = new AWS.CloudWatch();
 const lambdaClient = new AWS.Lambda();
@@ -83,16 +86,12 @@ describe('happy cases', () => {
     // THEN
     // sleep to allow metrics to be collected
     await new Promise((resolve) => setTimeout(resolve, 15000));
-  }, 200000);
+  }, ONE_MINUTE * 3);
 
   it('capture ColdStart Metric', async () => {
     // Check coldstart metric dimensions
-    const coldStartMetrics = await cloudwatchClient
-      .listMetrics({
-        Namespace: expectedNamespace,
-        MetricName: 'ColdStart',
-      })
-      .promise();
+    const coldStartMetrics = await getMetrics(cloudwatchClient, expectedNamespace, 'ColdStart', 1);
+
     expect(coldStartMetrics.Metrics?.length).toBe(1);
     const coldStartMetric = coldStartMetrics.Metrics?.[0];
     expect(coldStartMetric?.Dimensions).toStrictEqual([{ Name: 'service', Value: expectedServiceName }]);
@@ -119,16 +118,12 @@ describe('happy cases', () => {
     // Despite lambda has been called twice, coldstart metric sum should only be 1
     const singleDataPoint = coldStartMetricStat.Datapoints ? coldStartMetricStat.Datapoints[0] : {};
     expect(singleDataPoint?.Sum).toBe(1);
-  }, 15000);
+  }, ONE_MINUTE * 3);
 
   it('produce added Metric with the default and extra one dimensions', async () => {
     // Check metric dimensions
-    const metrics = await cloudwatchClient
-      .listMetrics({
-        Namespace: expectedNamespace,
-        MetricName: expectedMetricName,
-      })
-      .promise();
+    const metrics = await getMetrics(cloudwatchClient, expectedNamespace, expectedMetricName, 1);
+
     expect(metrics.Metrics?.length).toBe(1);
     const metric = metrics.Metrics?.[0];
     const expectedDimensions = [
@@ -139,16 +134,16 @@ describe('happy cases', () => {
     expect(metric?.Dimensions).toStrictEqual(expectedDimensions);
 
     // Check coldstart metric value
-    const adjustedStartTime = new Date(startTime.getTime() - 60 * 1000);
-    const endTime = new Date(new Date().getTime() + 60 * 1000);
+    const adjustedStartTime = new Date(startTime.getTime() - 3 * ONE_MINUTE);
+    const endTime = new Date(new Date().getTime() + ONE_MINUTE);
     console.log(`Manual command: aws cloudwatch get-metric-statistics --namespace ${expectedNamespace} --metric-name ${expectedMetricName} --start-time ${Math.floor(adjustedStartTime.getTime()/1000)} --end-time ${Math.floor(endTime.getTime()/1000)} --statistics 'Sum' --period 60 --dimensions '${JSON.stringify(expectedDimensions)}'`);
     const metricStat = await cloudwatchClient
       .getMetricStatistics(
         {
           Namespace: expectedNamespace,
-          StartTime: new Date(startTime.getTime() - 60 * 1000), // minus 1 minute,
+          StartTime: adjustedStartTime,
           Dimensions: expectedDimensions,
-          EndTime: new Date(new Date().getTime() + 60 * 1000),
+          EndTime: endTime,
           Period: 60,
           MetricName: expectedMetricName,
           Statistics: ['Sum'],
@@ -160,7 +155,7 @@ describe('happy cases', () => {
     // Since lambda has been called twice in this test and potentially more in others, metric sum should be at least of expectedMetricValue * invocationCount
     const singleDataPoint = metricStat.Datapoints ? metricStat.Datapoints[0] : {};
     expect(singleDataPoint.Sum).toBeGreaterThanOrEqual(parseInt(expectedMetricValue) * invocationCount);
-  }, 15000);
+  }, ONE_MINUTE * 3);
 
   afterAll(async () => {
     if (!process.env.DISABLE_TEARDOWN) {
@@ -176,5 +171,5 @@ describe('happy cases', () => {
         quiet: true,
       });
     }
-  }, 200000);
+  }, ONE_MINUTE * 3);
 });

--- a/packages/metrics/tests/helpers/metricsUtils.ts
+++ b/packages/metrics/tests/helpers/metricsUtils.ts
@@ -1,0 +1,24 @@
+import { CloudWatch } from 'aws-sdk';
+import promiseRetry from 'promise-retry';
+
+const getMetrics = async (cloudWatchClient: CloudWatch, namespace: string, metric: string, expectedMetrics: number): Promise<CloudWatch.ListMetricsOutput> => {
+  const retryOptions = { retries: 20, minTimeout: 5_000, maxTimeout: 10_000, factor: 1.25 };
+
+  return promiseRetry(async (retry: (err?: Error) => never, _: number) => {
+
+    const result = await cloudWatchClient
+      .listMetrics({
+        Namespace: namespace,
+        MetricName: metric,
+      })
+      .promise();
+
+    if (result.Metrics?.length !== expectedMetrics) {
+      retry(new Error(`Expected ${expectedMetrics} metrics, got ${result.Metrics?.length} for ${namespace}.${metric}`));
+    }
+
+    return result;
+  }, retryOptions);
+};
+
+export { getMetrics };

--- a/packages/tracing/package.json
+++ b/packages/tracing/package.json
@@ -30,7 +30,9 @@
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "devDependencies": {
-    "@aws-sdk/client-dynamodb": "^3.52.0"
+    "@aws-sdk/client-dynamodb": "^3.52.0",
+    "@types/promise-retry": "^1.1.3",
+    "promise-retry": "^2.0.1"
   },
   "files": [
     "lib"


### PR DESCRIPTION
## Description of your changes

This PR changes the way the E2E tests for **metrics** and **tracer** perform their checks.
Instead of waiting for a fixed amount of time (and hoping that the expected data will be available after the wait time elapses), the tests will now actively and periodically poll the corresponding services (CloudWatch metrics, X-Ray traces). When the expected number of result items arrives, the tests will perform their validation as usual. In case there will be not enough (or too many) items, the polling will stop after a timeout, so the tests will fail as intended.

The implementation relies on polling using unique IDs as keys. For metrics, the namespaces already represent such unique IDs in form of UUIDs. For traces, instead of introducing additional UUID annotations, it turned out to be easier to use unique Lambda function names for each test run.

This PR adds a new dev dependency: the [promise-retry](https://www.npmjs.com/package/promise-retry) package (and its corresponding type declaration package).

### How to verify this change

Run the E2E tests for **tracer** and **metrics** multiple times:

```bash
cd ./packages/tracing/ && for i in {1..10}; do npm run test:e2e; done && cd ..
cd ./packages/metrics/ && for i in {1..10}; do npm run test:e2e; done && cd ..
```
Explore the test results.

**NOTE:** The tests might fail for a different (legitimate) reason, so a red test result doesn't necessarily mean an issue with this PR. If any test fails, compare the actual stored trace or metric data with the expected values using AWS CLI or the Management Console. If the values differ, the test failure is caused not by the way the tests gather the data, so those failures must be investigated separately.

### Related issues, RFCs

<!--- Add here the link to one or more Github Issues or RFCs that are related to this PR. -->
#644

### PR status

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
- [x] I have performed a *self-review* of my own code
- [ ] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [ ] I have made corresponding changes to the *documentation*
- [ ] I have made corresponding changes to the *examples*
- [x] My changes generate *no new warnings*
- [x] The *code coverage* hasn't decreased
- [ ] I have *added tests* that prove my change is effective and works
- [x] New and existing *unit tests pass* locally and in Github Actions
- [ ] Any *dependent changes have been merged and published* in downstream module
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

- [ ] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
