### PR TITLE
fix(actions): added back fetch-depth: 0

### DIFF
--- a/.github/workflows/on-merge-to-main.yml
+++ b/.github/workflows/on-merge-to-main.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
     - name: "Checkout"
       uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
     #########################    
     # Release new version
     #########################

--- a/.github/workflows/on-release-prod.yml
+++ b/.github/workflows/on-release-prod.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
     - name: "Checkout"
       uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
       #########################    
       # Release new version
       #########################


### PR DESCRIPTION
## Description of your changes

This PR reintroduces a config item that was removed in #805 while trying to solve another tangential issue.

The setting in question is `fetch-depth: 0` and its absence seems to cause the fail of the Action [at a later point](https://github.com/awslabs/aws-lambda-powertools-typescript/runs/6175366337?check_suite_focus=true).

```sh
error: failed to push branch gh-pages to origin: "To https://github.com/awslabs/aws-lambda-powertools-typescript
[rejected]        gh-pages -> gh-pages (fetch first)
hint: Updates were rejected because the remote contains work that you do
hint: not have locally. This is usually caused by another repository pushing
hint: to the same ref. You may want to first integrate the remote changes
hint: (e.g., 'git pull ...') before pushing again.
hint: See the 'Note about fast-forwards' in 'git push --help' for details."
Error: Process completed with exit code 1.
```

Unfortunately I was not able to catch this error because the fork I was testing on didn't have GitHub Pages enabled, so it wouldn't fail at that point.

See #805 for full context. 

### How to verify this change

See `on-merge-to-main` execution results after merging.

### Related issues, RFCs

[#805](https://github.com/awslabs/aws-lambda-powertools-typescript/pull/805)

### PR status

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] My changes generate *no new warnings*
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

N/A

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
