### PR TITLE
chore: updated depdendabot configs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,32 @@
 version: 2
 updates:
 
+  # Maintain dependencies for Python
+  - package-ecosystem: "pip"
+    directory: "/docs"
+    schedule:
+      interval: "weekly"
+      day: "friday"
+      time: "05:00"
+      timezone: "Europe/Amsterdam"
+    open-pull-requests-limit: 20
+
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "friday"
+      time: "05:00"
+      timezone: "Europe/Amsterdam"
+    open-pull-requests-limit: 20
 
   # Maintain dependencies for npm
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "friday"
+      time: "05:00"
+      timezone: "Europe/Amsterdam"
+    open-pull-requests-limit: 20


### PR DESCRIPTION
## Description of your changes

As discussed in #672 we would like to reduce the noise from Dependabot while still being up to date with the dependency ecosystem. This PR introduces the following changes:
- Set Dependabot to run weekly, on Fridays, at 5AM (`Europe/Amsterdam` tz)
- Set PR limit to 20 **
- Add Dependabot checks for Python dependencies in `docs/requirements.txt`, this was previously ignored.

** I propose to set this number to 20 (default is 5) so to increase the chance that Dependabot will open most/all the PR at once. This will allow the maintainers to have a better idea of the amount of PR to handle on the day (Friday). The current behaviour of 5 at the time made it so that Dependabot would keep opening PRs every time one was merged causing frustration. Read more about this setting [here](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#open-pull-requests-limit).

### How to verify this change

TBD

### Related issues, RFCs

[#672](https://github.com/awslabs/aws-lambda-powertools-typescript/issues/672)  

### PR status

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [x] My changes generate *no new warnings*
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

N/A

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
