### PR TITLE
feat: added captureHTTPsRequest feature

### DIFF
--- a/docs/core/tracer.md
+++ b/docs/core/tracer.md
@@ -351,7 +351,7 @@ You can opt-out from this feature by setting the **`POWERTOOLS_TRACER_CAPTURE_HT
 
     const tracer = new Tracer({ serviceName: 'serverlessAirline' });
 
-    export const handler = async (event: any, context: Context): Promise<void> => {
+    export const handler = async (event: unknown, context: Context): Promise<void> => {
         await axios.get('https://httpbin.org/status/200');
     };
     ```

--- a/docs/core/tracer.md
+++ b/docs/core/tracer.md
@@ -16,6 +16,7 @@ Tracer is an opinionated thin wrapper for [AWS X-Ray SDK for Node.js](https://gi
 
 * Auto capture cold start and service name as annotations, and responses or full exceptions as metadata
 * Auto-disable when not running in AWS Lambda environment
+* Automatically trace HTTP(s) clients and generate segments for each request
 * Support tracing functions via decorators, middleware, and manual instrumentation
 * Support tracing AWS SDK v2 and v3 via AWS X-Ray SDK for Node.js  
 
@@ -49,13 +50,13 @@ The `Tracer` utility must always be instantiated outside of the Lambda handler. 
 
 ### Utility settings
 
-The library has one optional setting. You can set it as environment variable, or pass it in the constructor.
-
-This setting will be used across all traces emitted:
+The library has three optional settings. You can set them as environment variables, or pass them in the constructor:
 
 Setting | Description                                                                                    | Environment variable | Constructor parameter
 ------------------------------------------------- |------------------------------------------------------------------------------------------------| ------------------------------------------------- | -------------------------------------------------
+**Tracing enabled** | Enables or disables tracing. By default tracing is enabled when running in AWS Lambda. | `POWERTOOLS_TRACE_ENABLED`          | `enabled`
 **Service name** | Sets an annotation with the **name of the service** across all traces e.g. `serverlessAirline` | `POWERTOOLS_SERVICE_NAME` | `serviceName`
+**Capture HTTPs Requests** | Defines whether HTTPs requests will be traced or not, enabled by default when tracing is also enabled. | `POWERTOOLS_TRACER_CAPTURE_HTTPS_REQUESTS` | `captureHTTPsRequests`
 
 For a **complete list** of supported environment variables, refer to [this section](./../index.md#environment-variables).
 
@@ -137,13 +138,9 @@ You can quickly start by importing the `Tracer` class, initialize it outside the
 
 === "Middy Middleware"
 
-    !!! tip "Using Middy for the first time?"
-        You can install Middy by running `npm i @middy/core`.
-        Learn more about [its usage and lifecycle in the official Middy documentation](https://github.com/middyjs/middy#usage){target="_blank"}.
-
     ```typescript hl_lines="1-2 11 13"
     import { Tracer, captureLambdaHandler } from '@aws-lambda-powertools/tracer';
-    import middy from '@middy/core';
+    import middy from '@middy/core'; // (1)
 
     const tracer = new Tracer({ serviceName: 'serverlessAirline' });
 
@@ -156,6 +153,9 @@ You can quickly start by importing the `Tracer` class, initialize it outside the
         // Use the middleware by passing the Tracer instance as a parameter
         .use(captureLambdaHandler(tracer));
     ```
+
+    1. Using Middy for the first time? You can install Middy by running `npm i @middy/core`.
+       Learn more about [its usage and lifecycle in the official Middy documentation](https://github.com/middyjs/middy#usage){target="_blank"}.
 
 === "Decorator"
 
@@ -326,11 +326,64 @@ If you're looking to shave a few microseconds, or milliseconds depending on your
 === "index.ts"
 
     ```typescript hl_lines="5"
-    import { S3 } from "aws-sdk";
+    import { S3 } from 'aws-sdk';
     import { Tracer } from '@aws-lambda-powertools/tracer';
 
     const tracer = new Tracer({ serviceName: 'serverlessAirline' });
     const s3 = tracer.captureAWSClient(new S3());
+    ```
+
+### Tracing HTTP requests
+
+When your function makes calls to microservices or public HTTP APIs, Tracer automatically traces those calls and add the API to the service graph as a downstream service.
+
+You can opt-out from this feature by setting the **`POWERTOOLS_TRACER_CAPTURE_HTTPS_REQUESTS=false`** environment variable or by passing the `captureHTTPSRequests: false` option to the `Tracer` constructor.
+
+!!! info
+    The following snippet shows how to trace [axios](https://www.npmjs.com/package/axios) requests, but you can use any HTTP client library built on top of [http](https://nodejs.org/api/http.html) or [https](https://nodejs.org/api/https.html)
+
+=== "index.ts"
+
+    ```typescript hl_lines="2 7"
+    import { Tracer } from '@aws-lambda-powertools/tracer';
+    import axios from 'axios'; // (1)
+
+    const tracer = new Tracer({ serviceName: 'serverlessAirline' });
+
+    export const handler = async (event: any, context: Context): Promise<void> => {
+        await axios.get('https://httpbin.org/status/200');
+    };
+    ```
+
+    1.  You can install the [axios](https://www.npmjs.com/package/axios) package using `npm i axios`
+=== "Example Raw X-Ray Trace excerpt"
+
+    ```json hl_lines="6 9 12-21"
+    {
+        "id": "22883fbc730e3a0b",
+        "name": "## index.handler",
+        "start_time": 1647956168.22749,
+        "end_time": 1647956169.0679862,
+        "subsegments": [
+            {
+                "id": "ab82ab2b7d525d8f",
+                "name": "httpbin.org",
+                "start_time": 1647956168.407,
+                "end_time": 1647956168.945,
+                "http": {
+                    "request": {
+                        "url": "https://httpbin.org/status/200",
+                        "method": "GET"
+                    },
+                    "response": {
+                        "status": 200,
+                        "content_length": 0
+                    }
+                },
+                "namespace": "remote"
+            }
+        ]
+    }
     ```
 
 ## Advanced
@@ -361,7 +414,7 @@ This is useful when you need a feature available in X-Ray that is not available 
 
 === "index.ts"
 
-    ```typescript hl_lines="6"
+    ```typescript hl_lines="7"
     import { Logger } from '@aws-lambda-powertools/logger';
     import { Tracer } from '@aws-lambda-powertools/tracer';
 
@@ -379,4 +432,4 @@ Tracer is disabled by default when not running in the AWS Lambda environment - T
 
 * Use annotations on key operations to slice and dice traces, create unique views, and create metrics from it via Trace Groups
 * Use a namespace when adding metadata to group data more easily
-* Annotations and metadata are added to the current subsegment opened. If you want them in a specific subsegment, [create one](https://docs.aws.amazon.com/xray/latest/devguide/xray-sdk-nodejs-subsegments.html#xray-sdk-nodejs-subsegments-lambda) via the escape hatch mechanism
+* Annotations and metadata are added to the currently open subsegment. If you want them in a specific subsegment, [create one](https://docs.aws.amazon.com/xray/latest/devguide/xray-sdk-nodejs-subsegments.html#xray-sdk-nodejs-subsegments-lambda) via the escape hatch mechanism

--- a/docs/core/tracer.md
+++ b/docs/core/tracer.md
@@ -340,7 +340,8 @@ When your function makes calls to microservices or public HTTP APIs, Tracer auto
 You can opt-out from this feature by setting the **`POWERTOOLS_TRACER_CAPTURE_HTTPS_REQUESTS=false`** environment variable or by passing the `captureHTTPSRequests: false` option to the `Tracer` constructor.
 
 !!! info
-    The following snippet shows how to trace [axios](https://www.npmjs.com/package/axios) requests, but you can use any HTTP client library built on top of [http](https://nodejs.org/api/http.html) or [https](https://nodejs.org/api/https.html)
+    The following snippet shows how to trace [axios](https://www.npmjs.com/package/axios) requests, but you can use any HTTP client library built on top of [http](https://nodejs.org/api/http.html) or [https](https://nodejs.org/api/https.html).
+    Support to 3rd party HTTP clients is provided on a best effort basis.
 
 === "index.ts"
 

--- a/docs/core/tracer.md
+++ b/docs/core/tracer.md
@@ -335,7 +335,7 @@ If you're looking to shave a few microseconds, or milliseconds depending on your
 
 ### Tracing HTTP requests
 
-When your function makes calls to microservices or public HTTP APIs, Tracer automatically traces those calls and add the API to the service graph as a downstream service.
+When your function makes calls to HTTP APIs, Tracer automatically traces those calls and add the API to the service graph as a downstream service.
 
 You can opt-out from this feature by setting the **`POWERTOOLS_TRACER_CAPTURE_HTTPS_REQUESTS=false`** environment variable or by passing the `captureHTTPSRequests: false` option to the `Tracer` constructor.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -54,6 +54,7 @@ Each TypeScript utility is installed as standalone NPM package.
 | **POWERTOOLS_TRACE_ENABLED**              | Explicitly disables tracing | [Tracer](./core/tracer)   | `true`                |
 | **POWERTOOLS_TRACER_CAPTURE_RESPONSE**    | Captures Lambda or method return as metadata. | [Tracer](./core/tracer)   | `true`                |
 | **POWERTOOLS_TRACER_CAPTURE_ERROR**       | Captures Lambda or method exception as metadata. | [Tracer](./core/tracer)   | `true`                |
+| **POWERTOOLS_TRACER_CAPTURE_HTTPS_REQUESTS** | Captures HTTP(s) requests as segments. | [Tracer](./core/tracer)   | `true`                |
 | **POWERTOOLS_LOGGER_LOG_EVENT**           | Logs incoming event | [Logger](./core/logger)   | `false`               |
 | **POWERTOOLS_LOGGER_SAMPLE_RATE**         | Debug log sampling | [Logger](./core/logger)  | `0`                   |
 | **POWERTOOLS_LOG_DEDUPLICATION_DISABLED** | Disables log deduplication filter protection to use Pytest Live Log feature | [Logger](./core/logger)  | `false`               |

--- a/package-lock.json
+++ b/package-lock.json
@@ -5042,6 +5042,15 @@
       "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
       "dev": true
     },
+    "node_modules/axios": {
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+      "dev": true,
+      "dependencies": {
+        "follow-redirects": "^1.14.8"
+      }
+    },
     "node_modules/babel-jest": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-27.5.1.tgz",
@@ -8490,6 +8499,26 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.5.tgz",
       "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
       "dev": true
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.14.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
+      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
     },
     "node_modules/forever-agent": {
       "version": "0.6.1",
@@ -15638,12 +15667,13 @@
       "version": "0.7.2",
       "license": "MIT-0",
       "dependencies": {
-        "@aws-lambda-powertools/commons": "^0.7.2",
-        "aws-xray-sdk-core": "^3.3.3"
+        "@aws-lambda-powertools/commons": "^0.7.1",
+        "aws-xray-sdk-core": "^3.3.4"
       },
       "devDependencies": {
         "@aws-sdk/client-dynamodb": "^3.52.0",
         "@types/promise-retry": "^1.1.3",
+        "axios": "^0.26.1",
         "promise-retry": "^2.0.1"
       }
     }
@@ -15656,6 +15686,352 @@
       "dev": true,
       "requires": {
         "@jridgewell/trace-mapping": "^0.3.0"
+      }
+    },
+    "@aws-cdk/assets": {
+      "version": "1.147.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/assets/-/assets-1.147.0.tgz",
+      "integrity": "sha512-Fz5PB/cXPCeQUk0eNPQkYzzSG7encauGLT7Hm/egIavP6EKwGYxxkmy90SOHSOYg3FXjZxi5+evbyhL+2NAgRw==",
+      "dev": true,
+      "requires": {
+        "@aws-cdk/core": "1.147.0",
+        "@aws-cdk/cx-api": "1.147.0",
+        "constructs": "^3.3.69"
+      }
+    },
+    "@aws-cdk/aws-applicationautoscaling": {
+      "version": "1.147.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-applicationautoscaling/-/aws-applicationautoscaling-1.147.0.tgz",
+      "integrity": "sha512-pplTpCdgP9EjjSCsoFW9vjTp2XywDb22pTX/LRuc0dt5DDFmWxeKJyGpBkdcMDtrc8F4zrBV+T3qFy6pLzKJkA==",
+      "dev": true,
+      "requires": {
+        "@aws-cdk/aws-autoscaling-common": "1.147.0",
+        "@aws-cdk/aws-cloudwatch": "1.147.0",
+        "@aws-cdk/aws-iam": "1.147.0",
+        "@aws-cdk/core": "1.147.0",
+        "constructs": "^3.3.69"
+      }
+    },
+    "@aws-cdk/aws-autoscaling-common": {
+      "version": "1.147.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-autoscaling-common/-/aws-autoscaling-common-1.147.0.tgz",
+      "integrity": "sha512-NyzmbXP51rbK0/UPt6jy5BQqAfZrShABwMLPEhqeLRCkQqMmA2QkmkGebbTLWoCC1Kg5APsyx0Dm1/Wi1DNcCA==",
+      "dev": true,
+      "requires": {
+        "@aws-cdk/aws-iam": "1.147.0",
+        "@aws-cdk/core": "1.147.0",
+        "constructs": "^3.3.69"
+      }
+    },
+    "@aws-cdk/aws-cloudformation": {
+      "version": "1.147.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudformation/-/aws-cloudformation-1.147.0.tgz",
+      "integrity": "sha512-3qmi6RLY+y2GslTeyCQaIGOPs50PLsDLVkV5Lwo+S9ihGPmMWYvt3+kIlIFYSBpaoLR8eKqTmuvQG5ruq2Y9pA==",
+      "dev": true,
+      "requires": {
+        "@aws-cdk/aws-iam": "1.147.0",
+        "@aws-cdk/aws-lambda": "1.147.0",
+        "@aws-cdk/aws-s3": "1.147.0",
+        "@aws-cdk/aws-sns": "1.147.0",
+        "@aws-cdk/core": "1.147.0",
+        "@aws-cdk/cx-api": "1.147.0",
+        "constructs": "^3.3.69"
+      }
+    },
+    "@aws-cdk/aws-cloudwatch": {
+      "version": "1.147.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudwatch/-/aws-cloudwatch-1.147.0.tgz",
+      "integrity": "sha512-wyGbnzzCfULzOwNiqSPrDZPigy6svOcnZwUheu6dmzL7qxo1UHVj2hVCjTLbN7AtBx9WG3Rs70C6+WTqXQnYmQ==",
+      "dev": true,
+      "requires": {
+        "@aws-cdk/aws-iam": "1.147.0",
+        "@aws-cdk/core": "1.147.0",
+        "constructs": "^3.3.69"
+      }
+    },
+    "@aws-cdk/aws-codeguruprofiler": {
+      "version": "1.147.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-codeguruprofiler/-/aws-codeguruprofiler-1.147.0.tgz",
+      "integrity": "sha512-ykEENwhVKCI7WNIm2AjmiT2r+FxpNjt4tXdzWYEviJUr4h4LWnae7IHgfVPDeUXYZaEXnaajvAxXMkTROUJxAA==",
+      "dev": true,
+      "requires": {
+        "@aws-cdk/aws-iam": "1.147.0",
+        "@aws-cdk/core": "1.147.0",
+        "constructs": "^3.3.69"
+      }
+    },
+    "@aws-cdk/aws-codestarnotifications": {
+      "version": "1.147.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-codestarnotifications/-/aws-codestarnotifications-1.147.0.tgz",
+      "integrity": "sha512-+WOLDECaq7+fI5gIUJCi+svfHMC8+mfpL8hrV0a0rubTV3mHFoHv/vcdwYK5lW8X4PgfdWKbGUeBHoVweuIVBA==",
+      "dev": true,
+      "requires": {
+        "@aws-cdk/core": "1.147.0",
+        "constructs": "^3.3.69"
+      }
+    },
+    "@aws-cdk/aws-dynamodb": {
+      "version": "1.147.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-dynamodb/-/aws-dynamodb-1.147.0.tgz",
+      "integrity": "sha512-+uae79csAi8Gt+2o5PLSLSkgx3jo1bUHsnEmNUip/sDEaHGP+bhoZAmOMj38mZwiN6Tj91uibEKU9MMquvDGYQ==",
+      "dev": true,
+      "requires": {
+        "@aws-cdk/aws-applicationautoscaling": "1.147.0",
+        "@aws-cdk/aws-cloudwatch": "1.147.0",
+        "@aws-cdk/aws-iam": "1.147.0",
+        "@aws-cdk/aws-kinesis": "1.147.0",
+        "@aws-cdk/aws-kms": "1.147.0",
+        "@aws-cdk/aws-lambda": "1.147.0",
+        "@aws-cdk/core": "1.147.0",
+        "@aws-cdk/custom-resources": "1.147.0",
+        "constructs": "^3.3.69"
+      }
+    },
+    "@aws-cdk/aws-ec2": {
+      "version": "1.147.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ec2/-/aws-ec2-1.147.0.tgz",
+      "integrity": "sha512-rTb3BDrkog388k+OJnYWBltbjAfH8f7+NuXdlaxXyWCzl3yWqzHfEYVGUUQ6WpWZd7MiogOpL5JUY4e+Ch+SXw==",
+      "dev": true,
+      "requires": {
+        "@aws-cdk/aws-cloudwatch": "1.147.0",
+        "@aws-cdk/aws-iam": "1.147.0",
+        "@aws-cdk/aws-kms": "1.147.0",
+        "@aws-cdk/aws-logs": "1.147.0",
+        "@aws-cdk/aws-s3": "1.147.0",
+        "@aws-cdk/aws-s3-assets": "1.147.0",
+        "@aws-cdk/aws-ssm": "1.147.0",
+        "@aws-cdk/cloud-assembly-schema": "1.147.0",
+        "@aws-cdk/core": "1.147.0",
+        "@aws-cdk/cx-api": "1.147.0",
+        "@aws-cdk/region-info": "1.147.0",
+        "constructs": "^3.3.69"
+      }
+    },
+    "@aws-cdk/aws-ecr": {
+      "version": "1.147.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ecr/-/aws-ecr-1.147.0.tgz",
+      "integrity": "sha512-vwcupBCw3hoCS8tjoJHiYsFJ2cVeCr/4a/l2q12xZH0oyf9qMZye0cfIdZqIwRVABVgnbrcAH9eZZf8mvCb1vQ==",
+      "dev": true,
+      "requires": {
+        "@aws-cdk/aws-events": "1.147.0",
+        "@aws-cdk/aws-iam": "1.147.0",
+        "@aws-cdk/aws-kms": "1.147.0",
+        "@aws-cdk/core": "1.147.0",
+        "constructs": "^3.3.69"
+      }
+    },
+    "@aws-cdk/aws-ecr-assets": {
+      "version": "1.147.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ecr-assets/-/aws-ecr-assets-1.147.0.tgz",
+      "integrity": "sha512-04CpHNgBZ6el8Z9cH06kRyqK7QyazlF0AJVi2yIs1Xcg7gt4zh/P0mUneEW3o7Wy4NQeOQYmKC7IoPht6qfB+A==",
+      "dev": true,
+      "requires": {
+        "@aws-cdk/assets": "1.147.0",
+        "@aws-cdk/aws-ecr": "1.147.0",
+        "@aws-cdk/aws-iam": "1.147.0",
+        "@aws-cdk/aws-s3": "1.147.0",
+        "@aws-cdk/core": "1.147.0",
+        "@aws-cdk/cx-api": "1.147.0",
+        "constructs": "^3.3.69"
+      }
+    },
+    "@aws-cdk/aws-efs": {
+      "version": "1.147.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-efs/-/aws-efs-1.147.0.tgz",
+      "integrity": "sha512-gAi9vUBrvGOdLNqP7ORlgsIn4ZhLJQW1bK8vYrYpSMLDcTUf2kyo/xVoLMSm3YQ7UG75CrRqaKpSTBKhgMkRYg==",
+      "dev": true,
+      "requires": {
+        "@aws-cdk/aws-ec2": "1.147.0",
+        "@aws-cdk/aws-iam": "1.147.0",
+        "@aws-cdk/aws-kms": "1.147.0",
+        "@aws-cdk/cloud-assembly-schema": "1.147.0",
+        "@aws-cdk/core": "1.147.0",
+        "@aws-cdk/cx-api": "1.147.0",
+        "constructs": "^3.3.69"
+      }
+    },
+    "@aws-cdk/aws-events": {
+      "version": "1.147.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-events/-/aws-events-1.147.0.tgz",
+      "integrity": "sha512-zTwcs6pwMJSBipW4KNw75DjUqzMSeqBglGpgI3GAXjnqWODiZJ5E6OdsIMqkd8OyvZ+fvbNhNbWAN67iqcbI1w==",
+      "dev": true,
+      "requires": {
+        "@aws-cdk/aws-iam": "1.147.0",
+        "@aws-cdk/core": "1.147.0",
+        "constructs": "^3.3.69"
+      }
+    },
+    "@aws-cdk/aws-iam": {
+      "version": "1.147.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-iam/-/aws-iam-1.147.0.tgz",
+      "integrity": "sha512-25YwRaXiOmlI1YZ+CquR7vru59S+Wo1VlAsOnpZpzQ9RJiSgleOL6Qquw1veTylDK7xp1pijUhQdevQ8GUuwFA==",
+      "dev": true,
+      "requires": {
+        "@aws-cdk/core": "1.147.0",
+        "@aws-cdk/region-info": "1.147.0",
+        "constructs": "^3.3.69"
+      }
+    },
+    "@aws-cdk/aws-kinesis": {
+      "version": "1.147.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-kinesis/-/aws-kinesis-1.147.0.tgz",
+      "integrity": "sha512-Y+t3kdsb5qPsKg59bhQPlZfSIDfw89NbppkEdC7aLlvGzdWbBTv3hK3J3vRrSH4KLUYFaC/ylb9Ht6ZkEtfqEA==",
+      "dev": true,
+      "requires": {
+        "@aws-cdk/aws-cloudwatch": "1.147.0",
+        "@aws-cdk/aws-iam": "1.147.0",
+        "@aws-cdk/aws-kms": "1.147.0",
+        "@aws-cdk/aws-logs": "1.147.0",
+        "@aws-cdk/core": "1.147.0",
+        "constructs": "^3.3.69"
+      }
+    },
+    "@aws-cdk/aws-kms": {
+      "version": "1.147.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-kms/-/aws-kms-1.147.0.tgz",
+      "integrity": "sha512-O/BeiPXmWqETZKHgy1kYqcbMiMUVaC1BmB+zZnrk5j5Aivb19H9+1wLQ0uuXWQ8wfsrNKsg+nsjfiDGhGA71Qg==",
+      "dev": true,
+      "requires": {
+        "@aws-cdk/aws-iam": "1.147.0",
+        "@aws-cdk/cloud-assembly-schema": "1.147.0",
+        "@aws-cdk/core": "1.147.0",
+        "@aws-cdk/cx-api": "1.147.0",
+        "constructs": "^3.3.69"
+      }
+    },
+    "@aws-cdk/aws-lambda": {
+      "version": "1.147.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-lambda/-/aws-lambda-1.147.0.tgz",
+      "integrity": "sha512-zAU/jPN7zz/FNFBZCxq93iQuQqDMXVa8+DYay+p0/z+zivUZMyi9078xy8TrnrG59CZTiGiIDYMbmZOj2m5k6w==",
+      "dev": true,
+      "requires": {
+        "@aws-cdk/aws-applicationautoscaling": "1.147.0",
+        "@aws-cdk/aws-cloudwatch": "1.147.0",
+        "@aws-cdk/aws-codeguruprofiler": "1.147.0",
+        "@aws-cdk/aws-ec2": "1.147.0",
+        "@aws-cdk/aws-ecr": "1.147.0",
+        "@aws-cdk/aws-ecr-assets": "1.147.0",
+        "@aws-cdk/aws-efs": "1.147.0",
+        "@aws-cdk/aws-events": "1.147.0",
+        "@aws-cdk/aws-iam": "1.147.0",
+        "@aws-cdk/aws-kms": "1.147.0",
+        "@aws-cdk/aws-logs": "1.147.0",
+        "@aws-cdk/aws-s3": "1.147.0",
+        "@aws-cdk/aws-s3-assets": "1.147.0",
+        "@aws-cdk/aws-signer": "1.147.0",
+        "@aws-cdk/aws-sns": "1.147.0",
+        "@aws-cdk/aws-sqs": "1.147.0",
+        "@aws-cdk/core": "1.147.0",
+        "@aws-cdk/cx-api": "1.147.0",
+        "@aws-cdk/region-info": "1.147.0",
+        "constructs": "^3.3.69"
+      }
+    },
+    "@aws-cdk/aws-lambda-nodejs": {
+      "version": "1.147.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-lambda-nodejs/-/aws-lambda-nodejs-1.147.0.tgz",
+      "integrity": "sha512-d7pYBw3LA4+UdWn1Uk4AQQB4ZOfE+fUQfPAW0vuQ0za9Rcvbg0iLYmzrPrytx7jeNJmbxA8tBjrYk9okgqoUVg==",
+      "dev": true,
+      "requires": {
+        "@aws-cdk/aws-lambda": "1.147.0",
+        "@aws-cdk/core": "1.147.0",
+        "constructs": "^3.3.69"
+      }
+    },
+    "@aws-cdk/aws-logs": {
+      "version": "1.147.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-logs/-/aws-logs-1.147.0.tgz",
+      "integrity": "sha512-Rim34ijoHB+0KKdmURW3hqZj8GbgkUwxcU8MvlqAyFJtb2Ou0bq8F1drmEqC0OTV2cymlNLdFl6VqE8t0vkTMA==",
+      "dev": true,
+      "requires": {
+        "@aws-cdk/aws-cloudwatch": "1.147.0",
+        "@aws-cdk/aws-iam": "1.147.0",
+        "@aws-cdk/aws-kms": "1.147.0",
+        "@aws-cdk/aws-s3-assets": "1.147.0",
+        "@aws-cdk/core": "1.147.0",
+        "@aws-cdk/cx-api": "1.147.0",
+        "constructs": "^3.3.69"
+      }
+    },
+    "@aws-cdk/aws-s3": {
+      "version": "1.147.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-s3/-/aws-s3-1.147.0.tgz",
+      "integrity": "sha512-vkk8hy8Utpximxx5k7HXM+VBYa+63xIg1N669FZ7rKfVEZ/H3ZEezRzPG9b5pNDwk4w6nh0VfYB7Ckgj/+lKxw==",
+      "dev": true,
+      "requires": {
+        "@aws-cdk/aws-events": "1.147.0",
+        "@aws-cdk/aws-iam": "1.147.0",
+        "@aws-cdk/aws-kms": "1.147.0",
+        "@aws-cdk/core": "1.147.0",
+        "@aws-cdk/cx-api": "1.147.0",
+        "constructs": "^3.3.69"
+      }
+    },
+    "@aws-cdk/aws-s3-assets": {
+      "version": "1.147.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-s3-assets/-/aws-s3-assets-1.147.0.tgz",
+      "integrity": "sha512-7qRsjsqbLZKsGmwPzA3bMqnVd7bcKsOZEGSbl5UoY2U9UaMgOX5Lev53dDsh4qW9QSwXm0qBJTDeJwRrHfGaLQ==",
+      "dev": true,
+      "requires": {
+        "@aws-cdk/assets": "1.147.0",
+        "@aws-cdk/aws-iam": "1.147.0",
+        "@aws-cdk/aws-kms": "1.147.0",
+        "@aws-cdk/aws-s3": "1.147.0",
+        "@aws-cdk/core": "1.147.0",
+        "@aws-cdk/cx-api": "1.147.0",
+        "constructs": "^3.3.69"
+      }
+    },
+    "@aws-cdk/aws-signer": {
+      "version": "1.147.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-signer/-/aws-signer-1.147.0.tgz",
+      "integrity": "sha512-N42OxAqHXXNITurUBBddbWlzcr4PiXR7gM1gV9YvCI163eZUuKREuqtfhD8rmBAjMp6TJVDna3gAaySY+zNoBA==",
+      "dev": true,
+      "requires": {
+        "@aws-cdk/core": "1.147.0",
+        "constructs": "^3.3.69"
+      }
+    },
+    "@aws-cdk/aws-sns": {
+      "version": "1.147.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-sns/-/aws-sns-1.147.0.tgz",
+      "integrity": "sha512-j3eQetou0V/QRSvnP8G6zLryFN481BVEP4pkDjXmW4e/5tdHhj4Diy12SbrY8niwwzVj9gftsDmu9WEk+rAHQw==",
+      "dev": true,
+      "requires": {
+        "@aws-cdk/aws-cloudwatch": "1.147.0",
+        "@aws-cdk/aws-codestarnotifications": "1.147.0",
+        "@aws-cdk/aws-events": "1.147.0",
+        "@aws-cdk/aws-iam": "1.147.0",
+        "@aws-cdk/aws-kms": "1.147.0",
+        "@aws-cdk/aws-sqs": "1.147.0",
+        "@aws-cdk/core": "1.147.0",
+        "constructs": "^3.3.69"
+      }
+    },
+    "@aws-cdk/aws-sqs": {
+      "version": "1.147.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-sqs/-/aws-sqs-1.147.0.tgz",
+      "integrity": "sha512-76uRyNQJjTT8K82vgXfK4yCvFyt6YvKOVsSiOPtNK0ncu1dljgEIneIlP0pQIvyWODEV6Sgjh6z25yh6qP8KFw==",
+      "dev": true,
+      "requires": {
+        "@aws-cdk/aws-cloudwatch": "1.147.0",
+        "@aws-cdk/aws-iam": "1.147.0",
+        "@aws-cdk/aws-kms": "1.147.0",
+        "@aws-cdk/core": "1.147.0",
+        "constructs": "^3.3.69"
+      }
+    },
+    "@aws-cdk/aws-ssm": {
+      "version": "1.147.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ssm/-/aws-ssm-1.147.0.tgz",
+      "integrity": "sha512-/FHY5sIEQR+EO3CqZ9zA/7CnaGBcmSdsaXsj/sKgPkmUoV2WFFJYlHpfs9AacpNQw9v+zWiSdsn5rOK/UPJvGg==",
+      "dev": true,
+      "requires": {
+        "@aws-cdk/aws-iam": "1.147.0",
+        "@aws-cdk/aws-kms": "1.147.0",
+        "@aws-cdk/cloud-assembly-schema": "1.147.0",
+        "@aws-cdk/core": "1.147.0",
+        "constructs": "^3.3.69"
       }
     },
     "@aws-cdk/cfnspec": {
@@ -15888,7 +16264,8 @@
         "@aws-lambda-powertools/commons": "^0.7.2",
         "@aws-sdk/client-dynamodb": "^3.52.0",
         "@types/promise-retry": "^1.1.3",
-        "aws-xray-sdk-core": "^3.3.3",
+        "aws-xray-sdk-core": "^3.3.4",
+        "axios": "*",
         "promise-retry": "^2.0.1"
       }
     },
@@ -19655,6 +20032,15 @@
       "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
       "dev": true
     },
+    "axios": {
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+      "dev": true,
+      "requires": {
+        "follow-redirects": "^1.14.8"
+      }
+    },
     "babel-jest": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-27.5.1.tgz",
@@ -22378,6 +22764,12 @@
       "version": "3.2.5",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.5.tgz",
       "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
+      "dev": true
+    },
+    "follow-redirects": {
+      "version": "1.14.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
+      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==",
       "dev": true
     },
     "forever-agent": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -327,42 +327,42 @@
       }
     },
     "node_modules/@aws-sdk/client-dynamodb": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.55.0.tgz",
-      "integrity": "sha512-INXDvGzltlO91y/iqNIyPBI6kW1gYwZzHXUTBtDZO1hQCedukj/AXX3kIkksfd5XG96Sj8FTB+1u/bV74dfyVA==",
+      "version": "3.58.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.58.0.tgz",
+      "integrity": "sha512-54uclCvSVREutcty19NqfzC5V/0ebYSz51lz5jQpHYObP2uUAKOunTAWx1lnWACZ9U9Ka6SHWN/NhKFXeMKwgw==",
       "dev": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.55.0",
-        "@aws-sdk/config-resolver": "3.55.0",
-        "@aws-sdk/credential-provider-node": "3.55.0",
-        "@aws-sdk/fetch-http-handler": "3.55.0",
+        "@aws-sdk/client-sts": "3.58.0",
+        "@aws-sdk/config-resolver": "3.58.0",
+        "@aws-sdk/credential-provider-node": "3.58.0",
+        "@aws-sdk/fetch-http-handler": "3.58.0",
         "@aws-sdk/hash-node": "3.55.0",
         "@aws-sdk/invalid-dependency": "3.55.0",
-        "@aws-sdk/middleware-content-length": "3.55.0",
-        "@aws-sdk/middleware-endpoint-discovery": "3.55.0",
-        "@aws-sdk/middleware-host-header": "3.55.0",
+        "@aws-sdk/middleware-content-length": "3.58.0",
+        "@aws-sdk/middleware-endpoint-discovery": "3.58.0",
+        "@aws-sdk/middleware-host-header": "3.58.0",
         "@aws-sdk/middleware-logger": "3.55.0",
-        "@aws-sdk/middleware-retry": "3.55.0",
+        "@aws-sdk/middleware-retry": "3.58.0",
         "@aws-sdk/middleware-serde": "3.55.0",
-        "@aws-sdk/middleware-signing": "3.55.0",
+        "@aws-sdk/middleware-signing": "3.58.0",
         "@aws-sdk/middleware-stack": "3.55.0",
-        "@aws-sdk/middleware-user-agent": "3.55.0",
-        "@aws-sdk/node-config-provider": "3.55.0",
-        "@aws-sdk/node-http-handler": "3.55.0",
-        "@aws-sdk/protocol-http": "3.55.0",
+        "@aws-sdk/middleware-user-agent": "3.58.0",
+        "@aws-sdk/node-config-provider": "3.58.0",
+        "@aws-sdk/node-http-handler": "3.58.0",
+        "@aws-sdk/protocol-http": "3.58.0",
         "@aws-sdk/smithy-client": "3.55.0",
         "@aws-sdk/types": "3.55.0",
         "@aws-sdk/url-parser": "3.55.0",
-        "@aws-sdk/util-base64-browser": "3.55.0",
+        "@aws-sdk/util-base64-browser": "3.58.0",
         "@aws-sdk/util-base64-node": "3.55.0",
         "@aws-sdk/util-body-length-browser": "3.55.0",
         "@aws-sdk/util-body-length-node": "3.55.0",
         "@aws-sdk/util-defaults-mode-browser": "3.55.0",
-        "@aws-sdk/util-defaults-mode-node": "3.55.0",
-        "@aws-sdk/util-user-agent-browser": "3.55.0",
-        "@aws-sdk/util-user-agent-node": "3.55.0",
+        "@aws-sdk/util-defaults-mode-node": "3.58.0",
+        "@aws-sdk/util-user-agent-browser": "3.58.0",
+        "@aws-sdk/util-user-agent-node": "3.58.0",
         "@aws-sdk/util-utf8-browser": "3.55.0",
         "@aws-sdk/util-utf8-node": "3.55.0",
         "@aws-sdk/util-waiter": "3.55.0",
@@ -383,38 +383,38 @@
       }
     },
     "node_modules/@aws-sdk/client-sso": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.55.0.tgz",
