### PR TITLE
fix(actions): removed token from remaining actions

### DIFF
--- a/.github/workflows/on-merge-to-main.yml
+++ b/.github/workflows/on-merge-to-main.yml
@@ -16,9 +16,6 @@ jobs:
     steps:
     - name: "Checkout"
       uses: actions/checkout@v3
-      with:
-        token: ${{ secrets.GH_PUBLISH_TOKEN }}
-        fetch-depth: 0
     #########################    
     # Release new version
     #########################
@@ -44,7 +41,7 @@ jobs:
       run: npm run lerna-lint
     - name: Run tests
       run: npm run lerna-test
-    - name: update release draft
+    - name: Update release draft
       uses: release-drafter/release-drafter@v5.19.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/on-release-prod.yml
+++ b/.github/workflows/on-release-prod.yml
@@ -13,9 +13,6 @@ jobs:
     steps:
     - name: "Checkout"
       uses: actions/checkout@v3
-      with:
-        token: ${{ secrets.GH_PUBLISH_TOKEN }}
-        fetch-depth: 0
       #########################    
       # Release new version
       #########################


### PR DESCRIPTION
## Description of your changes

As of recently, the `on-merge-to-main` workflow has been failing in the very first step (`actions/checkout@v3`) ([example](https://github.com/awslabs/aws-lambda-powertools-typescript/runs/6155428079?check_suite_focus=true)). I have tried to run it again multiple times and then was able to track down the issue to a recent change in the action’s repo ([PR](https://github.com/actions/checkout/pull/770)).

Based on the content of that PR and related discussion, the GH action introduced a new default value around the `git config safe.directory` setting (`default true`) that seems to be what’s breaking our workflow, as well as others ([one](https://github.com/actions/checkout/issues/767) and [two](https://github.com/fwupd/fwupd/pull/4545)).

I have tried this in a fork, and setting the config to `*` (aka no check for `safe.directory`) fixes the issue ([link](https://github.com/dreamorosi/aws-lambda-powertools-typescript/runs/6158615149?check_suite_focus=true)). 

Just for context, [the docs for that config](https://git-scm.com/docs/git-config/2.35.2#Documentation/git-config.txt-safedirectory) say this:
> safe.directory
These config entries specify Git-tracked directories that are considered safe even if they are owned by someone other than the current user. By default, Git will refuse to even parse a Git config of a repository owned by someone else, let alone run its hooks, and this config setting allows users to specify exceptions, e.g. for intentionally shared repositories (see the --shared option in [git-init[1]](https://git-scm.com/docs/git-init)).
This is a multi-valued setting, i.e. you can add more than one directory via git config --add. To reset the list of safe directories (e.g. to override any such directories specified in the system config), add a safe.directory entry with an empty value.

Even though the risk of disabling the git check is acceptable, while making the changes for this PR I have noticed that other workflows like `pr-lint-and-test` (who also use that same GH Action) have kept running and not erroring ([example](https://github.com/awslabs/aws-lambda-powertools-typescript/actions/runs/2221032303)).

The main, and only, difference between the two workflow and how they use `actions/checkout@v3` is the one (the failing one) used to set a specific GitHub secret. This secret was there for historical reasons as the initial version of the workflow was set up when the repo was still private - hence the need for a token.

Before setting the `safe.directory` config to allow all I would like, with this PR, to try to remove the token first. If my understanding of the issue is correct then this workflow should start working again (@ijemmy you were right on Slack as for where the actual issue was) since with no token, the ownership/user will be the default one like in the other workflow that are still working.

### How to verify this change

I have already tried this config on a forked repo: https://github.com/dreamorosi/aws-lambda-powertools-typescript/runs/6160173289?check_suite_focus=true

But the only way to see it (AFAIK) is to merge and see the result. If this doesn't work then I'll roll-back & set the wildcard.

### Related issues, RFCs

N/A

### PR status

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

N/A

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
