### PR TITLE
feat(all): nodejs16x support

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 # See here for image contents: https://github.com/microsoft/vscode-dev-containers/blob/v0.212.0/containers/javascript-node/.devcontainer/base.Dockerfile
 # [Choice] Node.js version (use -bullseye variants on local arm64/Apple Silicon): 16, 14, 12, 16-bullseye, 14-bullseye, 12-bullseye, 16-buster, 14-buster, 12-buster
-ARG VARIANT="14-bullseye"
+ARG VARIANT="16-bullseye"
 FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:0-${VARIANT}
 
 # This section to install additional OS packages.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,7 @@
     // Update 'VARIANT' to pick a Node version: 16, 14, 12.
 		// Append -bullseye or -buster to pin to an OS version.
 		// Use -bullseye variants on local arm64/Apple Silicon.
-    "args": { "VARIANT": "14-bullseye" }
+    "args": { "VARIANT": "16-bullseye" }
   },
   
   // Set *default* container specific settings.json values on container create.

--- a/.github/workflows/on-merge-to-main.yml
+++ b/.github/workflows/on-merge-to-main.yml
@@ -21,10 +21,10 @@ jobs:
     #########################    
     # Release new version
     #########################
-    - name: "Use NodeJS 14"
+    - name: "Use NodeJS 16"
       uses: actions/setup-node@v3
       with:
-        node-version: '14'
+        node-version: '16'
     - name: Install npm@8.x
       run: npm i -g npm@next-8
     - name: "Setup npm"
@@ -39,6 +39,11 @@ jobs:
       # the dependencies in a separate step
       working-directory: ./examples/cdk
       run: npm ci
+    - name: "Setup SAM"
+      # We use an ad-hoc action so we can specify the SAM CLI version
+      uses: aws-actions/setup-sam@v2
+      with:
+        version: 1.49.0
     - name: Install SAM example packages
       # Since we are not managing the SAM examples with npm workspaces we install
       # the dependencies in a separate step

--- a/.github/workflows/on-release-prod.yml
+++ b/.github/workflows/on-release-prod.yml
@@ -21,10 +21,10 @@ jobs:
       #########################    
       # Release new version
       #########################
-    - name: "Use NodeJS 14"
+    - name: "Use NodeJS 16"
       uses: actions/setup-node@v3
       with:
-        node-version: '14'
+        node-version: '16'
     - name: Install npm@8.x
       run: npm i -g npm@next-8
     - name: "Setup npm"
@@ -39,6 +39,11 @@ jobs:
       # the dependencies in a separate step
       working-directory: ./examples/cdk
       run: npm ci
+    - name: "Setup SAM"
+      # We use an ad-hoc action so we can specify the SAM CLI version
+      uses: aws-actions/setup-sam@v2
+      with:
+        version: 1.49.0
     - name: Install SAM example packages
       # Since we are not managing the SAM examples with npm workspaces we install
       # the dependencies in a separate step

--- a/.github/workflows/pr_lint_and_test.yml
+++ b/.github/workflows/pr_lint_and_test.yml
@@ -9,10 +9,10 @@ jobs:
       NODE_ENV: dev
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Node
+      - name: "Use NodeJS 16"
         uses: actions/setup-node@v3
         with:
-          node-version: '14'
+          node-version: '16'
       - name: Install npm@8.x
         run: npm i -g npm@next-8
       - name: "Setup npm"
@@ -27,6 +27,11 @@ jobs:
         # the dependencies in a separate step
         working-directory: ./examples/cdk
         run: npm ci
+      - name: "Setup SAM"
+        # We use an ad-hoc action so we can specify the SAM CLI version
+        uses: aws-actions/setup-sam@v2
+        with:
+          version: 1.49.0
       - name: Install SAM example packages
         # Since we are not managing the SAM examples with npm workspaces we install
         # the dependencies in a separate step

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -24,6 +24,11 @@ jobs:
         # the dependencies in a separate step
         working-directory: ./examples/cdk
         run: npm ci
+      - name: "Setup SAM"
+        # We use an ad-hoc action so we can specify the SAM CLI version
+        uses: aws-actions/setup-sam@v2
+        with:
+          version: 1.49.0
       - name: Install SAM example packages
         # Since we are not managing the SAM examples with npm workspaces we install
         # the dependencies in a separate step