-      "integrity": "sha512-bIGy2xkWZ00Vn5ByLIQamHVbzSE6Pbcs67873otNWtpkygfMzvQRFZ8RB6J+C6BuAwT3xTLI0aNi40RxxwM4HQ==",
+      "version": "3.58.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.58.0.tgz",
+      "integrity": "sha512-nS5G/OX8Bg4ajBa6+jLcbbr4PpEO+l5eJfGUzoJQwS4Zqa0lF/wC0kyjKm61gLp4JuvhrQskxIC/3IXUqB1XVQ==",
       "dev": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.55.0",
-        "@aws-sdk/fetch-http-handler": "3.55.0",
+        "@aws-sdk/config-resolver": "3.58.0",
+        "@aws-sdk/fetch-http-handler": "3.58.0",
         "@aws-sdk/hash-node": "3.55.0",
         "@aws-sdk/invalid-dependency": "3.55.0",
-        "@aws-sdk/middleware-content-length": "3.55.0",
-        "@aws-sdk/middleware-host-header": "3.55.0",
+        "@aws-sdk/middleware-content-length": "3.58.0",
+        "@aws-sdk/middleware-host-header": "3.58.0",
         "@aws-sdk/middleware-logger": "3.55.0",
-        "@aws-sdk/middleware-retry": "3.55.0",
+        "@aws-sdk/middleware-retry": "3.58.0",
         "@aws-sdk/middleware-serde": "3.55.0",
         "@aws-sdk/middleware-stack": "3.55.0",
-        "@aws-sdk/middleware-user-agent": "3.55.0",
-        "@aws-sdk/node-config-provider": "3.55.0",
-        "@aws-sdk/node-http-handler": "3.55.0",
-        "@aws-sdk/protocol-http": "3.55.0",
+        "@aws-sdk/middleware-user-agent": "3.58.0",
+        "@aws-sdk/node-config-provider": "3.58.0",
+        "@aws-sdk/node-http-handler": "3.58.0",
+        "@aws-sdk/protocol-http": "3.58.0",
         "@aws-sdk/smithy-client": "3.55.0",
         "@aws-sdk/types": "3.55.0",
         "@aws-sdk/url-parser": "3.55.0",
-        "@aws-sdk/util-base64-browser": "3.55.0",
+        "@aws-sdk/util-base64-browser": "3.58.0",
         "@aws-sdk/util-base64-node": "3.55.0",
         "@aws-sdk/util-body-length-browser": "3.55.0",
         "@aws-sdk/util-body-length-node": "3.55.0",
         "@aws-sdk/util-defaults-mode-browser": "3.55.0",
-        "@aws-sdk/util-defaults-mode-node": "3.55.0",
-        "@aws-sdk/util-user-agent-browser": "3.55.0",
-        "@aws-sdk/util-user-agent-node": "3.55.0",
+        "@aws-sdk/util-defaults-mode-node": "3.58.0",
+        "@aws-sdk/util-user-agent-browser": "3.58.0",
+        "@aws-sdk/util-user-agent-node": "3.58.0",
         "@aws-sdk/util-utf8-browser": "3.55.0",
         "@aws-sdk/util-utf8-node": "3.55.0",
         "tslib": "^2.3.1"
@@ -424,41 +424,41 @@
       }
     },
     "node_modules/@aws-sdk/client-sts": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.55.0.tgz",
-      "integrity": "sha512-/xmx0bxvhL9ffQ7A263MyTAfC6G0cyy/FwTmTWTt2xoKCNub7sGrPCJOjZB5fvmy9FpUvFUOJw1DnCghANKxzw==",
+      "version": "3.58.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.58.0.tgz",
+      "integrity": "sha512-2cHZsG2eXv/Zl0hvsG9+rdHEuAclMFfkma/3LC3RRwSuZXo1rXoIhFkzHfGfIbivdk738YAo7FT3ZYGlrsK4ow==",
       "dev": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.55.0",
-        "@aws-sdk/credential-provider-node": "3.55.0",
-        "@aws-sdk/fetch-http-handler": "3.55.0",
+        "@aws-sdk/config-resolver": "3.58.0",
+        "@aws-sdk/credential-provider-node": "3.58.0",
+        "@aws-sdk/fetch-http-handler": "3.58.0",
         "@aws-sdk/hash-node": "3.55.0",
         "@aws-sdk/invalid-dependency": "3.55.0",
-        "@aws-sdk/middleware-content-length": "3.55.0",
-        "@aws-sdk/middleware-host-header": "3.55.0",
+        "@aws-sdk/middleware-content-length": "3.58.0",
+        "@aws-sdk/middleware-host-header": "3.58.0",
         "@aws-sdk/middleware-logger": "3.55.0",
-        "@aws-sdk/middleware-retry": "3.55.0",
-        "@aws-sdk/middleware-sdk-sts": "3.55.0",
+        "@aws-sdk/middleware-retry": "3.58.0",
+        "@aws-sdk/middleware-sdk-sts": "3.58.0",
         "@aws-sdk/middleware-serde": "3.55.0",
-        "@aws-sdk/middleware-signing": "3.55.0",
+        "@aws-sdk/middleware-signing": "3.58.0",
         "@aws-sdk/middleware-stack": "3.55.0",
-        "@aws-sdk/middleware-user-agent": "3.55.0",
-        "@aws-sdk/node-config-provider": "3.55.0",
-        "@aws-sdk/node-http-handler": "3.55.0",
-        "@aws-sdk/protocol-http": "3.55.0",
+        "@aws-sdk/middleware-user-agent": "3.58.0",
+        "@aws-sdk/node-config-provider": "3.58.0",
+        "@aws-sdk/node-http-handler": "3.58.0",
+        "@aws-sdk/protocol-http": "3.58.0",
         "@aws-sdk/smithy-client": "3.55.0",
         "@aws-sdk/types": "3.55.0",
         "@aws-sdk/url-parser": "3.55.0",
-        "@aws-sdk/util-base64-browser": "3.55.0",
+        "@aws-sdk/util-base64-browser": "3.58.0",
         "@aws-sdk/util-base64-node": "3.55.0",
         "@aws-sdk/util-body-length-browser": "3.55.0",
         "@aws-sdk/util-body-length-node": "3.55.0",
         "@aws-sdk/util-defaults-mode-browser": "3.55.0",
-        "@aws-sdk/util-defaults-mode-node": "3.55.0",
-        "@aws-sdk/util-user-agent-browser": "3.55.0",
-        "@aws-sdk/util-user-agent-node": "3.55.0",
+        "@aws-sdk/util-defaults-mode-node": "3.58.0",
+        "@aws-sdk/util-user-agent-browser": "3.58.0",
+        "@aws-sdk/util-user-agent-node": "3.58.0",
         "@aws-sdk/util-utf8-browser": "3.55.0",
         "@aws-sdk/util-utf8-node": "3.55.0",
         "entities": "2.2.0",
@@ -470,14 +470,15 @@
       }
     },
     "node_modules/@aws-sdk/config-resolver": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.55.0.tgz",
-      "integrity": "sha512-dW+UcGu6f+RA1ZsiSpdWUrWwrhevXZeeBtr08X83TP7dK8S6HHv5upX+4es1xou6aMqqin+yHZUVmabvAe/gpg==",
+      "version": "3.58.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.58.0.tgz",
+      "integrity": "sha512-NXEwYw0JrXcvenu42QpNMQXK+6pgZ+6bDGfCgOfCC0FmyI+w/CuF36lApwm7InHvHazOaDlwArXm2pfntErKoA==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/signature-v4": "3.55.0",
+        "@aws-sdk/signature-v4": "3.58.0",
         "@aws-sdk/types": "3.55.0",
         "@aws-sdk/util-config-provider": "3.55.0",
+        "@aws-sdk/util-middleware": "3.55.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -499,12 +500,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-imds": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.55.0.tgz",
-      "integrity": "sha512-aBOQomxYwNHQSHuOetrER1r13x3tJWNd9Eho2OcGLRioNS6/on2T5ptQI5/pJvAqOWe7LG65k1g3eTf1T8Nf1Q==",
+      "version": "3.58.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.58.0.tgz",
+      "integrity": "sha512-CdtnTQ9zqLx1FbXdbgjijLbMcIWOyQM03TFaLSCjI3FNbUwyt3T7StBU9tj/LtbypHhSdXyQBpzUtXTOMWCEhg==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/node-config-provider": "3.55.0",
+        "@aws-sdk/node-config-provider": "3.58.0",
         "@aws-sdk/property-provider": "3.55.0",
         "@aws-sdk/types": "3.55.0",
         "@aws-sdk/url-parser": "3.55.0",
@@ -515,17 +516,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.55.0.tgz",
-      "integrity": "sha512-f4+8mqJ1xapF9SR90VC+Ho4zlnLPdCgAAm9f7Pauf1/beAk5bkmfLshLwQ5Jo4oEPbWLn1Sdk403kwnxpsnksg==",
+      "version": "3.58.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.58.0.tgz",
+      "integrity": "sha512-uM62hcHUVaHP1YFnbrjf2RlrRj1m/BvMPE+T5jdNRWdE3lvnunhEMawB26HZs9nQqCV6d25I8G9/fGWVL7g3Og==",
       "dev": true,
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.55.0",
-        "@aws-sdk/credential-provider-imds": "3.55.0",
-        "@aws-sdk/credential-provider-sso": "3.55.0",
+        "@aws-sdk/credential-provider-imds": "3.58.0",
+        "@aws-sdk/credential-provider-sso": "3.58.0",
         "@aws-sdk/credential-provider-web-identity": "3.55.0",
         "@aws-sdk/property-provider": "3.55.0",
-        "@aws-sdk/shared-ini-file-loader": "3.55.0",
+        "@aws-sdk/shared-ini-file-loader": "3.58.0",
         "@aws-sdk/types": "3.55.0",
         "tslib": "^2.3.1"
       },
@@ -534,19 +535,19 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.55.0.tgz",
-      "integrity": "sha512-cDAk2+29sZyluk3D2vomCJd0adJxjun9yVdyAiuoutxx9LZ1KQgsDEVHDbPQFpmeOBBagtMNpHNVtUunQ3yy1w==",
+      "version": "3.58.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.58.0.tgz",
+      "integrity": "sha512-f0wzcgMYCQUrii6TLP2ggCxkQP4HH8PW8tbbWEgt4cdIXcjE9KEuxN5yOV6sFHzL3eJh0QM9Yaz8WzhWn6fT2A==",
       "dev": true,
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.55.0",
-        "@aws-sdk/credential-provider-imds": "3.55.0",
-        "@aws-sdk/credential-provider-ini": "3.55.0",
-        "@aws-sdk/credential-provider-process": "3.55.0",
-        "@aws-sdk/credential-provider-sso": "3.55.0",
+        "@aws-sdk/credential-provider-imds": "3.58.0",
+        "@aws-sdk/credential-provider-ini": "3.58.0",
+        "@aws-sdk/credential-provider-process": "3.58.0",
+        "@aws-sdk/credential-provider-sso": "3.58.0",
         "@aws-sdk/credential-provider-web-identity": "3.55.0",
         "@aws-sdk/property-provider": "3.55.0",
-        "@aws-sdk/shared-ini-file-loader": "3.55.0",
+        "@aws-sdk/shared-ini-file-loader": "3.58.0",
         "@aws-sdk/types": "3.55.0",
         "tslib": "^2.3.1"
       },
@@ -555,13 +556,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.55.0.tgz",
-      "integrity": "sha512-09AGJ6bdonXpV/dyHzrQqcbo2oy3aDxjcq+/LGo4GuB0ZHD2TJqKpExU7ie0rg/5OdBnTX6c+9JyjeFt03uX7w==",
+      "version": "3.58.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.58.0.tgz",
+      "integrity": "sha512-npgFqPUjMhUamf1FvJjBYUdpbWx8XWkKCwJsX73I7IYQAvAi2atCOkdtKq+4rds0VWAYu6vzlaI1tXgFxjOPNQ==",
       "dev": true,
       "dependencies": {
         "@aws-sdk/property-provider": "3.55.0",
-        "@aws-sdk/shared-ini-file-loader": "3.55.0",
+        "@aws-sdk/shared-ini-file-loader": "3.58.0",
         "@aws-sdk/types": "3.55.0",
         "tslib": "^2.3.1"
       },
@@ -570,14 +571,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.55.0.tgz",
-      "integrity": "sha512-hKWbZMDY5nZMsOKMVkeUrKCdHaemMhyAH4WfApq976DDJt6bm6U+jvkTspO8qQaIPD8xdRqyi5AMLvVcHjBbTg==",
+      "version": "3.58.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.58.0.tgz",
+      "integrity": "sha512-2qO34s9lJqvCC6zOF4UpopW6xURZpYfVC8xTUDpAUnvTOt4nS5hkx4vNyqPAXILoRHuFJsnlWsBH1UP5ZnBiZg==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/client-sso": "3.55.0",
+        "@aws-sdk/client-sso": "3.58.0",
         "@aws-sdk/property-provider": "3.55.0",
-        "@aws-sdk/shared-ini-file-loader": "3.55.0",
+        "@aws-sdk/shared-ini-file-loader": "3.58.0",
         "@aws-sdk/types": "3.55.0",
         "tslib": "^2.3.1"
       },
@@ -613,15 +614,15 @@
       }
     },
     "node_modules/@aws-sdk/fetch-http-handler": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.55.0.tgz",
-      "integrity": "sha512-/Sta3MLlszpRZ1pg+ClxfNqGvraX93F587eHrfQMaGXgQ2BqJLiAVRorBRGcmmmrHxfLOqspNqufF7ibrqziRQ==",
+      "version": "3.58.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.58.0.tgz",
+      "integrity": "sha512-timF3FjPV5Bd+Kgph83LIKVlPCFObVYzious1a6doeLAT6YFwZpRrWbfP/HzS+DCoYiwUsH69oVJ91BoV66oyA==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.55.0",
+        "@aws-sdk/protocol-http": "3.58.0",
         "@aws-sdk/querystring-builder": "3.55.0",
         "@aws-sdk/types": "3.55.0",
-        "@aws-sdk/util-base64-browser": "3.55.0",
+        "@aws-sdk/util-base64-browser": "3.58.0",
         "tslib": "^2.3.1"
       }
     },
@@ -662,12 +663,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-content-length": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.55.0.tgz",
-      "integrity": "sha512-IkFBwa1G5ERfKFh4Kdtcn/aNAGi3Hcp9IO1PVt69LZWaevxjXAi5NS2k65E9mZPEumzuLtcEeC+3qhPs4FUkqQ==",
+      "version": "3.58.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.58.0.tgz",
+      "integrity": "sha512-h/BypPkhjv2CpCUbXA8Fa2s7V2GPiz9l11XhYK+sKSuQvQ7Lbq6VhaKaLqfeD3gLVZHgJZSLGl2btdHV1qHNNA==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.55.0",
+        "@aws-sdk/protocol-http": "3.58.0",
         "@aws-sdk/types": "3.55.0",
         "tslib": "^2.3.1"
       },
@@ -676,14 +677,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-endpoint-discovery": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.55.0.tgz",
-      "integrity": "sha512-lVQLFQ9I3CCLNlx6lhH6rzodAJgM+rwXEbcn5UB1xSg1cmPd10hD1tvRHndDlHdrRF2ql6zk3LGq4JwB8IjNYw==",
+      "version": "3.58.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.58.0.tgz",
+      "integrity": "sha512-Ll42zMPP8dDTHesv5VdnM0vgT4mW+kR2SgXCWBMuwnZdBn0FDH1A3E0BqJkLuuq2TKIah0/l1sA1qVC68GkAeA==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/config-resolver": "3.55.0",
+        "@aws-sdk/config-resolver": "3.58.0",
         "@aws-sdk/endpoint-cache": "3.55.0",
-        "@aws-sdk/protocol-http": "3.55.0",
+        "@aws-sdk/protocol-http": "3.58.0",
         "@aws-sdk/types": "3.55.0",
         "tslib": "^2.3.1"
       },
@@ -692,12 +693,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.55.0.tgz",
-      "integrity": "sha512-69mTWJfuPP4aC+h2/cb9B2CUNA9tiRPUBp67dmMrA2dHyy53kNYo8TGgfLKProoBidBz/AVXIfnh+izJj0F20w==",
+      "version": "3.58.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.58.0.tgz",
+      "integrity": "sha512-q/UKGcanm9e6DBRNN6UKhVqLvpRRdZWbmmPCeDNr4HqhCmgT6i1OvWdhAMOnT++hvCX8DpTsIXzNSlY6zWAxBg==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.55.0",
+        "@aws-sdk/protocol-http": "3.58.0",
         "@aws-sdk/types": "3.55.0",
         "tslib": "^2.3.1"
       },
@@ -719,14 +720,15 @@
       }
     },
     "node_modules/@aws-sdk/middleware-retry": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.55.0.tgz",
-      "integrity": "sha512-Z0j4/zyvgp8Y7HYud1MCqheg9koVh7p1ekS8lm6GePZBWILXsFib8PK9eq7B16u2z7yyz2tHrzwQrHRRr0cQKQ==",
+      "version": "3.58.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.58.0.tgz",
+      "integrity": "sha512-sfSq+t0Yy47DQwrWGpA8iOx9sd26l4l1JDVTwHNi7+OKD4ClRPVCEdw3bTbbyYz/PV4f9AEfAZ6jwtSff4wkGw==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.55.0",
+        "@aws-sdk/protocol-http": "3.58.0",
         "@aws-sdk/service-error-classification": "3.55.0",
         "@aws-sdk/types": "3.55.0",
+        "@aws-sdk/util-middleware": "3.55.0",
         "tslib": "^2.3.1",
         "uuid": "^8.3.2"
       },
@@ -744,15 +746,15 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-sts": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.55.0.tgz",
-      "integrity": "sha512-BrK3UXmD08rGbhY6cAHXsQxDfflOrPbKe4gxymlckd9sGIPC42O1KfJQ0CaxWPvG1Gd3R/QFfoPFClpTDhdh0Q==",
+      "version": "3.58.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.58.0.tgz",
+      "integrity": "sha512-HUz7MhcsSDDTGygOwL61l4voc0pZco06J3z06JjTX19D5XxcQ7hSCtkHHHz0oMb9M1himVSiEon2tjhjsnB99g==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/middleware-signing": "3.55.0",
+        "@aws-sdk/middleware-signing": "3.58.0",
         "@aws-sdk/property-provider": "3.55.0",
-        "@aws-sdk/protocol-http": "3.55.0",
-        "@aws-sdk/signature-v4": "3.55.0",
+        "@aws-sdk/protocol-http": "3.58.0",
+        "@aws-sdk/signature-v4": "3.58.0",
         "@aws-sdk/types": "3.55.0",
         "tslib": "^2.3.1"
       },
@@ -774,14 +776,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-signing": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.55.0.tgz",
-      "integrity": "sha512-FUVrFv6zfHkX1gjwOvam4VneGJL9L/1can5HoNKAsxYwGUMVCrMEmyfkGWBy+paMe0dQ3bF4VVZjJHEvzJaQLQ==",
+      "version": "3.58.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.58.0.tgz",
+      "integrity": "sha512-4FXubHB66GbhyZUlo6YPQoWpYfED15GNbEmHbJLSONzrVzZR3IkViSPLasDngVm1a050JqKuqNkFYGJBP4No/Q==",
       "dev": true,
       "dependencies": {
         "@aws-sdk/property-provider": "3.55.0",
-        "@aws-sdk/protocol-http": "3.55.0",
-        "@aws-sdk/signature-v4": "3.55.0",
+        "@aws-sdk/protocol-http": "3.58.0",
+        "@aws-sdk/signature-v4": "3.58.0",
         "@aws-sdk/types": "3.55.0",
         "tslib": "^2.3.1"
       },
