### PR TITLE
build(docs): updated docs dependencies

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
 mike==1.1.2
-mkdocs-material==8.1.9
-mkdocs-git-revision-date-plugin==0.3.1
+mkdocs-material==8.2.6
+mkdocs-git-revision-date-plugin==0.3.2


### PR DESCRIPTION
## Description of your changes

`on-merge-to-main` action is failing ([#140](https://github.com/awslabs/aws-lambda-powertools-typescript/actions/runs/2034859221), [#141](https://github.com/awslabs/aws-lambda-powertools-typescript/actions/runs/2034856950)) due to a Python dependency issue.

Attempting to fix it by updating the dependencies related to the documentation to the latest version, one of which (`mkdocs-material` - which is the main one) had a [release yesterday](https://github.com/squidfunk/mkdocs-material/releases).

### How to verify this change

Docs should get built successfully.

### Related issues, RFCs

N/A

### PR status

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] My changes generate *no new warnings*
- [x] The *code coverage* hasn't decreased
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

N/A

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
