### PR TITLE
fix(logger): enable sequential invocation in e2e test

### DIFF
--- a/packages/logger/tests/e2e/basicFeatures.middy.test.ts
+++ b/packages/logger/tests/e2e/basicFeatures.middy.test.ts
@@ -72,7 +72,7 @@ describe(`logger E2E tests basic functionalities (middy) for runtime: ${runtime}
     logGroupName = outputs[STACK_OUTPUT_LOG_GROUP];
 
     // Invoke the function twice (one for cold start, another for warm start)
-    invocationLogs = await invokeFunction(functionName, 2);
+    invocationLogs = await invokeFunction(functionName, 2, 'SEQUENTIAL');
 
     console.log('logGroupName', logGroupName);
     

--- a/packages/logger/tests/e2e/basicFeatures.middy.test.ts
+++ b/packages/logger/tests/e2e/basicFeatures.middy.test.ts
@@ -103,12 +103,11 @@ describe(`logger E2E tests basic functionalities (middy) for runtime: ${runtime}
       for (const message of coldStartLogMessages) {
         expect(message).toContain(`"cold_start":true`);
       }
-      // TODO: There is an issue with the way in which functions are invoked that always forces a cold start. (#590) 
-      // Link to tracked issue: https://github.com/awslabs/aws-lambda-powertools-typescript/issues/590
-      // const normalLogMessages = invocationLogs[1].getFunctionLogs(LEVEL.INFO);
-      // for (const message of normalLogMessages) {
-      //   expect(message).not.toContain(`"cold_start":true`);
-      // }
+
+      const normalLogMessages = invocationLogs[1].getFunctionLogs(LEVEL.INFO);
+      for (const message of normalLogMessages) {
+        expect(message).not.toContain(`"cold_start":true`);
+      }
     }, TEST_CASE_TIMEOUT);
   });
 


### PR DESCRIPTION
## Description of your changes

This PR addresses the issue of the AWS Lambda function invocation mode in the E2E tests for the **Logger** package.
Previously, multiple function invocations have always been performed in parallel. However, this made all the cold start checks impossible, because parallel invocations cause multiple cold starts.

The `invokeFunction` helper function now has an additional optional parameter `invocationMode` with allowed options  `PARALLEL` or `SEQUENTIAL`. This parameter lets the invokers control how to call the function-under-test.

Note: the parameter is of a union type which differs from the original proposal of a `boolean` parameter.
The reasoning behind it is simple: it makes the code easier to read.
Compare:
```ts
invocationLogs = await invokeFunction(functionName, 2, false); // what does 'false' mean? need to delve
```
with
```ts
invocationLogs = await invokeFunction(functionName, 2, 'SEQUENTIAL'); // 100% clear
```

### How to verify this change

Run the E2E tests for the **Logger** package. The test `should include cold start equal to TRUE only on the first invocation` has to pass.
Follow the steps from the **Reproduce** section from #590. Only one initialization section has to appear.

### Related issues, RFCs

#590 

### PR status

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
- [x] I have performed a *self-review* of my own code
- [ ] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [ ] I have made corresponding changes to the *documentation*
- [ ] I have made corresponding changes to the *examples*
- [x] My changes generate *no new warnings*
- [x] The *code coverage* hasn't decreased
- [ ] I have *added tests* that prove my change is effective and works
- [x] New and existing *unit tests pass* locally and in Github Actions
- [ ] Any *dependent changes have been merged and published* in downstream module
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

- [ ] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