@@ -802,12 +804,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.55.0.tgz",
-      "integrity": "sha512-UOBimkQrj6onXb3Fyuao85IjipnDSowNHfOOl3ADVX9boA/A4db5QAXBSxThV0WHLArC0iiUsnwu95ElSSMVIg==",
+      "version": "3.58.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.58.0.tgz",
+      "integrity": "sha512-1c69bIWM63JwXijXvb9IWwcwQ/gViKMZ1lhxv52NvdG5VSxWXXsFJ2jETEXZoAypwT97Hmf3xo9SYuaHcKoq+g==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.55.0",
+        "@aws-sdk/protocol-http": "3.58.0",
         "@aws-sdk/types": "3.55.0",
         "tslib": "^2.3.1"
       },
@@ -816,13 +818,13 @@
       }
     },
     "node_modules/@aws-sdk/node-config-provider": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.55.0.tgz",
-      "integrity": "sha512-+qpAEWiRXCuY85+VkJWbe+4MfQjlq6Nzi4a+3OejyqTRYMkslK93tR7SejdCiyq1lWpqtbwI9DsjDO45/2P6LA==",
+      "version": "3.58.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.58.0.tgz",
+      "integrity": "sha512-AMcPqPhKxo/3/yOMS9PsKlI0GWp2/8eD6gSlhzdBpznPCKplyqXOSnSX7wS814Cyh373hFSjCaOrCOA9/EYtDg==",
       "dev": true,
       "dependencies": {
         "@aws-sdk/property-provider": "3.55.0",
-        "@aws-sdk/shared-ini-file-loader": "3.55.0",
+        "@aws-sdk/shared-ini-file-loader": "3.58.0",
         "@aws-sdk/types": "3.55.0",
         "tslib": "^2.3.1"
       },
@@ -831,13 +833,13 @@
       }
     },
     "node_modules/@aws-sdk/node-http-handler": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.55.0.tgz",
-      "integrity": "sha512-yF4YQr72YgVgWO9IDOhDcncqlKUJmMCtserAYhKNvmkVuaMGHE11p+IByWgcIsMJTvtFaFBhTA3W7zhJB1C1xA==",
+      "version": "3.58.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.58.0.tgz",
+      "integrity": "sha512-D9xVZG2nfo4GbPsby3JuBiAhpqXTFk1+CfuQU0AZv0gQvE3fFTCnB3za83jo7JV/pyRPU+s+/LHIpxCWUHzStg==",
       "dev": true,
       "dependencies": {
         "@aws-sdk/abort-controller": "3.55.0",
-        "@aws-sdk/protocol-http": "3.55.0",
+        "@aws-sdk/protocol-http": "3.58.0",
         "@aws-sdk/querystring-builder": "3.55.0",
         "@aws-sdk/types": "3.55.0",
         "tslib": "^2.3.1"
@@ -860,9 +862,9 @@
       }
     },
     "node_modules/@aws-sdk/protocol-http": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.55.0.tgz",
-      "integrity": "sha512-vNjjsP5bFuKQMhmuBQZDddH441xanPbm8n42qgfigv0RzgWQhvUFrnmZWLBdyY8geY0RwsQ6x9yfQ0gvs48tpw==",
+      "version": "3.58.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.58.0.tgz",
+      "integrity": "sha512-0yFFRPbR+CCa9eOQBBQ2qtrIDLYqSMN0y7G4iqVM8wQdIw7n3QK1PsTI3RNPGJ3Oi2krFTw5uUKqQQZPZEBuVQ==",
       "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.55.0",
@@ -908,9 +910,9 @@
       }
     },
     "node_modules/@aws-sdk/shared-ini-file-loader": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.55.0.tgz",
-      "integrity": "sha512-utmqVMvif8MjSr27HwPDZGCfJGCI4LoFkm4oyjonyu15aTfULm60mX6RTXftaQ2Syf7dnZ2U4kbp3xgzA5ZIgg==",
+      "version": "3.58.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.58.0.tgz",
+      "integrity": "sha512-ARDKQerIzgNs/MFNdCEuK2lgRJ1lneAaJw0p9O1LkJUvcSibvkSATwny7vwJMueOf+ae1Pf+8+54OMNIt0nTkQ==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.1"
@@ -920,14 +922,15 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.55.0.tgz",
-      "integrity": "sha512-ryJ43HSIVq7wt+QDBlb5CFH/rrH0+LtgnLDU+FM1XAQkT+oo3V9Hzr7rFmnFSfZqr/8hAn/4xUGTaJKZgO57NQ==",
+      "version": "3.58.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.58.0.tgz",
+      "integrity": "sha512-flEo8p3XkzWoBDqnIUQre4jLuT5aLnmfQNI8c2uSjyJ3OBxpJ0iS1cDu3E++d1/pN6Q8o0KOmr2ypHeiyBOujw==",
       "dev": true,
       "dependencies": {
         "@aws-sdk/is-array-buffer": "3.55.0",
         "@aws-sdk/types": "3.55.0",
-        "@aws-sdk/util-hex-encoding": "3.55.0",
+        "@aws-sdk/util-hex-encoding": "3.58.0",
+        "@aws-sdk/util-middleware": "3.55.0",
         "@aws-sdk/util-uri-escape": "3.55.0",
         "tslib": "^2.3.1"
       },
@@ -969,9 +972,9 @@
       }
     },
     "node_modules/@aws-sdk/util-base64-browser": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.55.0.tgz",
-      "integrity": "sha512-3hrZ2R/ZyD3IM25KhETOGLC5tB/ft8zoyVmNg1l4+takoUm46ompnglFXCVkWBu9Hpxc+M4XtiY7MHE6es4Wtg==",
+      "version": "3.58.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.58.0.tgz",
+      "integrity": "sha512-0ebsXIZNpu/fup9OgsFPnRKfCFbuuI9PPRzvP6twzLxUB0c/aix6Co7LGHFKcRKHZdaykoJMXArf8eHj2Nzv1Q==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.1"
@@ -1052,14 +1055,14 @@
       }
     },
     "node_modules/@aws-sdk/util-defaults-mode-node": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.55.0.tgz",
-      "integrity": "sha512-uIVZ7SVBUrkSH1lqhmvvb0Sc1aecPydGH4ex2qA4Vrp+Xp0h4pzjRELdVEOFbAFMB1uHXzgMV6jLjADGZPrHrQ==",
+      "version": "3.58.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.58.0.tgz",
+      "integrity": "sha512-KNUCp0MXI+z3Z3pQCKDkx3Stdy1TXDjcUB+ZJFxRTJGIuBYwX4fV6G8s/zeFJi5Qv1ztR3CJ9fWJGsrx9mQ5EA==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/config-resolver": "3.55.0",
-        "@aws-sdk/credential-provider-imds": "3.55.0",
-        "@aws-sdk/node-config-provider": "3.55.0",
+        "@aws-sdk/config-resolver": "3.58.0",
+        "@aws-sdk/credential-provider-imds": "3.58.0",
+        "@aws-sdk/node-config-provider": "3.58.0",
         "@aws-sdk/property-provider": "3.55.0",
         "@aws-sdk/types": "3.55.0",
         "tslib": "^2.3.1"
@@ -1069,9 +1072,9 @@
       }
     },
     "node_modules/@aws-sdk/util-hex-encoding": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.55.0.tgz",
-      "integrity": "sha512-zbDWNzIyqN2Po7SIo1ZDL4rQMP3R0TzGcCrm01bpQAb+2fWqUPigolvNZXXtMO6eS7EW3ZJJzkfoWHdH8zDz1A==",
+      "version": "3.58.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.58.0.tgz",
+      "integrity": "sha512-Rl+jXUzk/FJkOLYfUVYPhKa2aUmTpeobRP31l8IatQltSzDgLyRHO35f6UEs7Ztn5s1jbu/POatLAZ2WjbgVyg==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.1"
@@ -1084,6 +1087,18 @@
       "version": "3.55.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.55.0.tgz",
       "integrity": "sha512-0sPmK2JaJE2BbTcnvybzob/VrFKCXKfN4CUKcvn0yGg/me7Bz+vtzQRB3Xp+YSx+7OtWxzv63wsvHoAnXvgxgg==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-middleware": {
+      "version": "3.55.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.55.0.tgz",
+      "integrity": "sha512-82fW2XV+rUalv8lkd4VlhpPp6xnXO5n9sckMp1N+TrQ+p8eqxqT0+o8n1/6s9Qsnkw64Y3m6+EfCdc8/uFOY2g==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.1"
@@ -1105,9 +1120,9 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.55.0.tgz",
-      "integrity": "sha512-E+8PluqbdOKfdJc9E4k0vy4PPb9wvAMa2Zdm5ycoaY0IXRI9RjQJnRw5JKAAJWLuOy7Lb83LgoowGW3o+4AuKw==",
+      "version": "3.58.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.58.0.tgz",
+      "integrity": "sha512-aJpqCvT09giJRg5xFTBDBRAVF0k0yq3OEf6UTuiOVf5azlL2MGp6PJ/xkJp9Z06PuQQkwBJ/2nIQZemo02a5Sw==",
       "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.55.0",
@@ -1116,12 +1131,12 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.55.0.tgz",
-      "integrity": "sha512-7aoolXzpnTcvIGkxY8v8AZR5ooH7c0wttEjQNkOfORQprznNuj5RUZPxq8oStpFSvwASZJPpfd2Y18G2jPthMw==",
+      "version": "3.58.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.58.0.tgz",
+      "integrity": "sha512-VlbY/nzWdN2pfLUHqKvnlGBQ6tEeV4jyK9ggAD2Szjj0bkYvaaKwpBKswQmuJpi5/J2v7Bo4ayBLnqDL7PgzLA==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/node-config-provider": "3.55.0",
+        "@aws-sdk/node-config-provider": "3.58.0",
         "@aws-sdk/types": "3.55.0",
         "tslib": "^2.3.1"
       },
@@ -15671,7 +15686,7 @@
         "aws-xray-sdk-core": "^3.3.4"
       },
       "devDependencies": {
-        "@aws-sdk/client-dynamodb": "^3.52.0",
+        "@aws-sdk/client-dynamodb": "^3.58.0",
         "@types/promise-retry": "^1.1.3",
         "axios": "^0.26.1",
         "promise-retry": "^2.0.1"
@@ -15686,352 +15701,6 @@
       "dev": true,
       "requires": {
         "@jridgewell/trace-mapping": "^0.3.0"
-      }
-    },
-    "@aws-cdk/assets": {
-      "version": "1.147.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/assets/-/assets-1.147.0.tgz",
-      "integrity": "sha512-Fz5PB/cXPCeQUk0eNPQkYzzSG7encauGLT7Hm/egIavP6EKwGYxxkmy90SOHSOYg3FXjZxi5+evbyhL+2NAgRw==",
-      "dev": true,
-      "requires": {
-        "@aws-cdk/core": "1.147.0",
-        "@aws-cdk/cx-api": "1.147.0",
-        "constructs": "^3.3.69"
-      }
-    },
-    "@aws-cdk/aws-applicationautoscaling": {
-      "version": "1.147.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-applicationautoscaling/-/aws-applicationautoscaling-1.147.0.tgz",
-      "integrity": "sha512-pplTpCdgP9EjjSCsoFW9vjTp2XywDb22pTX/LRuc0dt5DDFmWxeKJyGpBkdcMDtrc8F4zrBV+T3qFy6pLzKJkA==",
-      "dev": true,
-      "requires": {
-        "@aws-cdk/aws-autoscaling-common": "1.147.0",
-        "@aws-cdk/aws-cloudwatch": "1.147.0",
-        "@aws-cdk/aws-iam": "1.147.0",
-        "@aws-cdk/core": "1.147.0",
-        "constructs": "^3.3.69"
-      }
-    },
-    "@aws-cdk/aws-autoscaling-common": {
-      "version": "1.147.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-autoscaling-common/-/aws-autoscaling-common-1.147.0.tgz",
-      "integrity": "sha512-NyzmbXP51rbK0/UPt6jy5BQqAfZrShABwMLPEhqeLRCkQqMmA2QkmkGebbTLWoCC1Kg5APsyx0Dm1/Wi1DNcCA==",
-      "dev": true,
-      "requires": {
-        "@aws-cdk/aws-iam": "1.147.0",
-        "@aws-cdk/core": "1.147.0",
-        "constructs": "^3.3.69"
-      }
-    },
-    "@aws-cdk/aws-cloudformation": {
-      "version": "1.147.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudformation/-/aws-cloudformation-1.147.0.tgz",
-      "integrity": "sha512-3qmi6RLY+y2GslTeyCQaIGOPs50PLsDLVkV5Lwo+S9ihGPmMWYvt3+kIlIFYSBpaoLR8eKqTmuvQG5ruq2Y9pA==",
-      "dev": true,
-      "requires": {
-        "@aws-cdk/aws-iam": "1.147.0",
-        "@aws-cdk/aws-lambda": "1.147.0",
-        "@aws-cdk/aws-s3": "1.147.0",
-        "@aws-cdk/aws-sns": "1.147.0",
-        "@aws-cdk/core": "1.147.0",
-        "@aws-cdk/cx-api": "1.147.0",
-        "constructs": "^3.3.69"
-      }
-    },
-    "@aws-cdk/aws-cloudwatch": {
-      "version": "1.147.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudwatch/-/aws-cloudwatch-1.147.0.tgz",
-      "integrity": "sha512-wyGbnzzCfULzOwNiqSPrDZPigy6svOcnZwUheu6dmzL7qxo1UHVj2hVCjTLbN7AtBx9WG3Rs70C6+WTqXQnYmQ==",
-      "dev": true,
-      "requires": {
-        "@aws-cdk/aws-iam": "1.147.0",
-        "@aws-cdk/core": "1.147.0",
-        "constructs": "^3.3.69"
-      }
-    },
-    "@aws-cdk/aws-codeguruprofiler": {
-      "version": "1.147.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-codeguruprofiler/-/aws-codeguruprofiler-1.147.0.tgz",
-      "integrity": "sha512-ykEENwhVKCI7WNIm2AjmiT2r+FxpNjt4tXdzWYEviJUr4h4LWnae7IHgfVPDeUXYZaEXnaajvAxXMkTROUJxAA==",
-      "dev": true,
-      "requires": {
-        "@aws-cdk/aws-iam": "1.147.0",
-        "@aws-cdk/core": "1.147.0",
-        "constructs": "^3.3.69"
-      }
-    },
-    "@aws-cdk/aws-codestarnotifications": {
-      "version": "1.147.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-codestarnotifications/-/aws-codestarnotifications-1.147.0.tgz",
-      "integrity": "sha512-+WOLDECaq7+fI5gIUJCi+svfHMC8+mfpL8hrV0a0rubTV3mHFoHv/vcdwYK5lW8X4PgfdWKbGUeBHoVweuIVBA==",
-      "dev": true,
-      "requires": {
-        "@aws-cdk/core": "1.147.0",
-        "constructs": "^3.3.69"
-      }
-    },
-    "@aws-cdk/aws-dynamodb": {
-      "version": "1.147.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-dynamodb/-/aws-dynamodb-1.147.0.tgz",
-      "integrity": "sha512-+uae79csAi8Gt+2o5PLSLSkgx3jo1bUHsnEmNUip/sDEaHGP+bhoZAmOMj38mZwiN6Tj91uibEKU9MMquvDGYQ==",
-      "dev": true,
-      "requires": {
-        "@aws-cdk/aws-applicationautoscaling": "1.147.0",
-        "@aws-cdk/aws-cloudwatch": "1.147.0",
-        "@aws-cdk/aws-iam": "1.147.0",
-        "@aws-cdk/aws-kinesis": "1.147.0",
-        "@aws-cdk/aws-kms": "1.147.0",
-        "@aws-cdk/aws-lambda": "1.147.0",
-        "@aws-cdk/core": "1.147.0",
-        "@aws-cdk/custom-resources": "1.147.0",
-        "constructs": "^3.3.69"
-      }
-    },
-    "@aws-cdk/aws-ec2": {
-      "version": "1.147.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ec2/-/aws-ec2-1.147.0.tgz",
-      "integrity": "sha512-rTb3BDrkog388k+OJnYWBltbjAfH8f7+NuXdlaxXyWCzl3yWqzHfEYVGUUQ6WpWZd7MiogOpL5JUY4e+Ch+SXw==",
-      "dev": true,
-      "requires": {
-        "@aws-cdk/aws-cloudwatch": "1.147.0",
-        "@aws-cdk/aws-iam": "1.147.0",
-        "@aws-cdk/aws-kms": "1.147.0",
-        "@aws-cdk/aws-logs": "1.147.0",
-        "@aws-cdk/aws-s3": "1.147.0",
-        "@aws-cdk/aws-s3-assets": "1.147.0",
-        "@aws-cdk/aws-ssm": "1.147.0",
-        "@aws-cdk/cloud-assembly-schema": "1.147.0",
-        "@aws-cdk/core": "1.147.0",
-        "@aws-cdk/cx-api": "1.147.0",
-        "@aws-cdk/region-info": "1.147.0",
-        "constructs": "^3.3.69"
-      }
-    },
-    "@aws-cdk/aws-ecr": {
-      "version": "1.147.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ecr/-/aws-ecr-1.147.0.tgz",
-      "integrity": "sha512-vwcupBCw3hoCS8tjoJHiYsFJ2cVeCr/4a/l2q12xZH0oyf9qMZye0cfIdZqIwRVABVgnbrcAH9eZZf8mvCb1vQ==",
-      "dev": true,
-      "requires": {
-        "@aws-cdk/aws-events": "1.147.0",
-        "@aws-cdk/aws-iam": "1.147.0",
-        "@aws-cdk/aws-kms": "1.147.0",
-        "@aws-cdk/core": "1.147.0",
-        "constructs": "^3.3.69"
-      }
-    },
-    "@aws-cdk/aws-ecr-assets": {
-      "version": "1.147.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ecr-assets/-/aws-ecr-assets-1.147.0.tgz",
-      "integrity": "sha512-04CpHNgBZ6el8Z9cH06kRyqK7QyazlF0AJVi2yIs1Xcg7gt4zh/P0mUneEW3o7Wy4NQeOQYmKC7IoPht6qfB+A==",
-      "dev": true,
-      "requires": {
-        "@aws-cdk/assets": "1.147.0",
-        "@aws-cdk/aws-ecr": "1.147.0",
-        "@aws-cdk/aws-iam": "1.147.0",
-        "@aws-cdk/aws-s3": "1.147.0",
-        "@aws-cdk/core": "1.147.0",
-        "@aws-cdk/cx-api": "1.147.0",
-        "constructs": "^3.3.69"
-      }
-    },
-    "@aws-cdk/aws-efs": {
-      "version": "1.147.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-efs/-/aws-efs-1.147.0.tgz",
-      "integrity": "sha512-gAi9vUBrvGOdLNqP7ORlgsIn4ZhLJQW1bK8vYrYpSMLDcTUf2kyo/xVoLMSm3YQ7UG75CrRqaKpSTBKhgMkRYg==",
-      "dev": true,
-      "requires": {
-        "@aws-cdk/aws-ec2": "1.147.0",
-        "@aws-cdk/aws-iam": "1.147.0",
-        "@aws-cdk/aws-kms": "1.147.0",
-        "@aws-cdk/cloud-assembly-schema": "1.147.0",
-        "@aws-cdk/core": "1.147.0",
-        "@aws-cdk/cx-api": "1.147.0",
-        "constructs": "^3.3.69"
-      }
-    },
-    "@aws-cdk/aws-events": {
-      "version": "1.147.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-events/-/aws-events-1.147.0.tgz",
-      "integrity": "sha512-zTwcs6pwMJSBipW4KNw75DjUqzMSeqBglGpgI3GAXjnqWODiZJ5E6OdsIMqkd8OyvZ+fvbNhNbWAN67iqcbI1w==",
-      "dev": true,
-      "requires": {
-        "@aws-cdk/aws-iam": "1.147.0",
-        "@aws-cdk/core": "1.147.0",
-        "constructs": "^3.3.69"
-      }
-    },
-    "@aws-cdk/aws-iam": {
-      "version": "1.147.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-iam/-/aws-iam-1.147.0.tgz",
-      "integrity": "sha512-25YwRaXiOmlI1YZ+CquR7vru59S+Wo1VlAsOnpZpzQ9RJiSgleOL6Qquw1veTylDK7xp1pijUhQdevQ8GUuwFA==",
-      "dev": true,
-      "requires": {
-        "@aws-cdk/core": "1.147.0",
-        "@aws-cdk/region-info": "1.147.0",
-        "constructs": "^3.3.69"
-      }
-    },
-    "@aws-cdk/aws-kinesis": {
-      "version": "1.147.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-kinesis/-/aws-kinesis-1.147.0.tgz",
-      "integrity": "sha512-Y+t3kdsb5qPsKg59bhQPlZfSIDfw89NbppkEdC7aLlvGzdWbBTv3hK3J3vRrSH4KLUYFaC/ylb9Ht6ZkEtfqEA==",
-      "dev": true,
-      "requires": {
-        "@aws-cdk/aws-cloudwatch": "1.147.0",
-        "@aws-cdk/aws-iam": "1.147.0",
-        "@aws-cdk/aws-kms": "1.147.0",
-        "@aws-cdk/aws-logs": "1.147.0",
-        "@aws-cdk/core": "1.147.0",
-        "constructs": "^3.3.69"
-      }
-    },
-    "@aws-cdk/aws-kms": {
-      "version": "1.147.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-kms/-/aws-kms-1.147.0.tgz",
-      "integrity": "sha512-O/BeiPXmWqETZKHgy1kYqcbMiMUVaC1BmB+zZnrk5j5Aivb19H9+1wLQ0uuXWQ8wfsrNKsg+nsjfiDGhGA71Qg==",
-      "dev": true,
-      "requires": {
-        "@aws-cdk/aws-iam": "1.147.0",
-        "@aws-cdk/cloud-assembly-schema": "1.147.0",
-        "@aws-cdk/core": "1.147.0",
-        "@aws-cdk/cx-api": "1.147.0",
-        "constructs": "^3.3.69"
-      }
-    },
-    "@aws-cdk/aws-lambda": {
-      "version": "1.147.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-lambda/-/aws-lambda-1.147.0.tgz",
-      "integrity": "sha512-zAU/jPN7zz/FNFBZCxq93iQuQqDMXVa8+DYay+p0/z+zivUZMyi9078xy8TrnrG59CZTiGiIDYMbmZOj2m5k6w==",
-      "dev": true,
-      "requires": {
-        "@aws-cdk/aws-applicationautoscaling": "1.147.0",
-        "@aws-cdk/aws-cloudwatch": "1.147.0",
-        "@aws-cdk/aws-codeguruprofiler": "1.147.0",
-        "@aws-cdk/aws-ec2": "1.147.0",
-        "@aws-cdk/aws-ecr": "1.147.0",
-        "@aws-cdk/aws-ecr-assets": "1.147.0",
-        "@aws-cdk/aws-efs": "1.147.0",
-        "@aws-cdk/aws-events": "1.147.0",
-        "@aws-cdk/aws-iam": "1.147.0",
-        "@aws-cdk/aws-kms": "1.147.0",
-        "@aws-cdk/aws-logs": "1.147.0",
-        "@aws-cdk/aws-s3": "1.147.0",
-        "@aws-cdk/aws-s3-assets": "1.147.0",
-        "@aws-cdk/aws-signer": "1.147.0",
-        "@aws-cdk/aws-sns": "1.147.0",
-        "@aws-cdk/aws-sqs": "1.147.0",
-        "@aws-cdk/core": "1.147.0",
-        "@aws-cdk/cx-api": "1.147.0",
-        "@aws-cdk/region-info": "1.147.0",
-        "constructs": "^3.3.69"
-      }
-    },
-    "@aws-cdk/aws-lambda-nodejs": {
-      "version": "1.147.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-lambda-nodejs/-/aws-lambda-nodejs-1.147.0.tgz",
-      "integrity": "sha512-d7pYBw3LA4+UdWn1Uk4AQQB4ZOfE+fUQfPAW0vuQ0za9Rcvbg0iLYmzrPrytx7jeNJmbxA8tBjrYk9okgqoUVg==",
-      "dev": true,
-      "requires": {
-        "@aws-cdk/aws-lambda": "1.147.0",
-        "@aws-cdk/core": "1.147.0",
-        "constructs": "^3.3.69"
-      }
-    },
-    "@aws-cdk/aws-logs": {
-      "version": "1.147.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-logs/-/aws-logs-1.147.0.tgz",
-      "integrity": "sha512-Rim34ijoHB+0KKdmURW3hqZj8GbgkUwxcU8MvlqAyFJtb2Ou0bq8F1drmEqC0OTV2cymlNLdFl6VqE8t0vkTMA==",
-      "dev": true,
-      "requires": {
-        "@aws-cdk/aws-cloudwatch": "1.147.0",
-        "@aws-cdk/aws-iam": "1.147.0",
-        "@aws-cdk/aws-kms": "1.147.0",
-        "@aws-cdk/aws-s3-assets": "1.147.0",
-        "@aws-cdk/core": "1.147.0",
-        "@aws-cdk/cx-api": "1.147.0",
-        "constructs": "^3.3.69"
-      }
-    },
-    "@aws-cdk/aws-s3": {
-      "version": "1.147.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-s3/-/aws-s3-1.147.0.tgz",
-      "integrity": "sha512-vkk8hy8Utpximxx5k7HXM+VBYa+63xIg1N669FZ7rKfVEZ/H3ZEezRzPG9b5pNDwk4w6nh0VfYB7Ckgj/+lKxw==",
-      "dev": true,
-      "requires": {
-        "@aws-cdk/aws-events": "1.147.0",
-        "@aws-cdk/aws-iam": "1.147.0",
-        "@aws-cdk/aws-kms": "1.147.0",
-        "@aws-cdk/core": "1.147.0",
-        "@aws-cdk/cx-api": "1.147.0",
-        "constructs": "^3.3.69"
-      }
-    },
-    "@aws-cdk/aws-s3-assets": {
-      "version": "1.147.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-s3-assets/-/aws-s3-assets-1.147.0.tgz",
-      "integrity": "sha512-7qRsjsqbLZKsGmwPzA3bMqnVd7bcKsOZEGSbl5UoY2U9UaMgOX5Lev53dDsh4qW9QSwXm0qBJTDeJwRrHfGaLQ==",
-      "dev": true,
-      "requires": {
-        "@aws-cdk/assets": "1.147.0",
-        "@aws-cdk/aws-iam": "1.147.0",
-        "@aws-cdk/aws-kms": "1.147.0",
-        "@aws-cdk/aws-s3": "1.147.0",
-        "@aws-cdk/core": "1.147.0",
-        "@aws-cdk/cx-api": "1.147.0",
-        "constructs": "^3.3.69"
-      }
-    },
-    "@aws-cdk/aws-signer": {
-      "version": "1.147.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-signer/-/aws-signer-1.147.0.tgz",
-      "integrity": "sha512-N42OxAqHXXNITurUBBddbWlzcr4PiXR7gM1gV9YvCI163eZUuKREuqtfhD8rmBAjMp6TJVDna3gAaySY+zNoBA==",
-      "dev": true,
-      "requires": {
-        "@aws-cdk/core": "1.147.0",
-        "constructs": "^3.3.69"
-      }
-    },
-    "@aws-cdk/aws-sns": {
-      "version": "1.147.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-sns/-/aws-sns-1.147.0.tgz",
-      "integrity": "sha512-j3eQetou0V/QRSvnP8G6zLryFN481BVEP4pkDjXmW4e/5tdHhj4Diy12SbrY8niwwzVj9gftsDmu9WEk+rAHQw==",
-      "dev": true,
-      "requires": {
-        "@aws-cdk/aws-cloudwatch": "1.147.0",
-        "@aws-cdk/aws-codestarnotifications": "1.147.0",
-        "@aws-cdk/aws-events": "1.147.0",
-        "@aws-cdk/aws-iam": "1.147.0",
-        "@aws-cdk/aws-kms": "1.147.0",
-        "@aws-cdk/aws-sqs": "1.147.0",
-        "@aws-cdk/core": "1.147.0",
-        "constructs": "^3.3.69"
-      }
-    },
-    "@aws-cdk/aws-sqs": {
-      "version": "1.147.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-sqs/-/aws-sqs-1.147.0.tgz",
-      "integrity": "sha512-76uRyNQJjTT8K82vgXfK4yCvFyt6YvKOVsSiOPtNK0ncu1dljgEIneIlP0pQIvyWODEV6Sgjh6z25yh6qP8KFw==",
-      "dev": true,
-      "requires": {
-        "@aws-cdk/aws-cloudwatch": "1.147.0",
-        "@aws-cdk/aws-iam": "1.147.0",
-        "@aws-cdk/aws-kms": "1.147.0",
-        "@aws-cdk/core": "1.147.0",
-        "constructs": "^3.3.69"
-      }
-    },
-    "@aws-cdk/aws-ssm": {
-      "version": "1.147.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ssm/-/aws-ssm-1.147.0.tgz",
-      "integrity": "sha512-/FHY5sIEQR+EO3CqZ9zA/7CnaGBcmSdsaXsj/sKgPkmUoV2WFFJYlHpfs9AacpNQw9v+zWiSdsn5rOK/UPJvGg==",
-      "dev": true,
-      "requires": {
-        "@aws-cdk/aws-iam": "1.147.0",
-        "@aws-cdk/aws-kms": "1.147.0",
-        "@aws-cdk/cloud-assembly-schema": "1.147.0",
-        "@aws-cdk/core": "1.147.0",
-        "constructs": "^3.3.69"
       }
     },
     "@aws-cdk/cfnspec": {
@@ -16262,10 +15931,9 @@
       "version": "file:packages/tracing",
       "requires": {
         "@aws-lambda-powertools/commons": "^0.7.2",
-        "@aws-sdk/client-dynamodb": "^3.52.0",
         "@types/promise-retry": "^1.1.3",
         "aws-xray-sdk-core": "^3.3.4",
-        "axios": "*",
+        "axios": "^0.26.1",
         "promise-retry": "^2.0.1"
       }
     },