@@ -42,8 +47,8 @@ jobs:
       contents: read
     strategy:
       matrix:
-        version: [12, 14, 16]
         package: [logger, metrics, tracer]
+        version: [12, 14, 16]
     steps:
       - name: "Checkout"
         uses: actions/checkout@v3

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -9,11 +9,10 @@ jobs:
     steps:
       - name: "Checkout"
         uses: actions/checkout@v3
-      - name: "Use NodeJS 14"
+      - name: "Use NodeJS 16"
         uses: actions/setup-node@v3
         with:
-          # Always use version 14 as we use TypeScript target es2020
-          node-version: 14
+          node-version: 16
       - name: "Install npm@8.x"
         run: npm i -g npm@next-8
       - name: "Install monorepo packages"
@@ -43,16 +42,15 @@ jobs:
       contents: read
     strategy:
       matrix:
-        version: [12, 14]
+        version: [12, 14, 16]
         package: [logger, metrics, tracer]
     steps:
       - name: "Checkout"
         uses: actions/checkout@v3
-      - name: "Use NodeJS 14"
+      - name: "Use NodeJS 16"
         uses: actions/setup-node@v3
         with:
-          # Always use version 14 as we use TypeScript target es2020
-          node-version: 14
+          node-version: 16
       - name: "Install npm@8.x"
         run: npm i -g npm@next-8
       - name: "Install monorepo packages"

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/fermium
+lts/gallium

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,7 +61,7 @@ The alternative is to use a Cloud IDE like [Gitpod](https://www.gitpod.io/) or [
 
 The following tools need to be installed on your system prior to starting working on a pull request:
 
-- [Node.js >= 14.18.1](https://nodejs.org/download/release/latest-v14.x/)
+- [Node.js >= 16.x](https://nodejs.org/download/release/latest-v16.x/)
   - We recommend using a version in [Active LTS](https://nodejs.org/en/about/releases/)
   - If you use [nvm](https://github.com/nvm-sh/nvm#nvmrc) or [fnm](https://github.com/Schniz/fnm) you can install the latest LTS version with `nvm use` or `fnm use` respectively. Both will use the `.nvmrc` file in the project's root.
 - [npm 8.x](https://www.npmjs.com/)
@@ -250,7 +250,7 @@ Contributions via pull requests are much appreciated.
 
 ### Summary
 
-* This project uses `node@14.x` and `npm@8.x` for development (see [Setup](#setup)).
+* This project uses `node@16.x` and `npm@8.x` for development (see [Setup](#setup)).
 * Before opening a Pull Request, please find the existing related issue or open a new one to discuss the proposed changes. A PR without a related issue or discussion has a high risk of being rejected. We are very appreciative and thankful for your time and efforts, and we want to make sure they are not wasted.
 * After your proposal has been reviewed and accepted by at least one of the project's maintainers, you can submit a pull request.
 * When opening a PR, make sure to follow the checklist inside the pull request template.

--- a/docs/core/logger.md
+++ b/docs/core/logger.md
@@ -82,7 +82,7 @@ For a **complete list** of supported environment variables, refer to [this secti
       ShoppingCartApiFunction:
         Type: AWS::Serverless::Function
         Properties:
-          Runtime: nodejs14.x
+          Runtime: nodejs16.x
           Environment:
             Variables:
               LOG_LEVEL: WARN

--- a/docs/core/metrics.md
+++ b/docs/core/metrics.md
@@ -101,7 +101,7 @@ The `Metrics` utility is instantiated outside of the Lambda handler. In doing th
       HelloWorldFunction:
         Type: AWS::Serverless::Function
         Properties:
-          Runtime: nodejs14.x
+          Runtime: nodejs16.x
           Environment:
           Variables:
             POWERTOOLS_SERVICE_NAME: orders

--- a/docs/core/tracer.md
+++ b/docs/core/tracer.md
@@ -88,7 +88,7 @@ The `Tracer` utility is instantiated outside of the Lambda handler. In doing thi
       HelloWorldFunction:
         Type: AWS::Serverless::Function
         Properties:
-          Runtime: nodejs14.x
+          Runtime: nodejs16.x
           Tracing: Active
           Environment:
             Variables:

--- a/examples/cdk/src/example-function.ts
+++ b/examples/cdk/src/example-function.ts
@@ -2,7 +2,7 @@ import { custom_resources, aws_iam } from 'aws-cdk-lib';
 import { Events } from '@aws-lambda-powertools/commons';
 import { Construct } from 'constructs';
 import { NodejsFunction, NodejsFunctionProps } from 'aws-cdk-lib/aws-lambda-nodejs';
-import { Tracing } from 'aws-cdk-lib/aws-lambda';
+import { Tracing, Runtime } from 'aws-cdk-lib/aws-lambda';
 
 interface ExampleFunctionProps {
   readonly functionName: string
@@ -23,6 +23,7 @@ class ExampleFunction extends Construct {
 
     const fn = new NodejsFunction(this, functionName, {
       tracing: tracingActive ? Tracing.ACTIVE : Tracing.DISABLED,
+      runtime: Runtime.NODEJS_16_X,
       ...fnProps
     });
 

--- a/examples/sam/template.yaml
+++ b/examples/sam/template.yaml
@@ -15,7 +15,7 @@ Transform: AWS::Serverless-2016-10-31
 # https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-specification-template-anatomy-globals.html
 Globals:
   Function:
-      Runtime: nodejs14.x
+      Runtime: nodejs16.x
       Architectures:
         - x86_64
       MemorySize: 128

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "lib/**/*"
   ],
   "engines": {
-    "node": ">=10"
+    "node": ">=12"
   },
   "dependencies": {
     "hosted-git-info": "^5.0.0"

--- a/packages/commons/tests/utils/e2eUtils.ts
+++ b/packages/commons/tests/utils/e2eUtils.ts
@@ -19,7 +19,7 @@ export type TestRuntimesKey = typeof testRuntimeKeys[number];
 export const TEST_RUNTIMES: Record<TestRuntimesKey, Runtime> = {
   nodejs12x: Runtime.NODEJS_12_X,
   nodejs14x: Runtime.NODEJS_14_X,
-  nodejs16x: Runtime.NODEJS_16_X
+  nodejs16x: Runtime.NODEJS_16_X,
 };
 
 export type StackWithLambdaFunctionOptions = {

--- a/packages/commons/tests/utils/e2eUtils.ts
+++ b/packages/commons/tests/utils/e2eUtils.ts
@@ -14,11 +14,12 @@ import { InvocationLogs } from './InvocationLogs';
 
 const lambdaClient = new AWS.Lambda();
 
-const testRuntimeKeys = [ 'nodejs12x', 'nodejs14x' ];
+const testRuntimeKeys = [ 'nodejs12x', 'nodejs14x', 'nodejs16x' ];
 export type TestRuntimesKey = typeof testRuntimeKeys[number];
 export const TEST_RUNTIMES: Record<TestRuntimesKey, Runtime> = {
   nodejs12x: Runtime.NODEJS_12_X,
   nodejs14x: Runtime.NODEJS_14_X,
+  nodejs16x: Runtime.NODEJS_16_X
 };
 
 export type StackWithLambdaFunctionOptions = {

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -15,6 +15,7 @@
     "test:unit": "jest --group=unit --detectOpenHandles --coverage --verbose",
     "test:e2e:nodejs12x": "RUNTIME=nodejs12x jest --group=e2e",
     "test:e2e:nodejs14x": "RUNTIME=nodejs14x jest --group=e2e",
+    "test:e2e:nodejs16x": "RUNTIME=nodejs16x jest --group=e2e",
     "test:e2e": "jest --group=e2e",
     "watch": "jest --watch --group=unit",
     "build": "tsc",

--- a/packages/logger/tests/e2e/basicFeatures.middy.test.ts
+++ b/packages/logger/tests/e2e/basicFeatures.middy.test.ts
@@ -26,7 +26,7 @@ import {
   TEARDOWN_TIMEOUT
 } from './constants';
 
-const runtime: string = process.env.RUNTIME || 'nodejs14x';
+const runtime: string = process.env.RUNTIME || 'nodejs16x';
 
 if (!isValidRuntimeKey(runtime)) {
   throw new Error(`Invalid runtime key value: ${runtime}`);

--- a/packages/logger/tests/e2e/childLogger.manual.test.ts
+++ b/packages/logger/tests/e2e/childLogger.manual.test.ts
@@ -26,7 +26,7 @@ import {
   TEARDOWN_TIMEOUT
 } from './constants';
 
-const runtime: string = process.env.RUNTIME || 'nodejs14x';
+const runtime: string = process.env.RUNTIME || 'nodejs16x';
 
 if (!isValidRuntimeKey(runtime)) {
   throw new Error(`Invalid runtime key value: ${runtime}`);

--- a/packages/logger/tests/e2e/sampleRate.decorator.test.ts
+++ b/packages/logger/tests/e2e/sampleRate.decorator.test.ts
@@ -26,7 +26,7 @@ import {
   TEARDOWN_TIMEOUT
 } from './constants';
 
-const runtime: string = process.env.RUNTIME || 'nodejs14x';
+const runtime: string = process.env.RUNTIME || 'nodejs16x';
 
 if (!isValidRuntimeKey(runtime)) {
   throw new Error(`Invalid runtime key value: ${runtime}`);

--- a/packages/metrics/package.json
+++ b/packages/metrics/package.json
@@ -15,6 +15,7 @@
     "test:unit": "jest --group=unit --detectOpenHandles --coverage --verbose",
     "test:e2e:nodejs12x": "RUNTIME=nodejs12x jest --group=e2e",
     "test:e2e:nodejs14x": "RUNTIME=nodejs14x jest --group=e2e",
+    "test:e2e:nodejs16x": "RUNTIME=nodejs16x jest --group=e2e",
     "test:e2e": "jest --group=e2e",
     "watch": "jest --group=unit --watch ",
     "build": "tsc",

--- a/packages/metrics/tests/e2e/basicFeatures.decorators.test.ts
+++ b/packages/metrics/tests/e2e/basicFeatures.decorators.test.ts
@@ -29,7 +29,7 @@ import {
 } from './constants';
 import { getMetrics } from '../helpers/metricsUtils';
 
-const runtime: string = process.env.RUNTIME || 'nodejs14x';
+const runtime: string = process.env.RUNTIME || 'nodejs16x';
 
 if (!isValidRuntimeKey(runtime)) {
   throw new Error(`Invalid runtime key value: ${runtime}`);

--- a/packages/metrics/tests/e2e/basicFeatures.manual.test.ts
+++ b/packages/metrics/tests/e2e/basicFeatures.manual.test.ts
@@ -29,7 +29,7 @@ import {
 } from './constants';
 import { getMetrics } from '../helpers/metricsUtils';
 
-const runtime: string = process.env.RUNTIME || 'nodejs14x';
+const runtime: string = process.env.RUNTIME || 'nodejs16x';
 
 if (!isValidRuntimeKey(runtime)) {
   throw new Error(`Invalid runtime key value: ${runtime}`);

--- a/packages/tracer/package.json
+++ b/packages/tracer/package.json
@@ -15,6 +15,7 @@
     "test:unit": "jest --group=unit --detectOpenHandles --coverage --verbose",
     "test:e2e:nodejs12x": "RUNTIME=nodejs12x jest --group=e2e",
     "test:e2e:nodejs14x": "RUNTIME=nodejs14x jest --group=e2e",
+    "test:e2e:nodejs16x": "RUNTIME=nodejs16x jest --group=e2e",
     "test:e2e": "jest --group=e2e",
     "watch": "jest --watch",
     "build": "tsc",

--- a/packages/tracer/tests/e2e/allFeatures.decorator.test.ts
+++ b/packages/tracer/tests/e2e/allFeatures.decorator.test.ts
@@ -40,7 +40,7 @@ import {
   assertErrorAndFault,
 } from '../helpers/traceAssertions';
 
-const runtime: string = process.env.RUNTIME || 'nodejs14x';
+const runtime: string = process.env.RUNTIME || 'nodejs16x';
 
 if (!isValidRuntimeKey(runtime)) {
   throw new Error(`Invalid runtime key value: ${runtime}`);

--- a/packages/tracer/tests/e2e/allFeatures.manual.test.ts
+++ b/packages/tracer/tests/e2e/allFeatures.manual.test.ts
@@ -41,7 +41,7 @@ import {
   assertAnnotation
 } from '../helpers/traceAssertions';
 
-const runtime: string = process.env.RUNTIME || 'nodejs14x';
+const runtime: string = process.env.RUNTIME || 'nodejs16x';
 
 if (!isValidRuntimeKey(runtime)) {
   throw new Error(`Invalid runtime key value: ${runtime}`);

--- a/packages/tracer/tests/e2e/allFeatures.middy.test.ts
+++ b/packages/tracer/tests/e2e/allFeatures.middy.test.ts
@@ -40,7 +40,7 @@ import {
   assertErrorAndFault,
 } from '../helpers/traceAssertions';
 
-const runtime: string = process.env.RUNTIME || 'nodejs14x';
+const runtime: string = process.env.RUNTIME || 'nodejs16x';
 
 if (!isValidRuntimeKey(runtime)) {
   throw new Error(`Invalid runtime key value: ${runtime}`);

--- a/packages/tracer/tests/e2e/asyncHandler.decorator.test.ts
+++ b/packages/tracer/tests/e2e/asyncHandler.decorator.test.ts
@@ -40,7 +40,7 @@ import {
   assertErrorAndFault,
 } from '../helpers/traceAssertions';
 
-const runtime: string = process.env.RUNTIME || 'nodejs14x';
+const runtime: string = process.env.RUNTIME || 'nodejs16x';
 
 if (!isValidRuntimeKey(runtime)) {
   throw new Error(`Invalid runtime key value: ${runtime}`);

--- a/packages/tracer/tests/helpers/populateEnvironmentVariables.ts
+++ b/packages/tracer/tests/helpers/populateEnvironmentVariables.ts
@@ -1,7 +1,7 @@
 // Reserved variables
 process.env._X_AMZN_TRACE_ID = '1-abcdef12-3456abcdef123456abcdef12';
 process.env.AWS_LAMBDA_FUNCTION_NAME = 'my-lambda-function';
-process.env.AWS_EXECUTION_ENV = 'nodejs14.x';
+process.env.AWS_EXECUTION_ENV = 'nodejs16.x';
 process.env.AWS_LAMBDA_FUNCTION_MEMORY_SIZE = '128';
 process.env.AWS_REGION = 'eu-west-1';
 process.env._HANDLER = 'index.handler';

--- a/packages/tracer/tests/unit/config/EnvironmentVariablesService.test.ts
+++ b/packages/tracer/tests/unit/config/EnvironmentVariablesService.test.ts
@@ -175,14 +175,14 @@ describe('Class: EnvironmentVariablesService', () => {
     test('It returns the value of the environment variable AWS_EXECUTION_ENV', () => {
 
       // Prepare
-      process.env.AWS_EXECUTION_ENV = 'nodejs14.x';
+      process.env.AWS_EXECUTION_ENV = 'nodejs16.x';
       const service = new EnvironmentVariablesService();
 
       // Act
       const value = service.getAwsExecutionEnv();
 
       // Assess
-      expect(value).toEqual('nodejs14.x');
+      expect(value).toEqual('nodejs16.x');
     });
 
   });

--- a/packages/tracer/tests/unit/helpers.test.ts
+++ b/packages/tracer/tests/unit/helpers.test.ts
@@ -220,7 +220,7 @@ describe('Helper: createTracer function', () => {
 
     test('when AWS_EXECUTION_ENV environment variable is set, tracing is enabled', () => {
       // Prepare
-      process.env.AWS_EXECUTION_ENV = 'nodejs14.x';
+      process.env.AWS_EXECUTION_ENV = 'nodejs16.x';
 
       // Act
       const tracer = createTracer();


### PR DESCRIPTION
## Description of your changes

AWS Lambda announced support for Node JS 16 a few days ago, this PR aims at adding support to that same runtime.

The changes in the PR revolve around:
- Adding the `nodejs16x` runtime to the e2e test matrix
- Making Node JS 16.x the default version for development
- Making Node JS 16.x the default version for CI/CD 

### How to verify this change

See successful run for GitHub Actions under this PR, as well as a successful run for the e2e tests that now includes the new runtime as part of the matrix ([link to execution](https://github.com/awslabs/aws-lambda-powertools-typescript/actions/runs/2319455980)).

### Related issues, RFCs

#830

### PR status

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [x] I have made corresponding changes to the *documentation*
- [x] I have made corresponding changes to the *examples*
- [x] My changes generate *no new warnings*
- [x] The *code coverage* hasn't decreased
- [x] New and existing *unit tests pass* locally and in Github Actions
- [x] Any *dependent changes have been merged and published* in downstream module
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

N/A

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