@@ -16280,42 +15948,42 @@
       }
     },
     "@aws-sdk/client-dynamodb": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.55.0.tgz",
-      "integrity": "sha512-INXDvGzltlO91y/iqNIyPBI6kW1gYwZzHXUTBtDZO1hQCedukj/AXX3kIkksfd5XG96Sj8FTB+1u/bV74dfyVA==",
+      "version": "3.58.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.58.0.tgz",
+      "integrity": "sha512-54uclCvSVREutcty19NqfzC5V/0ebYSz51lz5jQpHYObP2uUAKOunTAWx1lnWACZ9U9Ka6SHWN/NhKFXeMKwgw==",
       "dev": true,
       "requires": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.55.0",
-        "@aws-sdk/config-resolver": "3.55.0",
-        "@aws-sdk/credential-provider-node": "3.55.0",
-        "@aws-sdk/fetch-http-handler": "3.55.0",
+        "@aws-sdk/client-sts": "3.58.0",
+        "@aws-sdk/config-resolver": "3.58.0",
+        "@aws-sdk/credential-provider-node": "3.58.0",
+        "@aws-sdk/fetch-http-handler": "3.58.0",
         "@aws-sdk/hash-node": "3.55.0",
         "@aws-sdk/invalid-dependency": "3.55.0",
-        "@aws-sdk/middleware-content-length": "3.55.0",
-        "@aws-sdk/middleware-endpoint-discovery": "3.55.0",
-        "@aws-sdk/middleware-host-header": "3.55.0",
+        "@aws-sdk/middleware-content-length": "3.58.0",
+        "@aws-sdk/middleware-endpoint-discovery": "3.58.0",
+        "@aws-sdk/middleware-host-header": "3.58.0",
         "@aws-sdk/middleware-logger": "3.55.0",
-        "@aws-sdk/middleware-retry": "3.55.0",
+        "@aws-sdk/middleware-retry": "3.58.0",
         "@aws-sdk/middleware-serde": "3.55.0",
-        "@aws-sdk/middleware-signing": "3.55.0",
+        "@aws-sdk/middleware-signing": "3.58.0",
         "@aws-sdk/middleware-stack": "3.55.0",
-        "@aws-sdk/middleware-user-agent": "3.55.0",
-        "@aws-sdk/node-config-provider": "3.55.0",
-        "@aws-sdk/node-http-handler": "3.55.0",
-        "@aws-sdk/protocol-http": "3.55.0",
+        "@aws-sdk/middleware-user-agent": "3.58.0",
+        "@aws-sdk/node-config-provider": "3.58.0",
+        "@aws-sdk/node-http-handler": "3.58.0",
+        "@aws-sdk/protocol-http": "3.58.0",
         "@aws-sdk/smithy-client": "3.55.0",
         "@aws-sdk/types": "3.55.0",
         "@aws-sdk/url-parser": "3.55.0",
-        "@aws-sdk/util-base64-browser": "3.55.0",
+        "@aws-sdk/util-base64-browser": "3.58.0",
         "@aws-sdk/util-base64-node": "3.55.0",
         "@aws-sdk/util-body-length-browser": "3.55.0",
         "@aws-sdk/util-body-length-node": "3.55.0",
         "@aws-sdk/util-defaults-mode-browser": "3.55.0",
-        "@aws-sdk/util-defaults-mode-node": "3.55.0",
-        "@aws-sdk/util-user-agent-browser": "3.55.0",
-        "@aws-sdk/util-user-agent-node": "3.55.0",
+        "@aws-sdk/util-defaults-mode-node": "3.58.0",
+        "@aws-sdk/util-user-agent-browser": "3.58.0",
+        "@aws-sdk/util-user-agent-node": "3.58.0",
         "@aws-sdk/util-utf8-browser": "3.55.0",
         "@aws-sdk/util-utf8-node": "3.55.0",
         "@aws-sdk/util-waiter": "3.55.0",
@@ -16332,79 +16000,79 @@
       }
     },
     "@aws-sdk/client-sso": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.55.0.tgz",
-      "integrity": "sha512-bIGy2xkWZ00Vn5ByLIQamHVbzSE6Pbcs67873otNWtpkygfMzvQRFZ8RB6J+C6BuAwT3xTLI0aNi40RxxwM4HQ==",
+      "version": "3.58.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.58.0.tgz",
+      "integrity": "sha512-nS5G/OX8Bg4ajBa6+jLcbbr4PpEO+l5eJfGUzoJQwS4Zqa0lF/wC0kyjKm61gLp4JuvhrQskxIC/3IXUqB1XVQ==",
       "dev": true,
       "requires": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.55.0",
-        "@aws-sdk/fetch-http-handler": "3.55.0",
+        "@aws-sdk/config-resolver": "3.58.0",
+        "@aws-sdk/fetch-http-handler": "3.58.0",
         "@aws-sdk/hash-node": "3.55.0",
         "@aws-sdk/invalid-dependency": "3.55.0",
-        "@aws-sdk/middleware-content-length": "3.55.0",
-        "@aws-sdk/middleware-host-header": "3.55.0",
+        "@aws-sdk/middleware-content-length": "3.58.0",
+        "@aws-sdk/middleware-host-header": "3.58.0",
         "@aws-sdk/middleware-logger": "3.55.0",
-        "@aws-sdk/middleware-retry": "3.55.0",
+        "@aws-sdk/middleware-retry": "3.58.0",
         "@aws-sdk/middleware-serde": "3.55.0",
         "@aws-sdk/middleware-stack": "3.55.0",
-        "@aws-sdk/middleware-user-agent": "3.55.0",
-        "@aws-sdk/node-config-provider": "3.55.0",
-        "@aws-sdk/node-http-handler": "3.55.0",
-        "@aws-sdk/protocol-http": "3.55.0",
+        "@aws-sdk/middleware-user-agent": "3.58.0",
+        "@aws-sdk/node-config-provider": "3.58.0",
+        "@aws-sdk/node-http-handler": "3.58.0",
+        "@aws-sdk/protocol-http": "3.58.0",
         "@aws-sdk/smithy-client": "3.55.0",
         "@aws-sdk/types": "3.55.0",
         "@aws-sdk/url-parser": "3.55.0",
-        "@aws-sdk/util-base64-browser": "3.55.0",
+        "@aws-sdk/util-base64-browser": "3.58.0",
         "@aws-sdk/util-base64-node": "3.55.0",
         "@aws-sdk/util-body-length-browser": "3.55.0",
         "@aws-sdk/util-body-length-node": "3.55.0",
         "@aws-sdk/util-defaults-mode-browser": "3.55.0",
-        "@aws-sdk/util-defaults-mode-node": "3.55.0",
-        "@aws-sdk/util-user-agent-browser": "3.55.0",
-        "@aws-sdk/util-user-agent-node": "3.55.0",
+        "@aws-sdk/util-defaults-mode-node": "3.58.0",
+        "@aws-sdk/util-user-agent-browser": "3.58.0",
+        "@aws-sdk/util-user-agent-node": "3.58.0",
         "@aws-sdk/util-utf8-browser": "3.55.0",
         "@aws-sdk/util-utf8-node": "3.55.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/client-sts": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.55.0.tgz",
-      "integrity": "sha512-/xmx0bxvhL9ffQ7A263MyTAfC6G0cyy/FwTmTWTt2xoKCNub7sGrPCJOjZB5fvmy9FpUvFUOJw1DnCghANKxzw==",
+      "version": "3.58.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.58.0.tgz",
+      "integrity": "sha512-2cHZsG2eXv/Zl0hvsG9+rdHEuAclMFfkma/3LC3RRwSuZXo1rXoIhFkzHfGfIbivdk738YAo7FT3ZYGlrsK4ow==",
       "dev": true,
       "requires": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.55.0",
-        "@aws-sdk/credential-provider-node": "3.55.0",
-        "@aws-sdk/fetch-http-handler": "3.55.0",
+        "@aws-sdk/config-resolver": "3.58.0",
+        "@aws-sdk/credential-provider-node": "3.58.0",
+        "@aws-sdk/fetch-http-handler": "3.58.0",
         "@aws-sdk/hash-node": "3.55.0",
         "@aws-sdk/invalid-dependency": "3.55.0",
-        "@aws-sdk/middleware-content-length": "3.55.0",
-        "@aws-sdk/middleware-host-header": "3.55.0",
+        "@aws-sdk/middleware-content-length": "3.58.0",
+        "@aws-sdk/middleware-host-header": "3.58.0",
         "@aws-sdk/middleware-logger": "3.55.0",
-        "@aws-sdk/middleware-retry": "3.55.0",
-        "@aws-sdk/middleware-sdk-sts": "3.55.0",
+        "@aws-sdk/middleware-retry": "3.58.0",
+        "@aws-sdk/middleware-sdk-sts": "3.58.0",
         "@aws-sdk/middleware-serde": "3.55.0",
-        "@aws-sdk/middleware-signing": "3.55.0",
+        "@aws-sdk/middleware-signing": "3.58.0",
         "@aws-sdk/middleware-stack": "3.55.0",
-        "@aws-sdk/middleware-user-agent": "3.55.0",
-        "@aws-sdk/node-config-provider": "3.55.0",
-        "@aws-sdk/node-http-handler": "3.55.0",
-        "@aws-sdk/protocol-http": "3.55.0",
+        "@aws-sdk/middleware-user-agent": "3.58.0",
+        "@aws-sdk/node-config-provider": "3.58.0",
+        "@aws-sdk/node-http-handler": "3.58.0",
+        "@aws-sdk/protocol-http": "3.58.0",
         "@aws-sdk/smithy-client": "3.55.0",
         "@aws-sdk/types": "3.55.0",
         "@aws-sdk/url-parser": "3.55.0",
-        "@aws-sdk/util-base64-browser": "3.55.0",
+        "@aws-sdk/util-base64-browser": "3.58.0",
         "@aws-sdk/util-base64-node": "3.55.0",
         "@aws-sdk/util-body-length-browser": "3.55.0",
         "@aws-sdk/util-body-length-node": "3.55.0",
         "@aws-sdk/util-defaults-mode-browser": "3.55.0",
-        "@aws-sdk/util-defaults-mode-node": "3.55.0",
-        "@aws-sdk/util-user-agent-browser": "3.55.0",
-        "@aws-sdk/util-user-agent-node": "3.55.0",
+        "@aws-sdk/util-defaults-mode-node": "3.58.0",
+        "@aws-sdk/util-user-agent-browser": "3.58.0",
+        "@aws-sdk/util-user-agent-node": "3.58.0",
         "@aws-sdk/util-utf8-browser": "3.55.0",
         "@aws-sdk/util-utf8-node": "3.55.0",
         "entities": "2.2.0",
@@ -16413,14 +16081,15 @@
       }
     },
     "@aws-sdk/config-resolver": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.55.0.tgz",
-      "integrity": "sha512-dW+UcGu6f+RA1ZsiSpdWUrWwrhevXZeeBtr08X83TP7dK8S6HHv5upX+4es1xou6aMqqin+yHZUVmabvAe/gpg==",
+      "version": "3.58.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.58.0.tgz",
+      "integrity": "sha512-NXEwYw0JrXcvenu42QpNMQXK+6pgZ+6bDGfCgOfCC0FmyI+w/CuF36lApwm7InHvHazOaDlwArXm2pfntErKoA==",
       "dev": true,
       "requires": {
-        "@aws-sdk/signature-v4": "3.55.0",
+        "@aws-sdk/signature-v4": "3.58.0",
         "@aws-sdk/types": "3.55.0",
         "@aws-sdk/util-config-provider": "3.55.0",
+        "@aws-sdk/util-middleware": "3.55.0",
         "tslib": "^2.3.1"
       }
     },
@@ -16436,12 +16105,12 @@
       }
     },
     "@aws-sdk/credential-provider-imds": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.55.0.tgz",
-      "integrity": "sha512-aBOQomxYwNHQSHuOetrER1r13x3tJWNd9Eho2OcGLRioNS6/on2T5ptQI5/pJvAqOWe7LG65k1g3eTf1T8Nf1Q==",
+      "version": "3.58.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.58.0.tgz",
+      "integrity": "sha512-CdtnTQ9zqLx1FbXdbgjijLbMcIWOyQM03TFaLSCjI3FNbUwyt3T7StBU9tj/LtbypHhSdXyQBpzUtXTOMWCEhg==",
       "dev": true,
       "requires": {
-        "@aws-sdk/node-config-provider": "3.55.0",
+        "@aws-sdk/node-config-provider": "3.58.0",
         "@aws-sdk/property-provider": "3.55.0",
         "@aws-sdk/types": "3.55.0",
         "@aws-sdk/url-parser": "3.55.0",
@@ -16449,60 +16118,60 @@
       }
     },
     "@aws-sdk/credential-provider-ini": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.55.0.tgz",
-      "integrity": "sha512-f4+8mqJ1xapF9SR90VC+Ho4zlnLPdCgAAm9f7Pauf1/beAk5bkmfLshLwQ5Jo4oEPbWLn1Sdk403kwnxpsnksg==",
+      "version": "3.58.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.58.0.tgz",
+      "integrity": "sha512-uM62hcHUVaHP1YFnbrjf2RlrRj1m/BvMPE+T5jdNRWdE3lvnunhEMawB26HZs9nQqCV6d25I8G9/fGWVL7g3Og==",
       "dev": true,
       "requires": {
         "@aws-sdk/credential-provider-env": "3.55.0",
-        "@aws-sdk/credential-provider-imds": "3.55.0",
-        "@aws-sdk/credential-provider-sso": "3.55.0",
+        "@aws-sdk/credential-provider-imds": "3.58.0",
+        "@aws-sdk/credential-provider-sso": "3.58.0",
         "@aws-sdk/credential-provider-web-identity": "3.55.0",
         "@aws-sdk/property-provider": "3.55.0",
-        "@aws-sdk/shared-ini-file-loader": "3.55.0",
+        "@aws-sdk/shared-ini-file-loader": "3.58.0",
         "@aws-sdk/types": "3.55.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/credential-provider-node": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.55.0.tgz",
-      "integrity": "sha512-cDAk2+29sZyluk3D2vomCJd0adJxjun9yVdyAiuoutxx9LZ1KQgsDEVHDbPQFpmeOBBagtMNpHNVtUunQ3yy1w==",
+      "version": "3.58.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.58.0.tgz",
+      "integrity": "sha512-f0wzcgMYCQUrii6TLP2ggCxkQP4HH8PW8tbbWEgt4cdIXcjE9KEuxN5yOV6sFHzL3eJh0QM9Yaz8WzhWn6fT2A==",
       "dev": true,
       "requires": {
         "@aws-sdk/credential-provider-env": "3.55.0",
-        "@aws-sdk/credential-provider-imds": "3.55.0",
-        "@aws-sdk/credential-provider-ini": "3.55.0",
-        "@aws-sdk/credential-provider-process": "3.55.0",
-        "@aws-sdk/credential-provider-sso": "3.55.0",
+        "@aws-sdk/credential-provider-imds": "3.58.0",
+        "@aws-sdk/credential-provider-ini": "3.58.0",
+        "@aws-sdk/credential-provider-process": "3.58.0",
+        "@aws-sdk/credential-provider-sso": "3.58.0",
         "@aws-sdk/credential-provider-web-identity": "3.55.0",
         "@aws-sdk/property-provider": "3.55.0",
-        "@aws-sdk/shared-ini-file-loader": "3.55.0",
+        "@aws-sdk/shared-ini-file-loader": "3.58.0",
         "@aws-sdk/types": "3.55.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/credential-provider-process": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.55.0.tgz",
-      "integrity": "sha512-09AGJ6bdonXpV/dyHzrQqcbo2oy3aDxjcq+/LGo4GuB0ZHD2TJqKpExU7ie0rg/5OdBnTX6c+9JyjeFt03uX7w==",
+      "version": "3.58.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.58.0.tgz",
+      "integrity": "sha512-npgFqPUjMhUamf1FvJjBYUdpbWx8XWkKCwJsX73I7IYQAvAi2atCOkdtKq+4rds0VWAYu6vzlaI1tXgFxjOPNQ==",
       "dev": true,
       "requires": {
         "@aws-sdk/property-provider": "3.55.0",
-        "@aws-sdk/shared-ini-file-loader": "3.55.0",
+        "@aws-sdk/shared-ini-file-loader": "3.58.0",
         "@aws-sdk/types": "3.55.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/credential-provider-sso": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.55.0.tgz",
-      "integrity": "sha512-hKWbZMDY5nZMsOKMVkeUrKCdHaemMhyAH4WfApq976DDJt6bm6U+jvkTspO8qQaIPD8xdRqyi5AMLvVcHjBbTg==",
+      "version": "3.58.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.58.0.tgz",
+      "integrity": "sha512-2qO34s9lJqvCC6zOF4UpopW6xURZpYfVC8xTUDpAUnvTOt4nS5hkx4vNyqPAXILoRHuFJsnlWsBH1UP5ZnBiZg==",
       "dev": true,
       "requires": {
-        "@aws-sdk/client-sso": "3.55.0",
+        "@aws-sdk/client-sso": "3.58.0",
         "@aws-sdk/property-provider": "3.55.0",
-        "@aws-sdk/shared-ini-file-loader": "3.55.0",
+        "@aws-sdk/shared-ini-file-loader": "3.58.0",
         "@aws-sdk/types": "3.55.0",
         "tslib": "^2.3.1"
       }
@@ -16529,15 +16198,15 @@
       }
     },
     "@aws-sdk/fetch-http-handler": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.55.0.tgz",
-      "integrity": "sha512-/Sta3MLlszpRZ1pg+ClxfNqGvraX93F587eHrfQMaGXgQ2BqJLiAVRorBRGcmmmrHxfLOqspNqufF7ibrqziRQ==",
+      "version": "3.58.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.58.0.tgz",
+      "integrity": "sha512-timF3FjPV5Bd+Kgph83LIKVlPCFObVYzious1a6doeLAT6YFwZpRrWbfP/HzS+DCoYiwUsH69oVJ91BoV66oyA==",
       "dev": true,
       "requires": {
-        "@aws-sdk/protocol-http": "3.55.0",
+        "@aws-sdk/protocol-http": "3.58.0",
         "@aws-sdk/querystring-builder": "3.55.0",
         "@aws-sdk/types": "3.55.0",
-        "@aws-sdk/util-base64-browser": "3.55.0",
+        "@aws-sdk/util-base64-browser": "3.58.0",
         "tslib": "^2.3.1"
       }
     },
@@ -16572,36 +16241,36 @@
       }
     },
     "@aws-sdk/middleware-content-length": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.55.0.tgz",
-      "integrity": "sha512-IkFBwa1G5ERfKFh4Kdtcn/aNAGi3Hcp9IO1PVt69LZWaevxjXAi5NS2k65E9mZPEumzuLtcEeC+3qhPs4FUkqQ==",
+      "version": "3.58.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.58.0.tgz",
+      "integrity": "sha512-h/BypPkhjv2CpCUbXA8Fa2s7V2GPiz9l11XhYK+sKSuQvQ7Lbq6VhaKaLqfeD3gLVZHgJZSLGl2btdHV1qHNNA==",
       "dev": true,
       "requires": {
-        "@aws-sdk/protocol-http": "3.55.0",
+        "@aws-sdk/protocol-http": "3.58.0",
         "@aws-sdk/types": "3.55.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-endpoint-discovery": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.55.0.tgz",
-      "integrity": "sha512-lVQLFQ9I3CCLNlx6lhH6rzodAJgM+rwXEbcn5UB1xSg1cmPd10hD1tvRHndDlHdrRF2ql6zk3LGq4JwB8IjNYw==",
+      "version": "3.58.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.58.0.tgz",
+      "integrity": "sha512-Ll42zMPP8dDTHesv5VdnM0vgT4mW+kR2SgXCWBMuwnZdBn0FDH1A3E0BqJkLuuq2TKIah0/l1sA1qVC68GkAeA==",
       "dev": true,
       "requires": {
-        "@aws-sdk/config-resolver": "3.55.0",
+        "@aws-sdk/config-resolver": "3.58.0",
         "@aws-sdk/endpoint-cache": "3.55.0",
-        "@aws-sdk/protocol-http": "3.55.0",
+        "@aws-sdk/protocol-http": "3.58.0",
         "@aws-sdk/types": "3.55.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-host-header": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.55.0.tgz",
-      "integrity": "sha512-69mTWJfuPP4aC+h2/cb9B2CUNA9tiRPUBp67dmMrA2dHyy53kNYo8TGgfLKProoBidBz/AVXIfnh+izJj0F20w==",
+      "version": "3.58.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.58.0.tgz",
+      "integrity": "sha512-q/UKGcanm9e6DBRNN6UKhVqLvpRRdZWbmmPCeDNr4HqhCmgT6i1OvWdhAMOnT++hvCX8DpTsIXzNSlY6zWAxBg==",
       "dev": true,
       "requires": {
-        "@aws-sdk/protocol-http": "3.55.0",
+        "@aws-sdk/protocol-http": "3.58.0",
         "@aws-sdk/types": "3.55.0",
         "tslib": "^2.3.1"
       }
@@ -16617,14 +16286,15 @@
       }
     },
     "@aws-sdk/middleware-retry": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.55.0.tgz",
-      "integrity": "sha512-Z0j4/zyvgp8Y7HYud1MCqheg9koVh7p1ekS8lm6GePZBWILXsFib8PK9eq7B16u2z7yyz2tHrzwQrHRRr0cQKQ==",
+      "version": "3.58.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.58.0.tgz",
+      "integrity": "sha512-sfSq+t0Yy47DQwrWGpA8iOx9sd26l4l1JDVTwHNi7+OKD4ClRPVCEdw3bTbbyYz/PV4f9AEfAZ6jwtSff4wkGw==",
       "dev": true,
       "requires": {
-        "@aws-sdk/protocol-http": "3.55.0",
+        "@aws-sdk/protocol-http": "3.58.0",
         "@aws-sdk/service-error-classification": "3.55.0",
         "@aws-sdk/types": "3.55.0",
+        "@aws-sdk/util-middleware": "3.55.0",
         "tslib": "^2.3.1",
         "uuid": "^8.3.2"
       },
@@ -16638,15 +16308,15 @@
       }
     },
     "@aws-sdk/middleware-sdk-sts": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.55.0.tgz",
-      "integrity": "sha512-BrK3UXmD08rGbhY6cAHXsQxDfflOrPbKe4gxymlckd9sGIPC42O1KfJQ0CaxWPvG1Gd3R/QFfoPFClpTDhdh0Q==",
+      "version": "3.58.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.58.0.tgz",
+      "integrity": "sha512-HUz7MhcsSDDTGygOwL61l4voc0pZco06J3z06JjTX19D5XxcQ7hSCtkHHHz0oMb9M1himVSiEon2tjhjsnB99g==",
       "dev": true,
       "requires": {
-        "@aws-sdk/middleware-signing": "3.55.0",
+        "@aws-sdk/middleware-signing": "3.58.0",
         "@aws-sdk/property-provider": "3.55.0",
-        "@aws-sdk/protocol-http": "3.55.0",
-        "@aws-sdk/signature-v4": "3.55.0",
+        "@aws-sdk/protocol-http": "3.58.0",
+        "@aws-sdk/signature-v4": "3.58.0",
         "@aws-sdk/types": "3.55.0",
         "tslib": "^2.3.1"
       }
@@ -16662,14 +16332,14 @@
       }
     },
     "@aws-sdk/middleware-signing": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.55.0.tgz",
-      "integrity": "sha512-FUVrFv6zfHkX1gjwOvam4VneGJL9L/1can5HoNKAsxYwGUMVCrMEmyfkGWBy+paMe0dQ3bF4VVZjJHEvzJaQLQ==",
+      "version": "3.58.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.58.0.tgz",
+      "integrity": "sha512-4FXubHB66GbhyZUlo6YPQoWpYfED15GNbEmHbJLSONzrVzZR3IkViSPLasDngVm1a050JqKuqNkFYGJBP4No/Q==",
       "dev": true,
       "requires": {
         "@aws-sdk/property-provider": "3.55.0",
-        "@aws-sdk/protocol-http": "3.55.0",
-        "@aws-sdk/signature-v4": "3.55.0",
+        "@aws-sdk/protocol-http": "3.58.0",
+        "@aws-sdk/signature-v4": "3.58.0",
         "@aws-sdk/types": "3.55.0",
         "tslib": "^2.3.1"
       }
@@ -16684,36 +16354,36 @@
       }
     },
     "@aws-sdk/middleware-user-agent": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.55.0.tgz",
-      "integrity": "sha512-UOBimkQrj6onXb3Fyuao85IjipnDSowNHfOOl3ADVX9boA/A4db5QAXBSxThV0WHLArC0iiUsnwu95ElSSMVIg==",
+      "version": "3.58.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.58.0.tgz",
+      "integrity": "sha512-1c69bIWM63JwXijXvb9IWwcwQ/gViKMZ1lhxv52NvdG5VSxWXXsFJ2jETEXZoAypwT97Hmf3xo9SYuaHcKoq+g==",
       "dev": true,
       "requires": {
-        "@aws-sdk/protocol-http": "3.55.0",
+        "@aws-sdk/protocol-http": "3.58.0",
         "@aws-sdk/types": "3.55.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/node-config-provider": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.55.0.tgz",
-      "integrity": "sha512-+qpAEWiRXCuY85+VkJWbe+4MfQjlq6Nzi4a+3OejyqTRYMkslK93tR7SejdCiyq1lWpqtbwI9DsjDO45/2P6LA==",
+      "version": "3.58.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.58.0.tgz",
+      "integrity": "sha512-AMcPqPhKxo/3/yOMS9PsKlI0GWp2/8eD6gSlhzdBpznPCKplyqXOSnSX7wS814Cyh373hFSjCaOrCOA9/EYtDg==",
       "dev": true,
       "requires": {
         "@aws-sdk/property-provider": "3.55.0",
-        "@aws-sdk/shared-ini-file-loader": "3.55.0",
+        "@aws-sdk/shared-ini-file-loader": "3.58.0",
         "@aws-sdk/types": "3.55.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/node-http-handler": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.55.0.tgz",
-      "integrity": "sha512-yF4YQr72YgVgWO9IDOhDcncqlKUJmMCtserAYhKNvmkVuaMGHE11p+IByWgcIsMJTvtFaFBhTA3W7zhJB1C1xA==",
+      "version": "3.58.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.58.0.tgz",
+      "integrity": "sha512-D9xVZG2nfo4GbPsby3JuBiAhpqXTFk1+CfuQU0AZv0gQvE3fFTCnB3za83jo7JV/pyRPU+s+/LHIpxCWUHzStg==",
       "dev": true,
       "requires": {
         "@aws-sdk/abort-controller": "3.55.0",
-        "@aws-sdk/protocol-http": "3.55.0",
+        "@aws-sdk/protocol-http": "3.58.0",
         "@aws-sdk/querystring-builder": "3.55.0",
         "@aws-sdk/types": "3.55.0",
         "tslib": "^2.3.1"
@@ -16730,9 +16400,9 @@
       }
     },
     "@aws-sdk/protocol-http": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.55.0.tgz",
-      "integrity": "sha512-vNjjsP5bFuKQMhmuBQZDddH441xanPbm8n42qgfigv0RzgWQhvUFrnmZWLBdyY8geY0RwsQ6x9yfQ0gvs48tpw==",
+      "version": "3.58.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.58.0.tgz",
+      "integrity": "sha512-0yFFRPbR+CCa9eOQBBQ2qtrIDLYqSMN0y7G4iqVM8wQdIw7n3QK1PsTI3RNPGJ3Oi2krFTw5uUKqQQZPZEBuVQ==",
       "dev": true,
       "requires": {
         "@aws-sdk/types": "3.55.0",
@@ -16766,23 +16436,24 @@
       "integrity": "sha512-HdjnDyarsa1Avq1MJurkLyEe9c3eRa76dPmK4TmRGgwJ+tInEzGHL0rBW7V8xBK+PDF+fJQ71hvm8jPYmzvBwQ=="
     },
     "@aws-sdk/shared-ini-file-loader": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.55.0.tgz",
-      "integrity": "sha512-utmqVMvif8MjSr27HwPDZGCfJGCI4LoFkm4oyjonyu15aTfULm60mX6RTXftaQ2Syf7dnZ2U4kbp3xgzA5ZIgg==",
+      "version": "3.58.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.58.0.tgz",
+      "integrity": "sha512-ARDKQerIzgNs/MFNdCEuK2lgRJ1lneAaJw0p9O1LkJUvcSibvkSATwny7vwJMueOf+ae1Pf+8+54OMNIt0nTkQ==",
       "dev": true,
       "requires": {
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/signature-v4": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.55.0.tgz",
-      "integrity": "sha512-ryJ43HSIVq7wt+QDBlb5CFH/rrH0+LtgnLDU+FM1XAQkT+oo3V9Hzr7rFmnFSfZqr/8hAn/4xUGTaJKZgO57NQ==",
+      "version": "3.58.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.58.0.tgz",
+      "integrity": "sha512-flEo8p3XkzWoBDqnIUQre4jLuT5aLnmfQNI8c2uSjyJ3OBxpJ0iS1cDu3E++d1/pN6Q8o0KOmr2ypHeiyBOujw==",
       "dev": true,
       "requires": {
         "@aws-sdk/is-array-buffer": "3.55.0",
         "@aws-sdk/types": "3.55.0",
-        "@aws-sdk/util-hex-encoding": "3.55.0",
+        "@aws-sdk/util-hex-encoding": "3.58.0",
+        "@aws-sdk/util-middleware": "3.55.0",
         "@aws-sdk/util-uri-escape": "3.55.0",
         "tslib": "^2.3.1"
       }
@@ -16815,9 +16486,9 @@
       }
     },
     "@aws-sdk/util-base64-browser": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.55.0.tgz",
-      "integrity": "sha512-3hrZ2R/ZyD3IM25KhETOGLC5tB/ft8zoyVmNg1l4+takoUm46ompnglFXCVkWBu9Hpxc+M4XtiY7MHE6es4Wtg==",
+      "version": "3.58.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.58.0.tgz",
+      "integrity": "sha512-0ebsXIZNpu/fup9OgsFPnRKfCFbuuI9PPRzvP6twzLxUB0c/aix6Co7LGHFKcRKHZdaykoJMXArf8eHj2Nzv1Q==",
       "dev": true,
       "requires": {
         "tslib": "^2.3.1"
@@ -16883,23 +16554,23 @@
       }
     },
     "@aws-sdk/util-defaults-mode-node": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.55.0.tgz",
-      "integrity": "sha512-uIVZ7SVBUrkSH1lqhmvvb0Sc1aecPydGH4ex2qA4Vrp+Xp0h4pzjRELdVEOFbAFMB1uHXzgMV6jLjADGZPrHrQ==",
+      "version": "3.58.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.58.0.tgz",
+      "integrity": "sha512-KNUCp0MXI+z3Z3pQCKDkx3Stdy1TXDjcUB+ZJFxRTJGIuBYwX4fV6G8s/zeFJi5Qv1ztR3CJ9fWJGsrx9mQ5EA==",
       "dev": true,
       "requires": {
-        "@aws-sdk/config-resolver": "3.55.0",
-        "@aws-sdk/credential-provider-imds": "3.55.0",
-        "@aws-sdk/node-config-provider": "3.55.0",
+        "@aws-sdk/config-resolver": "3.58.0",
+        "@aws-sdk/credential-provider-imds": "3.58.0",
+        "@aws-sdk/node-config-provider": "3.58.0",
         "@aws-sdk/property-provider": "3.55.0",
         "@aws-sdk/types": "3.55.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-hex-encoding": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.55.0.tgz",
-      "integrity": "sha512-zbDWNzIyqN2Po7SIo1ZDL4rQMP3R0TzGcCrm01bpQAb+2fWqUPigolvNZXXtMO6eS7EW3ZJJzkfoWHdH8zDz1A==",
+      "version": "3.58.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.58.0.tgz",
+      "integrity": "sha512-Rl+jXUzk/FJkOLYfUVYPhKa2aUmTpeobRP31l8IatQltSzDgLyRHO35f6UEs7Ztn5s1jbu/POatLAZ2WjbgVyg==",
       "dev": true,
       "requires": {
         "tslib": "^2.3.1"
@@ -16909,6 +16580,15 @@
       "version": "3.55.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.55.0.tgz",
       "integrity": "sha512-0sPmK2JaJE2BbTcnvybzob/VrFKCXKfN4CUKcvn0yGg/me7Bz+vtzQRB3Xp+YSx+7OtWxzv63wsvHoAnXvgxgg==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-middleware": {
+      "version": "3.55.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.55.0.tgz",
+      "integrity": "sha512-82fW2XV+rUalv8lkd4VlhpPp6xnXO5n9sckMp1N+TrQ+p8eqxqT0+o8n1/6s9Qsnkw64Y3m6+EfCdc8/uFOY2g==",
       "dev": true,
       "requires": {
         "tslib": "^2.3.1"
@@ -16924,9 +16604,9 @@
       }
     },
     "@aws-sdk/util-user-agent-browser": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.55.0.tgz",
-      "integrity": "sha512-E+8PluqbdOKfdJc9E4k0vy4PPb9wvAMa2Zdm5ycoaY0IXRI9RjQJnRw5JKAAJWLuOy7Lb83LgoowGW3o+4AuKw==",
+      "version": "3.58.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.58.0.tgz",
+      "integrity": "sha512-aJpqCvT09giJRg5xFTBDBRAVF0k0yq3OEf6UTuiOVf5azlL2MGp6PJ/xkJp9Z06PuQQkwBJ/2nIQZemo02a5Sw==",
       "dev": true,
       "requires": {
         "@aws-sdk/types": "3.55.0",
@@ -16935,12 +16615,12 @@
       }
     },
     "@aws-sdk/util-user-agent-node": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.55.0.tgz",
-      "integrity": "sha512-7aoolXzpnTcvIGkxY8v8AZR5ooH7c0wttEjQNkOfORQprznNuj5RUZPxq8oStpFSvwASZJPpfd2Y18G2jPthMw==",
+      "version": "3.58.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.58.0.tgz",
+      "integrity": "sha512-VlbY/nzWdN2pfLUHqKvnlGBQ6tEeV4jyK9ggAD2Szjj0bkYvaaKwpBKswQmuJpi5/J2v7Bo4ayBLnqDL7PgzLA==",
       "dev": true,
       "requires": {
-        "@aws-sdk/node-config-provider": "3.55.0",
+        "@aws-sdk/node-config-provider": "3.58.0",
         "@aws-sdk/types": "3.55.0",
         "tslib": "^2.3.1"
       }

--- a/packages/tracing/package.json
+++ b/packages/tracing/package.json
@@ -30,7 +30,7 @@
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "devDependencies": {
-    "@aws-sdk/client-dynamodb": "^3.52.0",
+    "@aws-sdk/client-dynamodb": "^3.58.0",
     "@types/promise-retry": "^1.1.3",
     "axios": "^0.26.1",
     "promise-retry": "^2.0.1"

--- a/packages/tracing/package.json
+++ b/packages/tracing/package.json
@@ -32,6 +32,7 @@
   "devDependencies": {
     "@aws-sdk/client-dynamodb": "^3.52.0",
     "@types/promise-retry": "^1.1.3",
+    "axios": "^0.26.1",
     "promise-retry": "^2.0.1"
   },
   "files": [
@@ -45,7 +46,7 @@
     "url": "https://github.com/awslabs/aws-lambda-powertools-typescript/issues"
   },
   "dependencies": {
-    "@aws-lambda-powertools/commons": "^0.7.2",
-    "aws-xray-sdk-core": "^3.3.3"
+    "@aws-lambda-powertools/commons": "^0.7.1",
+    "aws-xray-sdk-core": "^3.3.4"
   }
 }

--- a/packages/tracing/src/Tracer.ts
+++ b/packages/tracing/src/Tracer.ts
@@ -15,6 +15,7 @@ import { Segment, Subsegment } from 'aws-xray-sdk-core';
  * ## Key features
  *   * Auto capture cold start as annotation, and responses or full exceptions as metadata
  *   * Auto-disable when not running in AWS Lambda environment
+ *   * Automatically trace HTTP(s) clients and generate segments for each request
  *   * Support tracing functions via decorators, middleware, and manual instrumentation
  *   * Support tracing AWS SDK v2 and v3 via AWS X-Ray SDK for Node.js
  * 
@@ -115,6 +116,8 @@ class Tracer extends Utility implements TracerInterface {
   public provider: ProviderServiceInterface;
   
   private captureError: boolean = true;
+
+  private captureHTTPsRequests: boolean = true;
   
   private captureResponse: boolean = true;
 
@@ -131,6 +134,9 @@ class Tracer extends Utility implements TracerInterface {
 
     this.setOptions(options);
     this.provider = new ProviderService();
+    if (this.isTracingEnabled() && this.captureHTTPsRequests) {
+      this.provider.captureHTTPsGlobal();
+    }
     if (!this.isTracingEnabled()) {
       // Tell x-ray-sdk to not throw an error if context is missing but tracing is disabled
       this.provider.setContextMissingStrategy(() => ({}));
@@ -632,6 +638,39 @@ class Tracer extends Utility implements TracerInterface {
   }
 
   /**
+   * Patch an all HTTP(s) clients and create traces when your application makes calls outgoing calls.
+   *
+   * Calls using third-party HTTP request libraries, such as Axios, are supported as long as they use the native http
+   * module under the hood. Support for third-party HTTP request libraries is provided on a best effort basis.
+   * 
+   * @see https://docs.aws.amazon.com/xray/latest/devguide/xray-sdk-nodejs-httpclients.html
+   * 
+   * @param enabled - Whether or not to patch all HTTP clients
+   * @returns void
+   */
+  private setCaptureHTTPsRequests(enabled?: boolean): void {
+    if (enabled !== undefined && !enabled) {
+      this.captureHTTPsRequests = false;
+
+      return;
+    }
+
+    const customConfigValue = this.getCustomConfigService()?.getCaptureHTTPsRequests();
+    if (customConfigValue !== undefined && customConfigValue.toLowerCase() === 'false') {
+      this.captureHTTPsRequests = false;
+
+      return;
+    }
+
+    const envVarsValue = this.getEnvVarsService()?.getCaptureHTTPsRequests();
+    if (envVarsValue.toLowerCase() === 'false') {
+      this.captureHTTPsRequests = false;
+
+      return;
+    }
+  }
+
+  /**
    * Setter for `captureResponse` based on configuration passed and environment variables.
    * Used internally during initialization.
    */
@@ -679,6 +718,7 @@ class Tracer extends Utility implements TracerInterface {
     const {
       enabled,
       serviceName,
+      captureHTTPsRequests,
       customConfigService
     } = options;
 
@@ -688,6 +728,7 @@ class Tracer extends Utility implements TracerInterface {
     this.setCaptureResponse();
     this.setCaptureError();
     this.setServiceName(serviceName);
+    this.setCaptureHTTPsRequests(captureHTTPsRequests);
 
     return this;
   }

--- a/packages/tracing/src/Tracer.ts
+++ b/packages/tracing/src/Tracer.ts
@@ -638,7 +638,7 @@ class Tracer extends Utility implements TracerInterface {
   }
 
   /**
-   * Patch an all HTTP(s) clients and create traces when your application makes calls outgoing calls.
+   * Patch all HTTP(s) clients and create traces when your application makes calls outgoing calls.
    *
    * Calls using third-party HTTP request libraries, such as Axios, are supported as long as they use the native http
    * module under the hood. Support for third-party HTTP request libraries is provided on a best effort basis.

--- a/packages/tracing/src/TracerInterface.ts
+++ b/packages/tracing/src/TracerInterface.ts
@@ -2,15 +2,20 @@ import { HandlerMethodDecorator, MethodDecorator } from './types';
 import { Segment, Subsegment } from 'aws-xray-sdk-core';
 
 interface TracerInterface {
-  getSegment(): Segment | Subsegment | undefined
-  setSegment(segment: Segment | Subsegment): void
-  putAnnotation: (key: string, value: string | number | boolean) => void
-  putMetadata: (key: string, value: unknown, namespace?: string | undefined) => void
-  captureLambdaHandler(): HandlerMethodDecorator
-  captureMethod(): MethodDecorator
+  addErrorAsMetadata(error: Error): void
+  addResponseAsMetadata(data?: unknown, methodName?: string): void
+  addServiceNameAnnotation(): void
+  annotateColdStart(): void
   captureAWS<T>(aws: T): void | T
   captureAWSv3Client<T>(service: T): void | T
   captureAWSClient<T>(service: T): void | T
+  captureLambdaHandler(): HandlerMethodDecorator
+  captureMethod(): MethodDecorator
+  getSegment(): Segment | Subsegment
+  isTracingEnabled(): boolean
+  putAnnotation: (key: string, value: string | number | boolean) => void
+  putMetadata: (key: string, value: unknown, namespace?: string | undefined) => void
+  setSegment(segment: Segment | Subsegment): void
 }
 
 export { 

--- a/packages/tracing/src/config/ConfigService.ts
+++ b/packages/tracing/src/config/ConfigService.ts
@@ -5,10 +5,13 @@ abstract class ConfigService implements ConfigServiceInterface {
   // Custom environment variables
   protected serviceNameVariable = 'POWERTOOLS_SERVICE_NAME';
   protected tracerCaptureErrorVariable = 'POWERTOOLS_TRACER_CAPTURE_ERROR';
+  protected tracerCaptureHTTPsRequestsVariable = 'POWERTOOLS_TRACER_CAPTURE_HTTPS_REQUESTS';
   protected tracerCaptureResponseVariable = 'POWERTOOLS_TRACER_CAPTURE_RESPONSE';
   protected tracingEnabledVariable = 'POWERTOOLS_TRACE_ENABLED';
 
   public abstract get(name: string): string;
+
+  public abstract getCaptureHTTPsRequests(): string;
 
   public abstract getServiceName(): string;
   

--- a/packages/tracing/src/config/ConfigServiceInterface.ts
+++ b/packages/tracing/src/config/ConfigServiceInterface.ts
@@ -2,6 +2,8 @@ interface ConfigServiceInterface {
 
   get(name: string): string
 
+  getCaptureHTTPsRequests(): string
+
   getTracingEnabled(): string
 
   getServiceName(): string

--- a/packages/tracing/src/config/EnvironmentVariablesService.ts
+++ b/packages/tracing/src/config/EnvironmentVariablesService.ts
@@ -15,6 +15,10 @@ class EnvironmentVariablesService extends ConfigService {
     return this.get(this.awsExecutionEnv);
   }
 
+  public getCaptureHTTPsRequests(): string {
+    return this.get(this.tracerCaptureHTTPsRequestsVariable);
+  }
+
   public getSamLocal(): string {
     return this.get(this.samLocalVariable);
   }

--- a/packages/tracing/src/provider/ProviderService.ts
+++ b/packages/tracing/src/provider/ProviderService.ts
@@ -1,7 +1,7 @@
 import { ContextMissingStrategy } from 'aws-xray-sdk-core/dist/lib/context_utils';
 import { Namespace } from 'cls-hooked';
 import { ProviderServiceInterface } from '.';
-import { captureAWS, captureAWSClient, captureAWSv3Client, captureAsyncFunc, captureFunc, getNamespace, getSegment, setSegment, Segment, Subsegment, setContextMissingStrategy, setDaemonAddress, setLogger, Logger } from 'aws-xray-sdk-core';
+import { captureAWS, captureAWSClient, captureAWSv3Client, captureAsyncFunc, captureFunc, captureHTTPsGlobal, getNamespace, getSegment, setSegment, Segment, Subsegment, setContextMissingStrategy, setDaemonAddress, setLogger, Logger, enableManualMode } from 'aws-xray-sdk-core';
 
 class ProviderService implements ProviderServiceInterface {
   
@@ -25,6 +25,13 @@ class ProviderService implements ProviderServiceInterface {
   
   public captureFunc(name: string, fcn: (subsegment?: Subsegment) => unknown, _parent?: Segment | Subsegment): unknown {
     return captureFunc(name, fcn);
+  }
+
+  public captureHTTPsGlobal(): void {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    captureHTTPsGlobal(require('http'));
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    captureHTTPsGlobal(require('https'));
   }
 
   public getNamespace(): Namespace {

--- a/packages/tracing/src/provider/ProviderService.ts
+++ b/packages/tracing/src/provider/ProviderService.ts
@@ -1,7 +1,7 @@
 import { ContextMissingStrategy } from 'aws-xray-sdk-core/dist/lib/context_utils';
 import { Namespace } from 'cls-hooked';
 import { ProviderServiceInterface } from '.';
-import { captureAWS, captureAWSClient, captureAWSv3Client, captureAsyncFunc, captureFunc, captureHTTPsGlobal, getNamespace, getSegment, setSegment, Segment, Subsegment, setContextMissingStrategy, setDaemonAddress, setLogger, Logger, enableManualMode } from 'aws-xray-sdk-core';
+import { captureAWS, captureAWSClient, captureAWSv3Client, captureAsyncFunc, captureFunc, captureHTTPsGlobal, getNamespace, getSegment, setSegment, Segment, Subsegment, setContextMissingStrategy, setDaemonAddress, setLogger, Logger } from 'aws-xray-sdk-core';
 
 class ProviderService implements ProviderServiceInterface {
   

--- a/packages/tracing/src/provider/ProviderServiceInterface.ts
+++ b/packages/tracing/src/provider/ProviderServiceInterface.ts
@@ -20,9 +20,11 @@ interface ProviderServiceInterface {
 
   captureAWSv3Client<T>(awsservice: T): T
 
+  captureAsyncFunc(name: string, fcn: (subsegment?: Subsegment) => unknown, parent?: Segment | Subsegment): unknown
+  
   captureFunc(name: string, fcn: (subsegment?: Subsegment) => unknown, parent?: Segment | Subsegment): unknown
 
-  captureAsyncFunc(name: string, fcn: (subsegment?: Subsegment) => unknown, parent?: Segment | Subsegment): unknown
+  captureHTTPsGlobal(): void
 }
 
 export {

--- a/packages/tracing/src/types/Tracer.ts
+++ b/packages/tracing/src/types/Tracer.ts
@@ -12,6 +12,7 @@ import { AsyncHandler, LambdaInterface, SyncHandler } from '@aws-lambda-powertoo
   * const tracerOptions: TracerOptions = {
   *   enabled?: true,
   *   serviceName?: 'serverlessAirline',
+  *   captureHTTPsRequests?: true,
   *   customConfigService?: customConfigService, // Only needed for advanced uses
   * };
   * 
@@ -21,6 +22,7 @@ import { AsyncHandler, LambdaInterface, SyncHandler } from '@aws-lambda-powertoo
 type TracerOptions = {
   enabled?: boolean
   serviceName?: string
+  captureHTTPsRequests?: boolean
   customConfigService?: ConfigServiceInterface
 };
 

--- a/packages/tracing/tests/e2e/tracer.test.Decorator.ts
+++ b/packages/tracing/tests/e2e/tracer.test.Decorator.ts
@@ -1,6 +1,7 @@
 import { Tracer } from '../../src';
 import { Callback, Context } from 'aws-lambda';
 import { DynamoDBClient, PutItemCommand } from '@aws-sdk/client-dynamodb';
+import axios from 'axios';
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 let AWS = require('aws-sdk');
 
@@ -54,6 +55,7 @@ export class MyFunctionWithDecorator {
     return Promise.all([
       dynamoDBv2.put({ TableName: testTableName, Item: { id: `${serviceName}-${event.invocation}-sdkv2` } }).promise(),
       dynamoDBv3.send(new PutItemCommand({ TableName: testTableName, Item: { id: { 'S': `${serviceName}-${event.invocation}-sdkv3` } } })),
+      axios.get('https://httpbin.org/status/200'),
       new Promise((resolve, reject) => {
         setTimeout(() => {
           const res = this.myMethod();
@@ -65,7 +67,7 @@ export class MyFunctionWithDecorator {
         }, 2000); // We need to wait for to make sure previous calls are finished
       })
     ])
-      .then(([ _dynamoDBv2Res, _dynamoDBv3Res, promiseRes ]) => promiseRes)
+      .then(([ _dynamoDBv2Res, _dynamoDBv3Res, _axiosRes, promiseRes ]) => promiseRes)
       .catch((err) => {
         throw err;
       });

--- a/packages/tracing/tests/e2e/tracer.test.Decorator.ts
+++ b/packages/tracing/tests/e2e/tracer.test.Decorator.ts
@@ -1,6 +1,7 @@
 import { Tracer } from '../../src';
 import { Callback, Context } from 'aws-lambda';
 import { DynamoDBClient, PutItemCommand } from '@aws-sdk/client-dynamodb';
+import axios from 'axios';
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 let AWS = require('aws-sdk');
 
@@ -54,6 +55,7 @@ export class MyFunctionWithDecorator {
     return Promise.all([
       dynamoDBv2.put({ TableName: testTableName, Item: { id: `${serviceName}-${event.invocation}-sdkv2` } }).promise(),
       dynamoDBv3.send(new PutItemCommand({ TableName: testTableName, Item: { id: { 'S': `${serviceName}-${event.invocation}-sdkv3` } } })),
+      axios.get('https://httpbin.org/status/200'),
       new Promise((resolve, reject) => {
         setTimeout(() => {
           const res = this.myMethod();

--- a/packages/tracing/tests/e2e/tracer.test.Decorator.ts
+++ b/packages/tracing/tests/e2e/tracer.test.Decorator.ts
@@ -1,7 +1,6 @@
 import { Tracer } from '../../src';
 import { Callback, Context } from 'aws-lambda';
 import { DynamoDBClient, PutItemCommand } from '@aws-sdk/client-dynamodb';
-import axios from 'axios';
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 let AWS = require('aws-sdk');
 
@@ -55,7 +54,6 @@ export class MyFunctionWithDecorator {
     return Promise.all([
       dynamoDBv2.put({ TableName: testTableName, Item: { id: `${serviceName}-${event.invocation}-sdkv2` } }).promise(),
       dynamoDBv3.send(new PutItemCommand({ TableName: testTableName, Item: { id: { 'S': `${serviceName}-${event.invocation}-sdkv3` } } })),
-      axios.get('https://httpbin.org/status/200'),
       new Promise((resolve, reject) => {
         setTimeout(() => {
           const res = this.myMethod();
@@ -64,10 +62,10 @@ export class MyFunctionWithDecorator {
           } else {
             resolve(res);
           }
-        }, 3000); // We need to wait to make sure previous calls are finished, we still want to see traces from them even when this throws
+        }, 2000); // We need to wait for to make sure previous calls are finished
       })
     ])
-      .then(([ _dynamoDBv2Res, _dynamoDBv3Res, _axiosRes, promiseRes ]) => promiseRes)
+      .then(([ _dynamoDBv2Res, _dynamoDBv3Res, promiseRes ]) => promiseRes)
       .catch((err) => {
         throw err;
       });

--- a/packages/tracing/tests/e2e/tracer.test.Decorator.ts
+++ b/packages/tracing/tests/e2e/tracer.test.Decorator.ts
@@ -64,10 +64,10 @@ export class MyFunctionWithDecorator {
           } else {
             resolve(res);
           }
-        }, 2000); // We need to wait for to make sure previous calls are finished
+        }, 3000); // We need to wait to make sure previous calls are finished, we still want to see traces from them even when this throws
       })
     ])
-      .then(([ _dynamoDBv2Res, _dynamoDBv3Res, promiseRes ]) => promiseRes)
+      .then(([ _dynamoDBv2Res, _dynamoDBv3Res, _axiosRes, promiseRes ]) => promiseRes)
       .catch((err) => {
         throw err;
       });

--- a/packages/tracing/tests/e2e/tracer.test.DecoratorWithAsyncHandler.ts
+++ b/packages/tracing/tests/e2e/tracer.test.DecoratorWithAsyncHandler.ts
@@ -1,7 +1,6 @@
 import { Tracer } from '../../src';
 import { Context } from 'aws-lambda';
 import { DynamoDBClient, PutItemCommand } from '@aws-sdk/client-dynamodb';
-import axios from 'axios';
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 let AWS = require('aws-sdk');
 
@@ -51,21 +50,30 @@ export class MyFunctionWithDecorator {
       AWS = tracer.captureAWS(AWS);
       dynamoDBv2 = new AWS.DynamoDB.DocumentClient();
     }
-    
+
     try {
       await dynamoDBv2.put({ TableName: testTableName, Item: { id: `${serviceName}-${event.invocation}-sdkv2` } }).promise();
-      await dynamoDBv3.send(new PutItemCommand({ TableName: testTableName, Item: { id: { 'S': `${serviceName}-${event.invocation}-sdkv3` } } }));
-      await axios.get('https://httpbin.org/status/200');
+    } catch (err) {
+      console.error(err);
+    }
 
-      const res = this.myMethod();
+    try {
+      await dynamoDBv3.send(new PutItemCommand({ TableName: testTableName, Item: { id: { 'S': `${serviceName}-${event.invocation}-sdkv3` } } }));
+    } catch (err) {
+      console.error(err);
+    }
+
+    let res;
+    try {
+      res = this.myMethod();
       if (event.throw) {
         throw new Error(customErrorMessage);
       }
-
-      return res;
     } catch (err) {
       throw err;
     }
+
+    return res;
   }
 
   @tracer.captureMethod()

--- a/packages/tracing/tests/e2e/tracer.test.DecoratorWithAsyncHandler.ts
+++ b/packages/tracing/tests/e2e/tracer.test.DecoratorWithAsyncHandler.ts
@@ -1,6 +1,7 @@
 import { Tracer } from '../../src';
 import { Context } from 'aws-lambda';
 import { DynamoDBClient, PutItemCommand } from '@aws-sdk/client-dynamodb';
+import axios from 'axios';
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 let AWS = require('aws-sdk');
 
@@ -50,30 +51,21 @@ export class MyFunctionWithDecorator {
       AWS = tracer.captureAWS(AWS);
       dynamoDBv2 = new AWS.DynamoDB.DocumentClient();
     }
-
+    
     try {
       await dynamoDBv2.put({ TableName: testTableName, Item: { id: `${serviceName}-${event.invocation}-sdkv2` } }).promise();
-    } catch (err) {
-      console.error(err);
-    }
-
-    try {
       await dynamoDBv3.send(new PutItemCommand({ TableName: testTableName, Item: { id: { 'S': `${serviceName}-${event.invocation}-sdkv3` } } }));
-    } catch (err) {
-      console.error(err);
-    }
+      await axios.get('https://httpbin.org/status/200');
 
-    let res;
-    try {
-      res = this.myMethod();
+      const res = this.myMethod();
       if (event.throw) {
         throw new Error(customErrorMessage);
       }
+
+      return res;
     } catch (err) {
       throw err;
     }
-
-    return res;
   }
 
   @tracer.captureMethod()

--- a/packages/tracing/tests/e2e/tracer.test.DecoratorWithAsyncHandler.ts
+++ b/packages/tracing/tests/e2e/tracer.test.DecoratorWithAsyncHandler.ts
@@ -53,27 +53,17 @@ export class MyFunctionWithDecorator {
 
     try {
       await dynamoDBv2.put({ TableName: testTableName, Item: { id: `${serviceName}-${event.invocation}-sdkv2` } }).promise();
-    } catch (err) {
-      console.error(err);
-    }
-
-    try {
       await dynamoDBv3.send(new PutItemCommand({ TableName: testTableName, Item: { id: { 'S': `${serviceName}-${event.invocation}-sdkv3` } } }));
-    } catch (err) {
-      console.error(err);
-    }
-
-    let res;
-    try {
-      res = this.myMethod();
+    
+      const res = this.myMethod();
       if (event.throw) {
         throw new Error(customErrorMessage);
       }
+
+      return res;
     } catch (err) {
       throw err;
     }
-
-    return res;
   }
 
   @tracer.captureMethod()

--- a/packages/tracing/tests/e2e/tracer.test.DecoratorWithAsyncHandler.ts
+++ b/packages/tracing/tests/e2e/tracer.test.DecoratorWithAsyncHandler.ts
@@ -1,6 +1,7 @@
 import { Tracer } from '../../src';
 import { Context } from 'aws-lambda';
 import { DynamoDBClient, PutItemCommand } from '@aws-sdk/client-dynamodb';
+import axios from 'axios';
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 let AWS = require('aws-sdk');
 
@@ -54,7 +55,8 @@ export class MyFunctionWithDecorator {
     try {
       await dynamoDBv2.put({ TableName: testTableName, Item: { id: `${serviceName}-${event.invocation}-sdkv2` } }).promise();
       await dynamoDBv3.send(new PutItemCommand({ TableName: testTableName, Item: { id: { 'S': `${serviceName}-${event.invocation}-sdkv3` } } }));
-    
+      await axios.get('https://httpbin.org/status/200');
+
       const res = this.myMethod();
       if (event.throw) {
         throw new Error(customErrorMessage);

--- a/packages/tracing/tests/e2e/tracer.test.Manual.ts
+++ b/packages/tracing/tests/e2e/tracer.test.Manual.ts
@@ -1,6 +1,7 @@
 import { Tracer } from '../../src';
 import { Context } from 'aws-lambda';
 import { DynamoDBClient, PutItemCommand } from '@aws-sdk/client-dynamodb';
+import axios from 'axios';
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 let AWS = require('aws-sdk');
 
@@ -57,7 +58,8 @@ export const handler = async (event: CustomEvent, _context: Context): Promise<vo
   try {
     await dynamoDBv2.put({ TableName: testTableName, Item: { id: `${serviceName}-${event.invocation}-sdkv2` } }).promise();
     await dynamoDBv3.send(new PutItemCommand({ TableName: testTableName, Item: { id: { 'S': `${serviceName}-${event.invocation}-sdkv3` } } }));
-    
+    await axios.get('https://httpbin.org/status/200');
+
     const res = customResponseValue;
     if (event.throw) {
       throw new Error(customErrorMessage);

--- a/packages/tracing/tests/e2e/tracer.test.Manual.ts
+++ b/packages/tracing/tests/e2e/tracer.test.Manual.ts
@@ -58,7 +58,8 @@ export const handler = async (event: CustomEvent, _context: Context): Promise<vo
   try {
     await dynamoDBv2.put({ TableName: testTableName, Item: { id: `${serviceName}-${event.invocation}-sdkv2` } }).promise();
     await dynamoDBv3.send(new PutItemCommand({ TableName: testTableName, Item: { id: { 'S': `${serviceName}-${event.invocation}-sdkv3` } } }));
-    await axios.get('https://httpbin.org/status/200');
+    const t = await axios.get('https://httpbin.org/status/200');
+    tracer.putAnnotation('httpbin', t.status);
 
     const res = customResponseValue;
     if (event.throw) {

--- a/packages/tracing/tests/e2e/tracer.test.Manual.ts
+++ b/packages/tracing/tests/e2e/tracer.test.Manual.ts
@@ -58,8 +58,7 @@ export const handler = async (event: CustomEvent, _context: Context): Promise<vo
   try {
     await dynamoDBv2.put({ TableName: testTableName, Item: { id: `${serviceName}-${event.invocation}-sdkv2` } }).promise();
     await dynamoDBv3.send(new PutItemCommand({ TableName: testTableName, Item: { id: { 'S': `${serviceName}-${event.invocation}-sdkv3` } } }));
-    const t = await axios.get('https://httpbin.org/status/200');
-    tracer.putAnnotation('httpbin', t.status);
+    await axios.get('https://httpbin.org/status/200');
 
     const res = customResponseValue;
     if (event.throw) {

--- a/packages/tracing/tests/e2e/tracer.test.Manual.ts
+++ b/packages/tracing/tests/e2e/tracer.test.Manual.ts
@@ -56,23 +56,15 @@ export const handler = async (event: CustomEvent, _context: Context): Promise<vo
   }
   try {
     await dynamoDBv2.put({ TableName: testTableName, Item: { id: `${serviceName}-${event.invocation}-sdkv2` } }).promise();
-  } catch (err) {
-    console.error(err);
-  }
-
-  try {
     await dynamoDBv3.send(new PutItemCommand({ TableName: testTableName, Item: { id: { 'S': `${serviceName}-${event.invocation}-sdkv3` } } }));
-  } catch (err) {
-    console.error(err);
-  }
-
-  let res;
-  try {
-    res = customResponseValue;
+    
+    const res = customResponseValue;
     if (event.throw) {
       throw new Error(customErrorMessage);
     }
     tracer.addResponseAsMetadata(res, process.env._HANDLER);
+
+    return res;
   } catch (err) {
     tracer.addErrorAsMetadata(err as Error);
     throw err;
@@ -80,6 +72,4 @@ export const handler = async (event: CustomEvent, _context: Context): Promise<vo
     subsegment.close();
     tracer.setSegment(segment);
   }
-
-  return res;
 };

--- a/packages/tracing/tests/e2e/tracer.test.Manual.ts
+++ b/packages/tracing/tests/e2e/tracer.test.Manual.ts
@@ -1,6 +1,7 @@
 import { Tracer } from '../../src';
 import { Context } from 'aws-lambda';
 import { DynamoDBClient, PutItemCommand } from '@aws-sdk/client-dynamodb';
+import axios from 'axios';
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 let AWS = require('aws-sdk');
 
@@ -54,25 +55,19 @@ export const handler = async (event: CustomEvent, _context: Context): Promise<vo
     AWS = tracer.captureAWS(AWS);
     dynamoDBv2 = new AWS.DynamoDB.DocumentClient();
   }
+
   try {
     await dynamoDBv2.put({ TableName: testTableName, Item: { id: `${serviceName}-${event.invocation}-sdkv2` } }).promise();
-  } catch (err) {
-    console.error(err);
-  }
-
-  try {
     await dynamoDBv3.send(new PutItemCommand({ TableName: testTableName, Item: { id: { 'S': `${serviceName}-${event.invocation}-sdkv3` } } }));
-  } catch (err) {
-    console.error(err);
-  }
+    await axios.get('https://httpbin.org/status/200');
 
-  let res;
-  try {
-    res = customResponseValue;
+    const res = customResponseValue;
     if (event.throw) {
       throw new Error(customErrorMessage);
     }
     tracer.addResponseAsMetadata(res, process.env._HANDLER);
+
+    return res;
   } catch (err) {
     tracer.addErrorAsMetadata(err as Error);
     throw err;
@@ -80,6 +75,4 @@ export const handler = async (event: CustomEvent, _context: Context): Promise<vo
     subsegment.close();
     tracer.setSegment(segment);
   }
-
-  return res;
 };

--- a/packages/tracing/tests/e2e/tracer.test.Middleware.ts
+++ b/packages/tracing/tests/e2e/tracer.test.Middleware.ts
@@ -2,6 +2,7 @@ import middy from '@middy/core';
 import { captureLambdaHandler, Tracer } from '../../src';
 import { Context } from 'aws-lambda';
 import { DynamoDBClient, PutItemCommand } from '@aws-sdk/client-dynamodb';
+import axios from 'axios';
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 let AWS = require('aws-sdk');
 
@@ -50,25 +51,16 @@ export const handler = middy(async (event: CustomEvent, _context: Context): Prom
   }
   try {
     await dynamoDBv2.put({ TableName: testTableName, Item: { id: `${serviceName}-${event.invocation}-sdkv2` } }).promise();
-  } catch (err) {
-    console.error(err);
-  }
-
-  try {
     await dynamoDBv3.send(new PutItemCommand({ TableName: testTableName, Item: { id: { 'S': `${serviceName}-${event.invocation}-sdkv3` } } }));
-  } catch (err) {
-    console.error(err);
-  }
+    await axios.get('https://httpbin.org/status/200');
 
-  let res;
-  try {
-    res = customResponseValue;
+    const res = customResponseValue;
     if (event.throw) {
       throw new Error(customErrorMessage);
     }
+
+    return res;
   } catch (err) {
     throw err;
   }
-
-  return res;
 }).use(captureLambdaHandler(tracer));

--- a/packages/tracing/tests/e2e/tracer.test.Middleware.ts
+++ b/packages/tracing/tests/e2e/tracer.test.Middleware.ts
@@ -2,6 +2,7 @@ import middy from '@middy/core';
 import { captureLambdaHandler, Tracer } from '../../src';
 import { Context } from 'aws-lambda';
 import { DynamoDBClient, PutItemCommand } from '@aws-sdk/client-dynamodb';
+import axios from 'axios';
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 let AWS = require('aws-sdk');
 
@@ -51,7 +52,8 @@ export const handler = middy(async (event: CustomEvent, _context: Context): Prom
   try {
     await dynamoDBv2.put({ TableName: testTableName, Item: { id: `${serviceName}-${event.invocation}-sdkv2` } }).promise();
     await dynamoDBv3.send(new PutItemCommand({ TableName: testTableName, Item: { id: { 'S': `${serviceName}-${event.invocation}-sdkv3` } } }));
-    
+    await axios.get('https://httpbin.org/status/200');
+
     const res = customResponseValue;
     if (event.throw) {
       throw new Error(customErrorMessage);

--- a/packages/tracing/tests/e2e/tracer.test.Middleware.ts
+++ b/packages/tracing/tests/e2e/tracer.test.Middleware.ts
@@ -2,7 +2,6 @@ import middy from '@middy/core';
 import { captureLambdaHandler, Tracer } from '../../src';
 import { Context } from 'aws-lambda';
 import { DynamoDBClient, PutItemCommand } from '@aws-sdk/client-dynamodb';
-import axios from 'axios';
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 let AWS = require('aws-sdk');
 
@@ -51,16 +50,25 @@ export const handler = middy(async (event: CustomEvent, _context: Context): Prom
   }
   try {
     await dynamoDBv2.put({ TableName: testTableName, Item: { id: `${serviceName}-${event.invocation}-sdkv2` } }).promise();
-    await dynamoDBv3.send(new PutItemCommand({ TableName: testTableName, Item: { id: { 'S': `${serviceName}-${event.invocation}-sdkv3` } } }));
-    await axios.get('https://httpbin.org/status/200');
+  } catch (err) {
+    console.error(err);
+  }
 
-    const res = customResponseValue;
+  try {
+    await dynamoDBv3.send(new PutItemCommand({ TableName: testTableName, Item: { id: { 'S': `${serviceName}-${event.invocation}-sdkv3` } } }));
+  } catch (err) {
+    console.error(err);
+  }
+
+  let res;
+  try {
+    res = customResponseValue;
     if (event.throw) {
       throw new Error(customErrorMessage);
     }
-
-    return res;
   } catch (err) {
     throw err;
   }
+
+  return res;
 }).use(captureLambdaHandler(tracer));

--- a/packages/tracing/tests/e2e/tracer.test.Middleware.ts
+++ b/packages/tracing/tests/e2e/tracer.test.Middleware.ts
@@ -50,25 +50,15 @@ export const handler = middy(async (event: CustomEvent, _context: Context): Prom
   }
   try {
     await dynamoDBv2.put({ TableName: testTableName, Item: { id: `${serviceName}-${event.invocation}-sdkv2` } }).promise();
-  } catch (err) {
-    console.error(err);
-  }
-
-  try {
     await dynamoDBv3.send(new PutItemCommand({ TableName: testTableName, Item: { id: { 'S': `${serviceName}-${event.invocation}-sdkv3` } } }));
-  } catch (err) {
-    console.error(err);
-  }
-
-  let res;
-  try {
-    res = customResponseValue;
+    
+    const res = customResponseValue;
     if (event.throw) {
       throw new Error(customErrorMessage);
     }
+
+    return res;
   } catch (err) {
     throw err;
   }
-
-  return res;
 }).use(captureLambdaHandler(tracer));

--- a/packages/tracing/tests/e2e/tracer.test.ts
+++ b/packages/tracing/tests/e2e/tracer.test.ts
@@ -141,7 +141,7 @@ describe('Tracer integration tests', () => {
 
     for (let i = 0; i < invocations; i++) {
       // Assert that the trace has the expected amount of segments
-      expect(sortedTraces[i].Segments.length).toBe(4);
+      expect(sortedTraces[i].Segments.length).toBe(5);
 
       const invocationSubsegment = getInvocationSubsegment(sortedTraces[i]);
 

--- a/packages/tracing/tests/e2e/tracer.test.ts
+++ b/packages/tracing/tests/e2e/tracer.test.ts
@@ -151,14 +151,13 @@ describe('Tracer integration tests', () => {
         // Assert that the subsegment name is the expected one
         expect(handlerSubsegment.name).toBe('## index.handler');
         if (handlerSubsegment?.subsegments !== undefined) {
-          // Assert that there're three subsegments
-          expect(handlerSubsegment?.subsegments?.length).toBe(3);
+          // Assert that there're two subsegments
+          expect(handlerSubsegment?.subsegments?.length).toBe(2);
 
-          const [ AWSSDKSubsegment1, AWSSDKSubsegment2, HTTPSegment ] = handlerSubsegment?.subsegments;
-          // Assert that the subsegment names are the expected ones
+          const [ AWSSDKSubsegment1, AWSSDKSubsegment2 ] = handlerSubsegment?.subsegments;
+          // Assert that the subsegment names is the expected ones
           expect(AWSSDKSubsegment1.name).toBe('DynamoDB');
           expect(AWSSDKSubsegment2.name).toBe('DynamoDB');
-          expect(HTTPSegment.name).toBe('httpbin.org');
           
           const { annotations, metadata } = handlerSubsegment;
 
@@ -199,7 +198,7 @@ describe('Tracer integration tests', () => {
       }
     }
 
-  }, ONE_MINUTE * 3);
+  }, ONE_MINUTE * 2);
 
   it('Verifies that a when Tracer is used as middleware all custom traces are generated with correct annotations and metadata', async () => {
     
@@ -223,13 +222,12 @@ describe('Tracer integration tests', () => {
         expect(handlerSubsegment.name).toBe('## index.handler');
         if (handlerSubsegment?.subsegments !== undefined) {
           // Assert that there're two subsegments
-          expect(handlerSubsegment?.subsegments?.length).toBe(3);
+          expect(handlerSubsegment?.subsegments?.length).toBe(2);
 
-          const [ AWSSDKSubsegment1, AWSSDKSubsegment2, HTTPSegment ] = handlerSubsegment?.subsegments;
-          // Assert that the subsegment names are the expected ones
+          const [ AWSSDKSubsegment1, AWSSDKSubsegment2 ] = handlerSubsegment?.subsegments;
+          // Assert that the subsegment names is the expected ones
           expect(AWSSDKSubsegment1.name).toBe('DynamoDB');
           expect(AWSSDKSubsegment2.name).toBe('DynamoDB');
-          expect(HTTPSegment.name).toBe('httpbin.org');
           
           const { annotations, metadata } = handlerSubsegment;
 
@@ -270,7 +268,7 @@ describe('Tracer integration tests', () => {
       }
     }
 
-  }, ONE_MINUTE * 3);
+  }, ONE_MINUTE * 2);
 
   it('Verifies that a when Tracer is used as middleware, with errors & response capturing disabled, all custom traces are generated with correct annotations', async () => {
     
@@ -294,13 +292,12 @@ describe('Tracer integration tests', () => {
         expect(handlerSubsegment.name).toBe('## index.handler');
         if (handlerSubsegment?.subsegments !== undefined) {
           // Assert that there're two subsegments
-          expect(handlerSubsegment?.subsegments?.length).toBe(3);
+          expect(handlerSubsegment?.subsegments?.length).toBe(2);
 
-          const [ AWSSDKSubsegment1, AWSSDKSubsegment2, HTTPSegment ] = handlerSubsegment?.subsegments;
-          // Assert that the subsegment names are the expected ones
+          const [ AWSSDKSubsegment1, AWSSDKSubsegment2 ] = handlerSubsegment?.subsegments;
+          // Assert that the subsegment names is the expected ones
           expect(AWSSDKSubsegment1.name).toBe('DynamoDB');
           expect(AWSSDKSubsegment2.name).toBe('DynamoDB');
-          expect(HTTPSegment.name).toBe('httpbin.org');
           
           const { annotations, metadata } = handlerSubsegment;
 
@@ -340,7 +337,7 @@ describe('Tracer integration tests', () => {
       }
     }
 
-  }, ONE_MINUTE * 3);
+  }, ONE_MINUTE * 2);
 
   it('Verifies that a when tracing is disabled in middleware mode no custom traces are generated', async () => {
     
@@ -357,14 +354,14 @@ describe('Tracer integration tests', () => {
       const invocationSubsegment = getInvocationSubsegment(sortedTraces[i]);
 
       expect(invocationSubsegment?.subsegments).toBeUndefined();
-         
+        
       if (i === invocations - 1) {
         // Assert that the subsegment has the expected fault
         expect(invocationSubsegment.error).toBe(true);
       }
     }
 
-  }, ONE_MINUTE * 3);
+  }, ONE_MINUTE * 2);
 
   it('Verifies that a when Tracer is used as decorator all custom traces are generated with correct annotations and metadata', async () => {
     
@@ -387,21 +384,18 @@ describe('Tracer integration tests', () => {
         // Assert that the subsegment name is the expected one
         expect(handlerSubsegment.name).toBe('## index.handler');
         if (handlerSubsegment?.subsegments !== undefined) {
-          // Assert that there're four subsegments
-          expect(handlerSubsegment?.subsegments?.length).toBe(4);
+          // Assert that there're three subsegments
+          expect(handlerSubsegment?.subsegments?.length).toBe(3);
           
           // Sort the subsegments by name
           const dynamoDBSubsegments: ParsedDocument[] = [];
           const methodSubsegment: ParsedDocument[] = [];
-          const httpSubsegment: ParsedDocument[] = [];
           const otherSegments: ParsedDocument[] = [];
           handlerSubsegment?.subsegments.forEach(subsegment => {
             if (subsegment.name === 'DynamoDB') {
               dynamoDBSubsegments.push(subsegment);
             } else if (subsegment.name === '### myMethod') {
               methodSubsegment.push(subsegment);
-            } else if (subsegment.name === 'httpbin.org') {
-              httpSubsegment.push(subsegment);
             } else {
               otherSegments.push(subsegment);
             }
@@ -410,8 +404,6 @@ describe('Tracer integration tests', () => {
           expect(dynamoDBSubsegments.length).toBe(2);
           // Assert that there is exactly one subsegment with the name '### myMethod'
           expect(methodSubsegment.length).toBe(1);
-          // Assert that there is exactly one subsegment with the name 'httpbin.org'
-          expect(httpSubsegment.length).toBe(1);
           // Assert that there are exactly zero other subsegments
           expect(otherSegments.length).toBe(0);
 
@@ -466,7 +458,7 @@ describe('Tracer integration tests', () => {
       }
     }
 
-  }, ONE_MINUTE * 3);
+  }, ONE_MINUTE * 2);
 
   it('Verifies that a when Tracer is used as decorator on an async handler all custom traces are generated with correct annotations and metadata', async () => {
     
@@ -489,21 +481,18 @@ describe('Tracer integration tests', () => {
         // Assert that the subsegment name is the expected one
         expect(handlerSubsegment.name).toBe('## index.handler');
         if (handlerSubsegment?.subsegments !== undefined) {
-          // Assert that there're four subsegments
-          expect(handlerSubsegment?.subsegments?.length).toBe(4);
+          // Assert that there're three subsegments
+          expect(handlerSubsegment?.subsegments?.length).toBe(3);
           
           // Sort the subsegments by name
           const dynamoDBSubsegments: ParsedDocument[] = [];
           const methodSubsegment: ParsedDocument[] = [];
-          const httpSubsegment: ParsedDocument[] = [];
           const otherSegments: ParsedDocument[] = [];
           handlerSubsegment?.subsegments.forEach(subsegment => {
             if (subsegment.name === 'DynamoDB') {
               dynamoDBSubsegments.push(subsegment);
             } else if (subsegment.name === '### myMethod') {
               methodSubsegment.push(subsegment);
-            } else if (subsegment.name === 'httpbin.org') {
-              httpSubsegment.push(subsegment);
             } else {
               otherSegments.push(subsegment);
             }
@@ -512,8 +501,6 @@ describe('Tracer integration tests', () => {
           expect(dynamoDBSubsegments.length).toBe(2);
           // Assert that there is exactly one subsegment with the name '### myMethod'
           expect(methodSubsegment.length).toBe(1);
-          // Assert that there is exactly one subsegment with the name 'httpbin.org'
-          expect(httpSubsegment.length).toBe(1);
           // Assert that there are exactly zero other subsegments
           expect(otherSegments.length).toBe(0);
 
@@ -568,7 +555,7 @@ describe('Tracer integration tests', () => {
       }
     }
 
-  }, ONE_MINUTE * 3);
+  }, ONE_MINUTE * 2);
 
   it('Verifies that a when Tracer is used as decorator, with errors & response capturing disabled, all custom traces are generated with correct annotations', async () => {
     
@@ -591,21 +578,18 @@ describe('Tracer integration tests', () => {
         // Assert that the subsegment name is the expected one
         expect(handlerSubsegment.name).toBe('## index.handler');
         if (handlerSubsegment?.subsegments !== undefined) {
-          // Assert that there're four subsegments
-          expect(handlerSubsegment?.subsegments?.length).toBe(4);
+          // Assert that there're three subsegments
+          expect(handlerSubsegment?.subsegments?.length).toBe(3);
           
           // Sort the subsegments by name
           const dynamoDBSubsegments: ParsedDocument[] = [];
           const methodSubsegment: ParsedDocument[] = [];
-          const httpSubsegment: ParsedDocument[] = [];
           const otherSegments: ParsedDocument[] = [];
           handlerSubsegment?.subsegments.forEach(subsegment => {
             if (subsegment.name === 'DynamoDB') {
               dynamoDBSubsegments.push(subsegment);
             } else if (subsegment.name === '### myMethod') {
               methodSubsegment.push(subsegment);
-            } else if (subsegment.name === 'httpbin.org') {
-              httpSubsegment.push(subsegment);
             } else {
               otherSegments.push(subsegment);
             }
@@ -614,8 +598,6 @@ describe('Tracer integration tests', () => {
           expect(dynamoDBSubsegments.length).toBe(2);
           // Assert that there is exactly one subsegment with the name '### myMethod'
           expect(methodSubsegment.length).toBe(1);
-          // Assert that there is exactly one subsegment with the name 'httpbin.org'
-          expect(httpSubsegment.length).toBe(1);
           // Assert that there are exactly zero other subsegments
           expect(otherSegments.length).toBe(0);
           // Assert that no response was captured on the subsegment
@@ -659,7 +641,7 @@ describe('Tracer integration tests', () => {
       }
     }
 
-  }, ONE_MINUTE * 3);
+  }, ONE_MINUTE * 2);
 
   it('Verifies that a when tracing is disabled in decorator mode no custom traces are generated', async () => {
     
@@ -676,13 +658,13 @@ describe('Tracer integration tests', () => {
       const invocationSubsegment = getInvocationSubsegment(sortedTraces[i]);
 
       expect(invocationSubsegment?.subsegments).toBeUndefined();
-         
+        
       if (i === invocations - 1) {
         // Assert that the subsegment has the expected fault
         expect(invocationSubsegment.error).toBe(true);
       }
     }
 
-  }, ONE_MINUTE * 3);
+  }, ONE_MINUTE * 2);
 
 });

--- a/packages/tracing/tests/e2e/tracer.test.ts
+++ b/packages/tracing/tests/e2e/tracer.test.ts
@@ -152,7 +152,7 @@ describe('Tracer integration tests', () => {
         expect(handlerSubsegment.name).toBe('## index.handler');
         if (handlerSubsegment?.subsegments !== undefined) {
           // Assert that there are three subsegments
-          expect(handlerSubsegment?.subsegments?.length).toBe(2);
+          expect(handlerSubsegment?.subsegments?.length).toBe(3);
 
           const [ AWSSDKSubsegment1, AWSSDKSubsegment2, HTTPSegment ] = handlerSubsegment?.subsegments;
           // Assert that the subsegment names are the expected ones
@@ -208,11 +208,11 @@ describe('Tracer integration tests', () => {
 
     // Assess
     // Retrieve traces from X-Ray using Resource ARN as filter
-    const sortedTraces = await getTraces(xray, startTime, resourceArn, invocations, 4);
+    const sortedTraces = await getTraces(xray, startTime, resourceArn, invocations, 5);
 
     for (let i = 0; i < invocations; i++) {
       // Assert that the trace has the expected amount of segments
-      expect(sortedTraces[i].Segments.length).toBe(4);
+      expect(sortedTraces[i].Segments.length).toBe(5);
 
       const invocationSubsegment = getInvocationSubsegment(sortedTraces[i]);
 
@@ -223,12 +223,13 @@ describe('Tracer integration tests', () => {
         expect(handlerSubsegment.name).toBe('## index.handler');
         if (handlerSubsegment?.subsegments !== undefined) {
           // Assert that there're two subsegments
-          expect(handlerSubsegment?.subsegments?.length).toBe(2);
+          expect(handlerSubsegment?.subsegments?.length).toBe(3);
 
-          const [ AWSSDKSubsegment1, AWSSDKSubsegment2 ] = handlerSubsegment?.subsegments;
+          const [ AWSSDKSubsegment1, AWSSDKSubsegment2, HTTPSegment ] = handlerSubsegment?.subsegments;
           // Assert that the subsegment names is the expected ones
           expect(AWSSDKSubsegment1.name).toBe('DynamoDB');
           expect(AWSSDKSubsegment2.name).toBe('DynamoDB');
+          expect(HTTPSegment.name).toBe('httpbin.org');
           
           const { annotations, metadata } = handlerSubsegment;
 
@@ -278,11 +279,11 @@ describe('Tracer integration tests', () => {
 
     // Assess
     // Retrieve traces from X-Ray using Resource ARN as filter
-    const sortedTraces = await getTraces(xray, startTime, resourceArn, invocations, 4);
+    const sortedTraces = await getTraces(xray, startTime, resourceArn, invocations, 5);
 
     for (let i = 0; i < invocations; i++) {
       // Assert that the trace has the expected amount of segments
-      expect(sortedTraces[i].Segments.length).toBe(4);
+      expect(sortedTraces[i].Segments.length).toBe(5);
 
       const invocationSubsegment = getInvocationSubsegment(sortedTraces[i]);
 
@@ -293,12 +294,13 @@ describe('Tracer integration tests', () => {
         expect(handlerSubsegment.name).toBe('## index.handler');
         if (handlerSubsegment?.subsegments !== undefined) {
           // Assert that there're two subsegments
-          expect(handlerSubsegment?.subsegments?.length).toBe(2);
+          expect(handlerSubsegment?.subsegments?.length).toBe(3);
 
-          const [ AWSSDKSubsegment1, AWSSDKSubsegment2 ] = handlerSubsegment?.subsegments;
-          // Assert that the subsegment names is the expected ones
+          const [ AWSSDKSubsegment1, AWSSDKSubsegment2, HTTPSegment ] = handlerSubsegment?.subsegments;
+          // Assert that the subsegment names are the expected ones
           expect(AWSSDKSubsegment1.name).toBe('DynamoDB');
           expect(AWSSDKSubsegment2.name).toBe('DynamoDB');
+          expect(HTTPSegment.name).toBe('httpbin.org');
           
           const { annotations, metadata } = handlerSubsegment;
 
@@ -371,11 +373,11 @@ describe('Tracer integration tests', () => {
     
     // Assess
     // Retrieve traces from X-Ray using Resource ARN as filter
-    const sortedTraces = await getTraces(xray, startTime, resourceArn, invocations, 4);
+    const sortedTraces = await getTraces(xray, startTime, resourceArn, invocations, 5);
 
     for (let i = 0; i < invocations; i++) {
       // Assert that the trace has the expected amount of segments
-      expect(sortedTraces[i].Segments.length).toBe(4);
+      expect(sortedTraces[i].Segments.length).toBe(5);
 
       const invocationSubsegment = getInvocationSubsegment(sortedTraces[i]);
 
@@ -386,17 +388,20 @@ describe('Tracer integration tests', () => {
         expect(handlerSubsegment.name).toBe('## index.handler');
         if (handlerSubsegment?.subsegments !== undefined) {
           // Assert that there're three subsegments
-          expect(handlerSubsegment?.subsegments?.length).toBe(3);
+          expect(handlerSubsegment?.subsegments?.length).toBe(4);
           
           // Sort the subsegments by name
           const dynamoDBSubsegments: ParsedDocument[] = [];
           const methodSubsegment: ParsedDocument[] = [];
+          const httpSubsegment: ParsedDocument[] = [];
           const otherSegments: ParsedDocument[] = [];
           handlerSubsegment?.subsegments.forEach(subsegment => {
             if (subsegment.name === 'DynamoDB') {
               dynamoDBSubsegments.push(subsegment);
             } else if (subsegment.name === '### myMethod') {
               methodSubsegment.push(subsegment);
+            } else if (subsegment.name === 'httpbin.org') {
+              httpSubsegment.push(subsegment);
             } else {
               otherSegments.push(subsegment);
             }
@@ -405,6 +410,8 @@ describe('Tracer integration tests', () => {
           expect(dynamoDBSubsegments.length).toBe(2);
           // Assert that there is exactly one subsegment with the name '### myMethod'
           expect(methodSubsegment.length).toBe(1);
+          // Assert that there is exactly one subsegment with the name 'httpbin.org'
+          expect(httpSubsegment.length).toBe(1);
           // Assert that there are exactly zero other subsegments
           expect(otherSegments.length).toBe(0);
 
@@ -468,11 +475,11 @@ describe('Tracer integration tests', () => {
     
     // Assess
     // Retrieve traces from X-Ray using Resource ARN as filter
-    const sortedTraces = await getTraces(xray, startTime, resourceArn, invocations, 4);
+    const sortedTraces = await getTraces(xray, startTime, resourceArn, invocations, 5);
 
     for (let i = 0; i < invocations; i++) {
       // Assert that the trace has the expected amount of segments
-      expect(sortedTraces[i].Segments.length).toBe(4);
+      expect(sortedTraces[i].Segments.length).toBe(5);
 
       const invocationSubsegment = getInvocationSubsegment(sortedTraces[i]);
 
@@ -483,17 +490,20 @@ describe('Tracer integration tests', () => {
         expect(handlerSubsegment.name).toBe('## index.handler');
         if (handlerSubsegment?.subsegments !== undefined) {
           // Assert that there're three subsegments
-          expect(handlerSubsegment?.subsegments?.length).toBe(3);
+          expect(handlerSubsegment?.subsegments?.length).toBe(4);
           
           // Sort the subsegments by name
           const dynamoDBSubsegments: ParsedDocument[] = [];
           const methodSubsegment: ParsedDocument[] = [];
+          const httpSubsegment: ParsedDocument[] = [];
           const otherSegments: ParsedDocument[] = [];
           handlerSubsegment?.subsegments.forEach(subsegment => {
             if (subsegment.name === 'DynamoDB') {
               dynamoDBSubsegments.push(subsegment);
             } else if (subsegment.name === '### myMethod') {
               methodSubsegment.push(subsegment);
+            } else if (subsegment.name === 'httpbin.org') {
+              httpSubsegment.push(subsegment);
             } else {
               otherSegments.push(subsegment);
             }
@@ -502,6 +512,8 @@ describe('Tracer integration tests', () => {
           expect(dynamoDBSubsegments.length).toBe(2);
           // Assert that there is exactly one subsegment with the name '### myMethod'
           expect(methodSubsegment.length).toBe(1);
+          // Assert that there is exactly one subsegment with the name 'httpbin.org'
+          expect(httpSubsegment.length).toBe(1);
           // Assert that there are exactly zero other subsegments
           expect(otherSegments.length).toBe(0);
 
@@ -565,11 +577,11 @@ describe('Tracer integration tests', () => {
     
     // Assess
     // Retrieve traces from X-Ray using Resource ARN as filter
-    const sortedTraces = await getTraces(xray, startTime, resourceArn, invocations, 4);
+    const sortedTraces = await getTraces(xray, startTime, resourceArn, invocations, 5);
 
     for (let i = 0; i < invocations; i++) {
       // Assert that the trace has the expected amount of segments
-      expect(sortedTraces[i].Segments.length).toBe(4);
+      expect(sortedTraces[i].Segments.length).toBe(5);
 
       const invocationSubsegment = getInvocationSubsegment(sortedTraces[i]);
 
@@ -580,17 +592,20 @@ describe('Tracer integration tests', () => {
         expect(handlerSubsegment.name).toBe('## index.handler');
         if (handlerSubsegment?.subsegments !== undefined) {
           // Assert that there're three subsegments
-          expect(handlerSubsegment?.subsegments?.length).toBe(3);
+          expect(handlerSubsegment?.subsegments?.length).toBe(5);
           
           // Sort the subsegments by name
           const dynamoDBSubsegments: ParsedDocument[] = [];
           const methodSubsegment: ParsedDocument[] = [];
+          const httpSubsegment: ParsedDocument[] = [];
           const otherSegments: ParsedDocument[] = [];
           handlerSubsegment?.subsegments.forEach(subsegment => {
             if (subsegment.name === 'DynamoDB') {
               dynamoDBSubsegments.push(subsegment);
             } else if (subsegment.name === '### myMethod') {
               methodSubsegment.push(subsegment);
+            } else if (subsegment.name === 'httpbin.org') {
+              httpSubsegment.push(subsegment);
             } else {
               otherSegments.push(subsegment);
             }
@@ -599,6 +614,8 @@ describe('Tracer integration tests', () => {
           expect(dynamoDBSubsegments.length).toBe(2);
           // Assert that there is exactly one subsegment with the name '### myMethod'
           expect(methodSubsegment.length).toBe(1);
+          // Assert that there is exactly one subsegment with the name 'httpbin.org'
+          expect(httpSubsegment.length).toBe(1);
           // Assert that there are exactly zero other subsegments
           expect(otherSegments.length).toBe(0);
           // Assert that no response was captured on the subsegment

--- a/packages/tracing/tests/e2e/tracer.test.ts
+++ b/packages/tracing/tests/e2e/tracer.test.ts
@@ -199,7 +199,7 @@ describe('Tracer integration tests', () => {
       }
     }
 
-  }, ONE_MINUTE * 4);
+  }, ONE_MINUTE * 3);
 
   it('Verifies that a when Tracer is used as middleware all custom traces are generated with correct annotations and metadata', async () => {
     
@@ -270,7 +270,7 @@ describe('Tracer integration tests', () => {
       }
     }
 
-  }, ONE_MINUTE * 4);
+  }, ONE_MINUTE * 3);
 
   it('Verifies that a when Tracer is used as middleware, with errors & response capturing disabled, all custom traces are generated with correct annotations', async () => {
     
@@ -340,7 +340,7 @@ describe('Tracer integration tests', () => {
       }
     }
 
-  }, ONE_MINUTE * 4);
+  }, ONE_MINUTE * 3);
 
   it('Verifies that a when tracing is disabled in middleware mode no custom traces are generated', async () => {
     
@@ -364,7 +364,7 @@ describe('Tracer integration tests', () => {
       }
     }
 
-  }, ONE_MINUTE * 4);
+  }, ONE_MINUTE * 3);
 
   it('Verifies that a when Tracer is used as decorator all custom traces are generated with correct annotations and metadata', async () => {
     
@@ -466,7 +466,7 @@ describe('Tracer integration tests', () => {
       }
     }
 
-  }, ONE_MINUTE * 4);
+  }, ONE_MINUTE * 3);
 
   it('Verifies that a when Tracer is used as decorator on an async handler all custom traces are generated with correct annotations and metadata', async () => {
     
@@ -568,7 +568,7 @@ describe('Tracer integration tests', () => {
       }
     }
 
-  }, ONE_MINUTE * 4);
+  }, ONE_MINUTE * 3);
 
   it('Verifies that a when Tracer is used as decorator, with errors & response capturing disabled, all custom traces are generated with correct annotations', async () => {
     
@@ -659,7 +659,7 @@ describe('Tracer integration tests', () => {
       }
     }
 
-  }, ONE_MINUTE * 4);
+  }, ONE_MINUTE * 3);
 
   it('Verifies that a when tracing is disabled in decorator mode no custom traces are generated', async () => {
     
@@ -683,6 +683,6 @@ describe('Tracer integration tests', () => {
       }
     }
 
-  }, ONE_MINUTE * 4);
+  }, ONE_MINUTE * 3);
 
 });

--- a/packages/tracing/tests/e2e/tracer.test.ts
+++ b/packages/tracing/tests/e2e/tracer.test.ts
@@ -91,6 +91,9 @@ describe('Tracer integration tests', () => {
           TEST_TABLE_NAME: table.tableName,
         },
         timeout: Duration.seconds(30),
+        bundling: {
+          externalModules: ['aws-sdk'],
+        }
       });
       table.grantWriteData(fn);
       invocationsMap[functionName] = {
@@ -195,7 +198,7 @@ describe('Tracer integration tests', () => {
       }
     }
 
-  }, ONE_MINUTE * 3);
+  }, ONE_MINUTE * 4);
 
   it('Verifies that a when Tracer is used as middleware all custom traces are generated with correct annotations and metadata', async () => {
     
@@ -265,7 +268,7 @@ describe('Tracer integration tests', () => {
       }
     }
 
-  }, ONE_MINUTE * 3);
+  }, ONE_MINUTE * 4);
 
   it('Verifies that a when Tracer is used as middleware, with errors & response capturing disabled, all custom traces are generated with correct annotations', async () => {
     
@@ -334,7 +337,7 @@ describe('Tracer integration tests', () => {
       }
     }
 
-  }, ONE_MINUTE * 3);
+  }, ONE_MINUTE * 4);
 
   it('Verifies that a when tracing is disabled in middleware mode no custom traces are generated', async () => {
     
@@ -358,7 +361,7 @@ describe('Tracer integration tests', () => {
       }
     }
 
-  }, ONE_MINUTE * 3);
+  }, ONE_MINUTE * 4);
 
   it('Verifies that a when Tracer is used as decorator all custom traces are generated with correct annotations and metadata', async () => {
     
@@ -455,7 +458,7 @@ describe('Tracer integration tests', () => {
       }
     }
 
-  }, ONE_MINUTE * 3);
+  }, ONE_MINUTE * 4);
 
   it('Verifies that a when Tracer is used as decorator on an async handler all custom traces are generated with correct annotations and metadata', async () => {
     
@@ -552,7 +555,7 @@ describe('Tracer integration tests', () => {
       }
     }
 
-  }, ONE_MINUTE * 3);
+  }, ONE_MINUTE * 4);
 
   it('Verifies that a when Tracer is used as decorator, with errors & response capturing disabled, all custom traces are generated with correct annotations', async () => {
     
@@ -638,7 +641,7 @@ describe('Tracer integration tests', () => {
       }
     }
 
-  }, ONE_MINUTE * 3);
+  }, ONE_MINUTE * 4);
 
   it('Verifies that a when tracing is disabled in decorator mode no custom traces are generated', async () => {
     
@@ -662,6 +665,6 @@ describe('Tracer integration tests', () => {
       }
     }
 
-  }, ONE_MINUTE * 3);
+  }, ONE_MINUTE * 4);
 
 });

--- a/packages/tracing/tests/e2e/tracer.test.ts
+++ b/packages/tracing/tests/e2e/tracer.test.ts
@@ -151,13 +151,14 @@ describe('Tracer integration tests', () => {
         // Assert that the subsegment name is the expected one
         expect(handlerSubsegment.name).toBe('## index.handler');
         if (handlerSubsegment?.subsegments !== undefined) {
-          // Assert that there're two subsegments
-          expect(handlerSubsegment?.subsegments?.length).toBe(2);
+          // Assert that there are three subsegments
+          expect(handlerSubsegment?.subsegments?.length).toBe(3);
 
-          const [ AWSSDKSubsegment1, AWSSDKSubsegment2 ] = handlerSubsegment?.subsegments;
-          // Assert that the subsegment names is the expected ones
+          const [ AWSSDKSubsegment1, AWSSDKSubsegment2, HTTPSegment ] = handlerSubsegment?.subsegments;
+          // Assert that the subsegment names are the expected ones
           expect(AWSSDKSubsegment1.name).toBe('DynamoDB');
           expect(AWSSDKSubsegment2.name).toBe('DynamoDB');
+          expect(HTTPSegment.name).toBe('httpbin.org');
           
           const { annotations, metadata } = handlerSubsegment;
 

--- a/packages/tracing/tests/e2e/tracer.test.ts
+++ b/packages/tracing/tests/e2e/tracer.test.ts
@@ -195,7 +195,7 @@ describe('Tracer integration tests', () => {
       }
     }
 
-  }, ONE_MINUTE * 2);
+  }, ONE_MINUTE * 3);
 
   it('Verifies that a when Tracer is used as middleware all custom traces are generated with correct annotations and metadata', async () => {
     
@@ -265,7 +265,7 @@ describe('Tracer integration tests', () => {
       }
     }
 
-  }, ONE_MINUTE * 2);
+  }, ONE_MINUTE * 3);
 
   it('Verifies that a when Tracer is used as middleware, with errors & response capturing disabled, all custom traces are generated with correct annotations', async () => {
     
@@ -334,7 +334,7 @@ describe('Tracer integration tests', () => {
       }
     }
 
-  }, ONE_MINUTE * 2);
+  }, ONE_MINUTE * 3);
 
   it('Verifies that a when tracing is disabled in middleware mode no custom traces are generated', async () => {
     
@@ -358,7 +358,7 @@ describe('Tracer integration tests', () => {
       }
     }
 
-  }, ONE_MINUTE * 2);
+  }, ONE_MINUTE * 3);
 
   it('Verifies that a when Tracer is used as decorator all custom traces are generated with correct annotations and metadata', async () => {
     
@@ -455,7 +455,7 @@ describe('Tracer integration tests', () => {
       }
     }
 
-  }, ONE_MINUTE * 2);
+  }, ONE_MINUTE * 3);
 
   it('Verifies that a when Tracer is used as decorator on an async handler all custom traces are generated with correct annotations and metadata', async () => {
     
@@ -552,7 +552,7 @@ describe('Tracer integration tests', () => {
       }
     }
 
-  }, ONE_MINUTE * 2);
+  }, ONE_MINUTE * 3);
 
   it('Verifies that a when Tracer is used as decorator, with errors & response capturing disabled, all custom traces are generated with correct annotations', async () => {
     
@@ -638,7 +638,7 @@ describe('Tracer integration tests', () => {
       }
     }
 
-  }, ONE_MINUTE * 2);
+  }, ONE_MINUTE * 3);
 
   it('Verifies that a when tracing is disabled in decorator mode no custom traces are generated', async () => {
     
@@ -662,6 +662,6 @@ describe('Tracer integration tests', () => {
       }
     }
 
-  }, ONE_MINUTE * 2);
+  }, ONE_MINUTE * 3);
 
 });

--- a/packages/tracing/tests/e2e/tracer.test.ts
+++ b/packages/tracing/tests/e2e/tracer.test.ts
@@ -154,11 +154,25 @@ describe('Tracer integration tests', () => {
           // Assert that there are three subsegments
           expect(handlerSubsegment?.subsegments?.length).toBe(3);
 
-          const [ AWSSDKSubsegment1, AWSSDKSubsegment2, HTTPSegment ] = handlerSubsegment?.subsegments;
-          // Assert that the subsegment names are the expected ones
-          expect(AWSSDKSubsegment1.name).toBe('DynamoDB');
-          expect(AWSSDKSubsegment2.name).toBe('DynamoDB');
-          expect(HTTPSegment.name).toBe('httpbin.org');
+          // Sort the subsegments by name
+          const dynamoDBSubsegments: ParsedDocument[] = [];
+          const httpSubsegment: ParsedDocument[] = [];
+          const otherSegments: ParsedDocument[] = [];
+          handlerSubsegment?.subsegments.forEach(subsegment => {
+            if (subsegment.name === 'DynamoDB') {
+              dynamoDBSubsegments.push(subsegment);
+            } else if (subsegment.name === 'httpbin.org') {
+              httpSubsegment.push(subsegment);
+            } else {
+              otherSegments.push(subsegment);
+            }
+          });
+          // Assert that there are exactly two subsegment with the name 'DynamoDB'
+          expect(dynamoDBSubsegments.length).toBe(2);
+          // Assert that there is exactly one subsegment with the name 'httpbin.org'
+          expect(httpSubsegment.length).toBe(1);
+          // Assert that there are exactly zero other subsegments
+          expect(otherSegments.length).toBe(0);
           
           const { annotations, metadata } = handlerSubsegment;
 
@@ -225,11 +239,25 @@ describe('Tracer integration tests', () => {
           // Assert that there're two subsegments
           expect(handlerSubsegment?.subsegments?.length).toBe(3);
 
-          const [ AWSSDKSubsegment1, AWSSDKSubsegment2, HTTPSegment ] = handlerSubsegment?.subsegments;
-          // Assert that the subsegment names is the expected ones
-          expect(AWSSDKSubsegment1.name).toBe('DynamoDB');
-          expect(AWSSDKSubsegment2.name).toBe('DynamoDB');
-          expect(HTTPSegment.name).toBe('httpbin.org');
+          // Sort the subsegments by name
+          const dynamoDBSubsegments: ParsedDocument[] = [];
+          const httpSubsegment: ParsedDocument[] = [];
+          const otherSegments: ParsedDocument[] = [];
+          handlerSubsegment?.subsegments.forEach(subsegment => {
+            if (subsegment.name === 'DynamoDB') {
+              dynamoDBSubsegments.push(subsegment);
+            } else if (subsegment.name === 'httpbin.org') {
+              httpSubsegment.push(subsegment);
+            } else {
+              otherSegments.push(subsegment);
+            }
+          });
+          // Assert that there are exactly two subsegment with the name 'DynamoDB'
+          expect(dynamoDBSubsegments.length).toBe(2);
+          // Assert that there is exactly one subsegment with the name 'httpbin.org'
+          expect(httpSubsegment.length).toBe(1);
+          // Assert that there are exactly zero other subsegments
+          expect(otherSegments.length).toBe(0);
           
           const { annotations, metadata } = handlerSubsegment;
 
@@ -296,11 +324,25 @@ describe('Tracer integration tests', () => {
           // Assert that there're two subsegments
           expect(handlerSubsegment?.subsegments?.length).toBe(3);
 
-          const [ AWSSDKSubsegment1, AWSSDKSubsegment2, HTTPSegment ] = handlerSubsegment?.subsegments;
-          // Assert that the subsegment names are the expected ones
-          expect(AWSSDKSubsegment1.name).toBe('DynamoDB');
-          expect(AWSSDKSubsegment2.name).toBe('DynamoDB');
-          expect(HTTPSegment.name).toBe('httpbin.org');
+          // Sort the subsegments by name
+          const dynamoDBSubsegments: ParsedDocument[] = [];
+          const httpSubsegment: ParsedDocument[] = [];
+          const otherSegments: ParsedDocument[] = [];
+          handlerSubsegment?.subsegments.forEach(subsegment => {
+            if (subsegment.name === 'DynamoDB') {
+              dynamoDBSubsegments.push(subsegment);
+            } else if (subsegment.name === 'httpbin.org') {
+              httpSubsegment.push(subsegment);
+            } else {
+              otherSegments.push(subsegment);
+            }
+          });
+          // Assert that there are exactly two subsegment with the name 'DynamoDB'
+          expect(dynamoDBSubsegments.length).toBe(2);
+          // Assert that there is exactly one subsegment with the name 'httpbin.org'
+          expect(httpSubsegment.length).toBe(1);
+          // Assert that there are exactly zero other subsegments
+          expect(otherSegments.length).toBe(0);
           
           const { annotations, metadata } = handlerSubsegment;
 
@@ -387,7 +429,7 @@ describe('Tracer integration tests', () => {
         // Assert that the subsegment name is the expected one
         expect(handlerSubsegment.name).toBe('## index.handler');
         if (handlerSubsegment?.subsegments !== undefined) {
-          // Assert that there're three subsegments
+          // Assert that there are four subsegments
           expect(handlerSubsegment?.subsegments?.length).toBe(4);
           
           // Sort the subsegments by name
@@ -489,7 +531,7 @@ describe('Tracer integration tests', () => {
         // Assert that the subsegment name is the expected one
         expect(handlerSubsegment.name).toBe('## index.handler');
         if (handlerSubsegment?.subsegments !== undefined) {
-          // Assert that there're three subsegments
+          // Assert that there are four subsegments
           expect(handlerSubsegment?.subsegments?.length).toBe(4);
           
           // Sort the subsegments by name
@@ -591,8 +633,8 @@ describe('Tracer integration tests', () => {
         // Assert that the subsegment name is the expected one
         expect(handlerSubsegment.name).toBe('## index.handler');
         if (handlerSubsegment?.subsegments !== undefined) {
-          // Assert that there're three subsegments
-          expect(handlerSubsegment?.subsegments?.length).toBe(5);
+          // Assert that there are four subsegments
+          expect(handlerSubsegment?.subsegments?.length).toBe(4);
           
           // Sort the subsegments by name
           const dynamoDBSubsegments: ParsedDocument[] = [];

--- a/packages/tracing/tests/e2e/tracer.test.ts
+++ b/packages/tracing/tests/e2e/tracer.test.ts
@@ -151,13 +151,14 @@ describe('Tracer integration tests', () => {
         // Assert that the subsegment name is the expected one
         expect(handlerSubsegment.name).toBe('## index.handler');
         if (handlerSubsegment?.subsegments !== undefined) {
-          // Assert that there're two subsegments
-          expect(handlerSubsegment?.subsegments?.length).toBe(2);
+          // Assert that there're three subsegments
+          expect(handlerSubsegment?.subsegments?.length).toBe(3);
 
-          const [ AWSSDKSubsegment1, AWSSDKSubsegment2 ] = handlerSubsegment?.subsegments;
-          // Assert that the subsegment names is the expected ones
+          const [ AWSSDKSubsegment1, AWSSDKSubsegment2, HTTPSegment ] = handlerSubsegment?.subsegments;
+          // Assert that the subsegment names are the expected ones
           expect(AWSSDKSubsegment1.name).toBe('DynamoDB');
           expect(AWSSDKSubsegment2.name).toBe('DynamoDB');
+          expect(HTTPSegment.name).toBe('httpbin.org');
           
           const { annotations, metadata } = handlerSubsegment;
 
@@ -222,12 +223,13 @@ describe('Tracer integration tests', () => {
         expect(handlerSubsegment.name).toBe('## index.handler');
         if (handlerSubsegment?.subsegments !== undefined) {
           // Assert that there're two subsegments
-          expect(handlerSubsegment?.subsegments?.length).toBe(2);
+          expect(handlerSubsegment?.subsegments?.length).toBe(3);
 
-          const [ AWSSDKSubsegment1, AWSSDKSubsegment2 ] = handlerSubsegment?.subsegments;
-          // Assert that the subsegment names is the expected ones
+          const [ AWSSDKSubsegment1, AWSSDKSubsegment2, HTTPSegment ] = handlerSubsegment?.subsegments;
+          // Assert that the subsegment names are the expected ones
           expect(AWSSDKSubsegment1.name).toBe('DynamoDB');
           expect(AWSSDKSubsegment2.name).toBe('DynamoDB');
+          expect(HTTPSegment.name).toBe('httpbin.org');
           
           const { annotations, metadata } = handlerSubsegment;
 
@@ -292,12 +294,13 @@ describe('Tracer integration tests', () => {
         expect(handlerSubsegment.name).toBe('## index.handler');
         if (handlerSubsegment?.subsegments !== undefined) {
           // Assert that there're two subsegments
-          expect(handlerSubsegment?.subsegments?.length).toBe(2);
+          expect(handlerSubsegment?.subsegments?.length).toBe(3);
 
-          const [ AWSSDKSubsegment1, AWSSDKSubsegment2 ] = handlerSubsegment?.subsegments;
-          // Assert that the subsegment names is the expected ones
+          const [ AWSSDKSubsegment1, AWSSDKSubsegment2, HTTPSegment ] = handlerSubsegment?.subsegments;
+          // Assert that the subsegment names are the expected ones
           expect(AWSSDKSubsegment1.name).toBe('DynamoDB');
           expect(AWSSDKSubsegment2.name).toBe('DynamoDB');
+          expect(HTTPSegment.name).toBe('httpbin.org');
           
           const { annotations, metadata } = handlerSubsegment;
 
@@ -384,18 +387,21 @@ describe('Tracer integration tests', () => {
         // Assert that the subsegment name is the expected one
         expect(handlerSubsegment.name).toBe('## index.handler');
         if (handlerSubsegment?.subsegments !== undefined) {
-          // Assert that there're three subsegments
-          expect(handlerSubsegment?.subsegments?.length).toBe(3);
+          // Assert that there're four subsegments
+          expect(handlerSubsegment?.subsegments?.length).toBe(4);
           
           // Sort the subsegments by name
           const dynamoDBSubsegments: ParsedDocument[] = [];
           const methodSubsegment: ParsedDocument[] = [];
+          const httpSubsegment: ParsedDocument[] = [];
           const otherSegments: ParsedDocument[] = [];
           handlerSubsegment?.subsegments.forEach(subsegment => {
             if (subsegment.name === 'DynamoDB') {
               dynamoDBSubsegments.push(subsegment);
             } else if (subsegment.name === '### myMethod') {
               methodSubsegment.push(subsegment);
+            } else if (subsegment.name === 'httpbin.org') {
+              httpSubsegment.push(subsegment);
             } else {
               otherSegments.push(subsegment);
             }
@@ -404,6 +410,8 @@ describe('Tracer integration tests', () => {
           expect(dynamoDBSubsegments.length).toBe(2);
           // Assert that there is exactly one subsegment with the name '### myMethod'
           expect(methodSubsegment.length).toBe(1);
+          // Assert that there is exactly one subsegment with the name 'httpbin.org'
+          expect(httpSubsegment.length).toBe(1);
           // Assert that there are exactly zero other subsegments
           expect(otherSegments.length).toBe(0);
 
@@ -481,18 +489,21 @@ describe('Tracer integration tests', () => {
         // Assert that the subsegment name is the expected one
         expect(handlerSubsegment.name).toBe('## index.handler');
         if (handlerSubsegment?.subsegments !== undefined) {
-          // Assert that there're three subsegments
-          expect(handlerSubsegment?.subsegments?.length).toBe(3);
+          // Assert that there're four subsegments
+          expect(handlerSubsegment?.subsegments?.length).toBe(4);
           
           // Sort the subsegments by name
           const dynamoDBSubsegments: ParsedDocument[] = [];
           const methodSubsegment: ParsedDocument[] = [];
+          const httpSubsegment: ParsedDocument[] = [];
           const otherSegments: ParsedDocument[] = [];
           handlerSubsegment?.subsegments.forEach(subsegment => {
             if (subsegment.name === 'DynamoDB') {
               dynamoDBSubsegments.push(subsegment);
             } else if (subsegment.name === '### myMethod') {
               methodSubsegment.push(subsegment);
+            } else if (subsegment.name === 'httpbin.org') {
+              httpSubsegment.push(subsegment);
             } else {
               otherSegments.push(subsegment);
             }
@@ -501,6 +512,8 @@ describe('Tracer integration tests', () => {
           expect(dynamoDBSubsegments.length).toBe(2);
           // Assert that there is exactly one subsegment with the name '### myMethod'
           expect(methodSubsegment.length).toBe(1);
+          // Assert that there is exactly one subsegment with the name 'httpbin.org'
+          expect(httpSubsegment.length).toBe(1);
           // Assert that there are exactly zero other subsegments
           expect(otherSegments.length).toBe(0);
 
@@ -578,18 +591,21 @@ describe('Tracer integration tests', () => {
         // Assert that the subsegment name is the expected one
         expect(handlerSubsegment.name).toBe('## index.handler');
         if (handlerSubsegment?.subsegments !== undefined) {
-          // Assert that there're three subsegments
-          expect(handlerSubsegment?.subsegments?.length).toBe(3);
+          // Assert that there're four subsegments
+          expect(handlerSubsegment?.subsegments?.length).toBe(4);
           
           // Sort the subsegments by name
           const dynamoDBSubsegments: ParsedDocument[] = [];
           const methodSubsegment: ParsedDocument[] = [];
+          const httpSubsegment: ParsedDocument[] = [];
           const otherSegments: ParsedDocument[] = [];
           handlerSubsegment?.subsegments.forEach(subsegment => {
             if (subsegment.name === 'DynamoDB') {
               dynamoDBSubsegments.push(subsegment);
             } else if (subsegment.name === '### myMethod') {
               methodSubsegment.push(subsegment);
+            } else if (subsegment.name === 'httpbin.org') {
+              httpSubsegment.push(subsegment);
             } else {
               otherSegments.push(subsegment);
             }
@@ -598,6 +614,8 @@ describe('Tracer integration tests', () => {
           expect(dynamoDBSubsegments.length).toBe(2);
           // Assert that there is exactly one subsegment with the name '### myMethod'
           expect(methodSubsegment.length).toBe(1);
+          // Assert that there is exactly one subsegment with the name 'httpbin.org'
+          expect(httpSubsegment.length).toBe(1);
           // Assert that there are exactly zero other subsegments
           expect(otherSegments.length).toBe(0);
           // Assert that no response was captured on the subsegment

--- a/packages/tracing/tests/e2e/tracer.test.ts
+++ b/packages/tracing/tests/e2e/tracer.test.ts
@@ -12,8 +12,7 @@ import { Table, AttributeType, BillingMode } from 'aws-cdk-lib/aws-dynamodb';
 import { App, Duration, Stack, RemovalPolicy } from 'aws-cdk-lib';
 import { deployStack, destroyStack } from '../../../commons/tests/utils/cdk-cli';
 import * as AWS from 'aws-sdk';
-import { getTraces, getInvocationSubsegment } from '../helpers/tracesUtils';
-import type { ParsedDocument } from '../helpers/tracesUtils';
+import { getTraces, getInvocationSubsegment, splitSegmentsByName } from '../helpers/tracesUtils';
 
 const xray = new AWS.XRay();
 const lambdaClient = new AWS.Lambda();
@@ -140,39 +139,26 @@ describe('Tracer integration tests', () => {
     const sortedTraces = await getTraces(xray, startTime, resourceArn, invocations, 5);
 
     for (let i = 0; i < invocations; i++) {
-      // Assert that the trace has the expected amount of segments
       expect(sortedTraces[i].Segments.length).toBe(5);
 
       const invocationSubsegment = getInvocationSubsegment(sortedTraces[i]);
 
       if (invocationSubsegment?.subsegments !== undefined) {
         expect(invocationSubsegment?.subsegments?.length).toBe(1);
+        
         const handlerSubsegment = invocationSubsegment?.subsegments[0];
-        // Assert that the subsegment name is the expected one
         expect(handlerSubsegment.name).toBe('## index.handler');
+        
         if (handlerSubsegment?.subsegments !== undefined) {
-          // Assert that there are three subsegments
           expect(handlerSubsegment?.subsegments?.length).toBe(3);
 
-          // Sort the subsegments by name
-          const dynamoDBSubsegments: ParsedDocument[] = [];
-          const httpSubsegment: ParsedDocument[] = [];
-          const otherSegments: ParsedDocument[] = [];
-          handlerSubsegment?.subsegments.forEach(subsegment => {
-            if (subsegment.name === 'DynamoDB') {
-              dynamoDBSubsegments.push(subsegment);
-            } else if (subsegment.name === 'httpbin.org') {
-              httpSubsegment.push(subsegment);
-            } else {
-              otherSegments.push(subsegment);
-            }
-          });
+          const subsegments = splitSegmentsByName(handlerSubsegment.subsegments, [ 'DynamoDB', 'httpbin.org' ]);
           // Assert that there are exactly two subsegment with the name 'DynamoDB'
-          expect(dynamoDBSubsegments.length).toBe(2);
+          expect(subsegments.get('DynamoDB')?.length).toBe(2);
           // Assert that there is exactly one subsegment with the name 'httpbin.org'
-          expect(httpSubsegment.length).toBe(1);
+          expect(subsegments.get('httpbin.org')?.length).toBe(1);
           // Assert that there are exactly zero other subsegments
-          expect(otherSegments.length).toBe(0);
+          expect(subsegments.get('other')?.length).toBe(0);
           
           const { annotations, metadata } = handlerSubsegment;
 
@@ -232,32 +218,20 @@ describe('Tracer integration tests', () => {
 
       if (invocationSubsegment?.subsegments !== undefined) {
         expect(invocationSubsegment?.subsegments?.length).toBe(1);
+        
         const handlerSubsegment = invocationSubsegment?.subsegments[0];
-        // Assert that the subsegment name is the expected one
         expect(handlerSubsegment.name).toBe('## index.handler');
+        
         if (handlerSubsegment?.subsegments !== undefined) {
-          // Assert that there're two subsegments
           expect(handlerSubsegment?.subsegments?.length).toBe(3);
 
-          // Sort the subsegments by name
-          const dynamoDBSubsegments: ParsedDocument[] = [];
-          const httpSubsegment: ParsedDocument[] = [];
-          const otherSegments: ParsedDocument[] = [];
-          handlerSubsegment?.subsegments.forEach(subsegment => {
-            if (subsegment.name === 'DynamoDB') {
-              dynamoDBSubsegments.push(subsegment);
-            } else if (subsegment.name === 'httpbin.org') {
-              httpSubsegment.push(subsegment);
-            } else {
-              otherSegments.push(subsegment);
-            }
-          });
+          const subsegments = splitSegmentsByName(handlerSubsegment.subsegments, [ 'DynamoDB', 'httpbin.org' ]);
           // Assert that there are exactly two subsegment with the name 'DynamoDB'
-          expect(dynamoDBSubsegments.length).toBe(2);
+          expect(subsegments.get('DynamoDB')?.length).toBe(2);
           // Assert that there is exactly one subsegment with the name 'httpbin.org'
-          expect(httpSubsegment.length).toBe(1);
+          expect(subsegments.get('httpbin.org')?.length).toBe(1);
           // Assert that there are exactly zero other subsegments
-          expect(otherSegments.length).toBe(0);
+          expect(subsegments.get('other')?.length).toBe(0);
           
           const { annotations, metadata } = handlerSubsegment;
 
@@ -317,32 +291,20 @@ describe('Tracer integration tests', () => {
 
       if (invocationSubsegment?.subsegments !== undefined) {
         expect(invocationSubsegment?.subsegments?.length).toBe(1);
+        
         const handlerSubsegment = invocationSubsegment?.subsegments[0];
-        // Assert that the subsegment name is the expected one
         expect(handlerSubsegment.name).toBe('## index.handler');
+        
         if (handlerSubsegment?.subsegments !== undefined) {
-          // Assert that there're two subsegments
           expect(handlerSubsegment?.subsegments?.length).toBe(3);
 
-          // Sort the subsegments by name
-          const dynamoDBSubsegments: ParsedDocument[] = [];
-          const httpSubsegment: ParsedDocument[] = [];
-          const otherSegments: ParsedDocument[] = [];
-          handlerSubsegment?.subsegments.forEach(subsegment => {
-            if (subsegment.name === 'DynamoDB') {
-              dynamoDBSubsegments.push(subsegment);
-            } else if (subsegment.name === 'httpbin.org') {
-              httpSubsegment.push(subsegment);
-            } else {
-              otherSegments.push(subsegment);
-            }
-          });
+          const subsegments = splitSegmentsByName(handlerSubsegment.subsegments, [ 'DynamoDB', 'httpbin.org' ]);
           // Assert that there are exactly two subsegment with the name 'DynamoDB'
-          expect(dynamoDBSubsegments.length).toBe(2);
+          expect(subsegments.get('DynamoDB')?.length).toBe(2);
           // Assert that there is exactly one subsegment with the name 'httpbin.org'
-          expect(httpSubsegment.length).toBe(1);
+          expect(subsegments.get('httpbin.org')?.length).toBe(1);
           // Assert that there are exactly zero other subsegments
-          expect(otherSegments.length).toBe(0);
+          expect(subsegments.get('other')?.length).toBe(0);
           
           const { annotations, metadata } = handlerSubsegment;
 
@@ -425,38 +387,24 @@ describe('Tracer integration tests', () => {
 
       if (invocationSubsegment?.subsegments !== undefined) {
         expect(invocationSubsegment?.subsegments?.length).toBe(1);
+        
         const handlerSubsegment = invocationSubsegment?.subsegments[0];
-        // Assert that the subsegment name is the expected one
         expect(handlerSubsegment.name).toBe('## index.handler');
+        
         if (handlerSubsegment?.subsegments !== undefined) {
-          // Assert that there are four subsegments
           expect(handlerSubsegment?.subsegments?.length).toBe(4);
           
-          // Sort the subsegments by name
-          const dynamoDBSubsegments: ParsedDocument[] = [];
-          const methodSubsegment: ParsedDocument[] = [];
-          const httpSubsegment: ParsedDocument[] = [];
-          const otherSegments: ParsedDocument[] = [];
-          handlerSubsegment?.subsegments.forEach(subsegment => {
-            if (subsegment.name === 'DynamoDB') {
-              dynamoDBSubsegments.push(subsegment);
-            } else if (subsegment.name === '### myMethod') {
-              methodSubsegment.push(subsegment);
-            } else if (subsegment.name === 'httpbin.org') {
-              httpSubsegment.push(subsegment);
-            } else {
-              otherSegments.push(subsegment);
-            }
-          });
+          const subsegments = splitSegmentsByName(handlerSubsegment.subsegments, [ 'DynamoDB', 'httpbin.org', '### myMethod' ]);
           // Assert that there are exactly two subsegment with the name 'DynamoDB'
-          expect(dynamoDBSubsegments.length).toBe(2);
-          // Assert that there is exactly one subsegment with the name '### myMethod'
-          expect(methodSubsegment.length).toBe(1);
+          expect(subsegments.get('DynamoDB')?.length).toBe(2);
           // Assert that there is exactly one subsegment with the name 'httpbin.org'
-          expect(httpSubsegment.length).toBe(1);
+          expect(subsegments.get('httpbin.org')?.length).toBe(1);
+          // Assert that there is exactly one subsegment with the name '### myMethod'
+          expect(subsegments.get('### myMethod')?.length).toBe(1);
           // Assert that there are exactly zero other subsegments
-          expect(otherSegments.length).toBe(0);
+          expect(subsegments.get('other')?.length).toBe(0);
 
+          const methodSubsegment = subsegments.get('### myMethod') || [];
           const { metadata } = methodSubsegment[0];
 
           if (metadata !== undefined) {
@@ -527,38 +475,24 @@ describe('Tracer integration tests', () => {
 
       if (invocationSubsegment?.subsegments !== undefined) {
         expect(invocationSubsegment?.subsegments?.length).toBe(1);
+        
         const handlerSubsegment = invocationSubsegment?.subsegments[0];
-        // Assert that the subsegment name is the expected one
         expect(handlerSubsegment.name).toBe('## index.handler');
+        
         if (handlerSubsegment?.subsegments !== undefined) {
-          // Assert that there are four subsegments
           expect(handlerSubsegment?.subsegments?.length).toBe(4);
           
-          // Sort the subsegments by name
-          const dynamoDBSubsegments: ParsedDocument[] = [];
-          const methodSubsegment: ParsedDocument[] = [];
-          const httpSubsegment: ParsedDocument[] = [];
-          const otherSegments: ParsedDocument[] = [];
-          handlerSubsegment?.subsegments.forEach(subsegment => {
-            if (subsegment.name === 'DynamoDB') {
-              dynamoDBSubsegments.push(subsegment);
-            } else if (subsegment.name === '### myMethod') {
-              methodSubsegment.push(subsegment);
-            } else if (subsegment.name === 'httpbin.org') {
-              httpSubsegment.push(subsegment);
-            } else {
-              otherSegments.push(subsegment);
-            }
-          });
+          const subsegments = splitSegmentsByName(handlerSubsegment.subsegments, [ 'DynamoDB', 'httpbin.org', '### myMethod' ]);
           // Assert that there are exactly two subsegment with the name 'DynamoDB'
-          expect(dynamoDBSubsegments.length).toBe(2);
-          // Assert that there is exactly one subsegment with the name '### myMethod'
-          expect(methodSubsegment.length).toBe(1);
+          expect(subsegments.get('DynamoDB')?.length).toBe(2);
           // Assert that there is exactly one subsegment with the name 'httpbin.org'
-          expect(httpSubsegment.length).toBe(1);
+          expect(subsegments.get('httpbin.org')?.length).toBe(1);
+          // Assert that there is exactly one subsegment with the name '### myMethod'
+          expect(subsegments.get('### myMethod')?.length).toBe(1);
           // Assert that there are exactly zero other subsegments
-          expect(otherSegments.length).toBe(0);
+          expect(subsegments.get('other')?.length).toBe(0);
 
+          const methodSubsegment = subsegments.get('### myMethod') || [];
           const { metadata } = methodSubsegment[0];
 
           if (metadata !== undefined) {
@@ -629,38 +563,25 @@ describe('Tracer integration tests', () => {
 
       if (invocationSubsegment?.subsegments !== undefined) {
         expect(invocationSubsegment?.subsegments?.length).toBe(1);
+        
         const handlerSubsegment = invocationSubsegment?.subsegments[0];
-        // Assert that the subsegment name is the expected one
         expect(handlerSubsegment.name).toBe('## index.handler');
+        
         if (handlerSubsegment?.subsegments !== undefined) {
-          // Assert that there are four subsegments
           expect(handlerSubsegment?.subsegments?.length).toBe(4);
           
-          // Sort the subsegments by name
-          const dynamoDBSubsegments: ParsedDocument[] = [];
-          const methodSubsegment: ParsedDocument[] = [];
-          const httpSubsegment: ParsedDocument[] = [];
-          const otherSegments: ParsedDocument[] = [];
-          handlerSubsegment?.subsegments.forEach(subsegment => {
-            if (subsegment.name === 'DynamoDB') {
-              dynamoDBSubsegments.push(subsegment);
-            } else if (subsegment.name === '### myMethod') {
-              methodSubsegment.push(subsegment);
-            } else if (subsegment.name === 'httpbin.org') {
-              httpSubsegment.push(subsegment);
-            } else {
-              otherSegments.push(subsegment);
-            }
-          });
+          const subsegments = splitSegmentsByName(handlerSubsegment.subsegments, [ 'DynamoDB', 'httpbin.org', '### myMethod' ]);
           // Assert that there are exactly two subsegment with the name 'DynamoDB'
-          expect(dynamoDBSubsegments.length).toBe(2);
-          // Assert that there is exactly one subsegment with the name '### myMethod'
-          expect(methodSubsegment.length).toBe(1);
+          expect(subsegments.get('DynamoDB')?.length).toBe(2);
           // Assert that there is exactly one subsegment with the name 'httpbin.org'
-          expect(httpSubsegment.length).toBe(1);
+          expect(subsegments.get('httpbin.org')?.length).toBe(1);
+          // Assert that there is exactly one subsegment with the name '### myMethod'
+          expect(subsegments.get('### myMethod')?.length).toBe(1);
           // Assert that there are exactly zero other subsegments
-          expect(otherSegments.length).toBe(0);
+          expect(subsegments.get('other')?.length).toBe(0);
+
           // Assert that no response was captured on the subsegment
+          const methodSubsegment = subsegments.get('### myMethod') || [];
           expect(methodSubsegment[0].hasOwnProperty('metadata')).toBe(false);
         } else {
           // Make test fail if the handlerSubsegment subsegment doesn't have any subsebment

--- a/packages/tracing/tests/e2e/tracer.test.ts
+++ b/packages/tracing/tests/e2e/tracer.test.ts
@@ -137,7 +137,7 @@ describe('Tracer integration tests', () => {
     
     // Assess
     // Retrieve traces from X-Ray using Resource ARN as filter
-    const sortedTraces = await getTraces(xray, startTime, resourceArn, invocations, 4);
+    const sortedTraces = await getTraces(xray, startTime, resourceArn, invocations, 5);
 
     for (let i = 0; i < invocations; i++) {
       // Assert that the trace has the expected amount of segments
@@ -152,7 +152,7 @@ describe('Tracer integration tests', () => {
         expect(handlerSubsegment.name).toBe('## index.handler');
         if (handlerSubsegment?.subsegments !== undefined) {
           // Assert that there are three subsegments
-          expect(handlerSubsegment?.subsegments?.length).toBe(3);
+          expect(handlerSubsegment?.subsegments?.length).toBe(2);
 
           const [ AWSSDKSubsegment1, AWSSDKSubsegment2, HTTPSegment ] = handlerSubsegment?.subsegments;
           // Assert that the subsegment names are the expected ones

--- a/packages/tracing/tests/helpers/tracesUtils.ts
+++ b/packages/tracing/tests/helpers/tracesUtils.ts
@@ -135,10 +135,23 @@ const getInvocationSubsegment = (trace: ParsedTrace): ParsedDocument => {
   return invocationSubsegment;
 };
 
+const splitSegmentsByName = (subsegments: ParsedDocument[], expectedNames: string[]): Map<string, ParsedDocument[]> => {
+  const splitSegments: Map<string, ParsedDocument[]> = new Map([ ...expectedNames, 'other' ].map(name => [ name, [] ]));
+  subsegments.forEach(subsegment => {
+    const name = expectedNames.indexOf(subsegment.name) !== -1 ? subsegment.name : 'other';
+    const newSegments = splitSegments.get(name) as ParsedDocument[];
+    newSegments.push(subsegment);
+    splitSegments.set(name, newSegments);
+  });
+  
+  return splitSegments;
+};
+
 export {
   getTraces,
   getFunctionSegment,
   getInvocationSubsegment,
+  splitSegmentsByName
 };
 
 export type {

--- a/packages/tracing/tests/unit/ProviderService.test.ts
+++ b/packages/tracing/tests/unit/ProviderService.test.ts
@@ -5,13 +5,16 @@
  */
 
 import { ProviderService } from '../../src/provider';
-import { captureAWS, captureAWSClient, captureAWSv3Client, captureAsyncFunc, captureFunc, getNamespace, getSegment, setContextMissingStrategy, setDaemonAddress, setLogger, setSegment, Subsegment } from 'aws-xray-sdk-core';
+import { captureAWS, captureAWSClient, captureAWSv3Client, captureAsyncFunc, captureHTTPsGlobal, captureFunc, getNamespace, getSegment, setContextMissingStrategy, setDaemonAddress, setLogger, setSegment, Subsegment } from 'aws-xray-sdk-core';
+import http from 'http';
+import https from 'https';
 
 jest.mock('aws-xray-sdk-core', () => ({
   captureAWS: jest.fn(),
   captureAWSClient: jest.fn(),
   captureAWSv3Client: jest.fn(),
   captureAsyncFunc: jest.fn(),
+  captureHTTPsGlobal: jest.fn(),
   captureFunc: jest.fn(),
   getNamespace: jest.fn(),
   getSegment: jest.fn(),
@@ -94,6 +97,25 @@ describe('Class: ProviderService', () => {
       // Assess
       expect(captureAsyncFunc).toHaveBeenCalledTimes(1);
       expect(captureAsyncFunc).toHaveBeenCalledWith('my-func', expect.anything());
+    
+    });
+    
+  });
+
+  describe('Method: captureHTTPsGlobal', () => {
+
+    test('when called, it forwards the correct parameter, and call the correct function, twice', () => {
+    
+      // Prepare
+      const provider: ProviderService = new ProviderService();
+    
+      // Act
+      provider.captureHTTPsGlobal();
+    
+      // Assess
+      expect(captureHTTPsGlobal).toHaveBeenCalledTimes(2);
+      expect(captureHTTPsGlobal).toHaveBeenNthCalledWith(1, http);
+      expect(captureHTTPsGlobal).toHaveBeenNthCalledWith(2, https);
     
     });
     

--- a/packages/tracing/tests/unit/ProviderService.test.ts
+++ b/packages/tracing/tests/unit/ProviderService.test.ts
@@ -104,7 +104,7 @@ describe('Class: ProviderService', () => {
 
   describe('Method: captureHTTPsGlobal', () => {
 
-    test('when called, it forwards the correct parameter, and call the correct function, twice', () => {
+    test('when called, it forwards the correct parameter and calls the correct function, twice', () => {
     
       // Prepare
       const provider: ProviderService = new ProviderService();

--- a/packages/tracing/tests/unit/Tracer.test.ts
+++ b/packages/tracing/tests/unit/Tracer.test.ts
@@ -1102,4 +1102,5 @@ describe('Class: Tracer', () => {
     });
 
   });
+
 });

--- a/packages/tracing/tests/unit/config/EnvironmentVariablesService.test.ts
+++ b/packages/tracing/tests/unit/config/EnvironmentVariablesService.test.ts
@@ -102,6 +102,23 @@ describe('Class: EnvironmentVariablesService', () => {
 
   });
 
+  describe('Method: getCaptureHTTPsRequests', () => {
+
+    test('It returns the value of the environment variable POWERTOOLS_TRACER_CAPTURE_HTTPS_REQUESTS', () => {
+
+      // Prepare
+      process.env.POWERTOOLS_TRACER_CAPTURE_HTTPS_REQUESTS = 'false';
+      const service = new EnvironmentVariablesService();
+
+      // Act
+      const value = service.getCaptureHTTPsRequests();
+
+      // Assess
+      expect(value).toEqual('false');
+    });
+
+  });
+
   describe('Method: getServiceName', () => {
 
     test('It returns the value of the environment variable POWERTOOLS_SERVICE_NAME', () => {


### PR DESCRIPTION
## Description of your changes

This PR introduces a new feature for Tracer that allows to trace, by default, all outgoing HTTP(s) requests:
- Customers can opt-out from this feature by setting the `POWERTOOLS_TRACER_CAPTURE_HTTPS_REQUESTS` environment variable or `captureHTTPsRequests` constructor parameter to false when instantiating the Tracer
- The feature relies on `aws-xray-sdk` ability to instrument the standard library's `http` and `https` modules, as Tracer should be able to trace any 3rd party request client library that is built upon these two modules. Support to 3rd party HTTP clients is provided on a best effort basis (this disclaimer is specified in the documentation). `axios` has been tested during development and is included in integration tests.
- Documentation and JSDocs updated
- The feature is implemented without exposing any new API on Tracer and directly on the Tracer instance, as such no changes to decorator and middleware implementation has been made
- Unit tests implemented
- Integration tests implemented
- Minor housekeeping changes (mostly formatting)

### How to verify this change

See checks passing on this PR, see integration test results ([link](https://github.com/awslabs/aws-lambda-powertools-typescript/runs/5669680344?check_suite_focus=true))

Screenshots of the new section in the documentation:
![image](https://user-images.githubusercontent.com/7353869/159504583-56dffe8c-2a34-4b93-9373-e778e8ba8767.png)

Documentation changes also include the addition of the new config to the Utility Settings section:
![image](https://user-images.githubusercontent.com/7353869/159504725-502b4939-5953-4266-913b-7cbe62329013.png)

Screenshots of traces & service map generated by running this build & using `axios`:
![Screenshot 2022-03-22 at 14 37 02](https://user-images.githubusercontent.com/7353869/159502965-da8f881c-ae51-43d9-8de7-26db66d7ce3b.png)
![Screenshot 2022-03-22 at 14 36 45](https://user-images.githubusercontent.com/7353869/159503003-fec16635-0d9a-4a1f-8648-556c2913454b.png)


### Related issues, RFCs

[#675](https://github.com/awslabs/aws-lambda-powertools-typescript/issues/675)  
[#275](https://github.com/awslabs/aws-lambda-powertools-typescript/issues/275)

### PR status

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [x] I have made corresponding changes to the *documentation*
- [ ] I have made corresponding changes to the *examples*
- [x] My changes generate *no new warnings*
- [x] The *code coverage* hasn't decreased
- [x] I have *added tests* that prove my change is effective and works
- [x] New and existing *unit tests pass* locally and in Github Actions
- [x] Any *dependent changes have been merged and published* in downstream module
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

N/A

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
