### PR TITLE
fix(commons) prune issue - fix #664

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15514,15 +15514,15 @@
     },
     "packages/commons": {
       "name": "@aws-lambda-powertools/commons",
-      "version": "0.8.1",
+      "version": "0.9.0",
       "license": "MIT-0"
     },
     "packages/logger": {
       "name": "@aws-lambda-powertools/logger",
-      "version": "0.8.1",
+      "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
-        "@aws-lambda-powertools/commons": "^0.8.1",
+        "@aws-lambda-powertools/commons": "^0.9.0",
         "lodash.clonedeep": "^4.5.0",
         "lodash.merge": "^4.6.2",
         "lodash.pickby": "^4.6.0"
@@ -15535,10 +15535,10 @@
     },
     "packages/metrics": {
       "name": "@aws-lambda-powertools/metrics",
-      "version": "0.8.1",
+      "version": "0.9.0",
       "license": "MIT-0",
       "dependencies": {
-        "@aws-lambda-powertools/commons": "^0.8.1"
+        "@aws-lambda-powertools/commons": "^0.9.0"
       },
       "devDependencies": {
         "@types/promise-retry": "^1.1.3",
@@ -15547,10 +15547,10 @@
     },
     "packages/tracer": {
       "name": "@aws-lambda-powertools/tracer",
-      "version": "0.8.1",
+      "version": "0.9.0",
       "license": "MIT-0",
       "dependencies": {
-        "@aws-lambda-powertools/commons": "^0.8.1",
+        "@aws-lambda-powertools/commons": "^0.9.0",
         "aws-xray-sdk-core": "^3.3.4"
       },
       "devDependencies": {
@@ -15777,7 +15777,7 @@
     "@aws-lambda-powertools/logger": {
       "version": "file:packages/logger",
       "requires": {
-        "@aws-lambda-powertools/commons": "^0.8.1",
+        "@aws-lambda-powertools/commons": "^0.9.0",
         "@types/lodash.clonedeep": "^4.5.6",
         "@types/lodash.merge": "^4.6.6",
         "@types/lodash.pickby": "^4.6.6",
@@ -15789,7 +15789,7 @@
     "@aws-lambda-powertools/metrics": {
       "version": "file:packages/metrics",
       "requires": {
-        "@aws-lambda-powertools/commons": "^0.8.1",
+        "@aws-lambda-powertools/commons": "^0.9.0",
         "@types/promise-retry": "^1.1.3",
         "promise-retry": "^2.0.1"
       }
@@ -15797,7 +15797,7 @@
     "@aws-lambda-powertools/tracer": {
       "version": "file:packages/tracer",
       "requires": {
-        "@aws-lambda-powertools/commons": "^0.8.1",
+        "@aws-lambda-powertools/commons": "^0.9.0",
         "@aws-sdk/client-dynamodb": "^3.58.0",
         "@types/promise-retry": "^1.1.3",
         "aws-xray-sdk-core": "^3.3.4",

--- a/packages/logger/src/Logger.ts
+++ b/packages/logger/src/Logger.ts
@@ -1,6 +1,6 @@
 import { Console } from 'console';
 import type { Context } from 'aws-lambda';
-import { Utility } from '@aws-lambda-powertools/commons';
+import { Utility } from '@aws-lambda-powertools/commons/lib/Utility';
 import { LogFormatterInterface, PowertoolLogFormatter } from './formatter';
 import { LogItem } from './log';
 import cloneDeep from 'lodash.clonedeep';

--- a/packages/metrics/src/Metrics.ts
+++ b/packages/metrics/src/Metrics.ts
@@ -1,5 +1,5 @@
 import { Callback, Context } from 'aws-lambda';
-import { Utility } from '@aws-lambda-powertools/commons';
+import { Utility } from '@aws-lambda-powertools/commons/lib/Utility';
 import { MetricsInterface } from '.';
 import { ConfigServiceInterface, EnvironmentVariablesService } from './config';
 import {

--- a/packages/tracer/src/Tracer.ts
+++ b/packages/tracer/src/Tracer.ts
@@ -1,5 +1,5 @@
 import { Handler } from 'aws-lambda';
-import { Utility } from '@aws-lambda-powertools/commons';
+import { Utility } from '@aws-lambda-powertools/commons/lib/Utility';
 import { TracerInterface } from '.';
 import { ConfigServiceInterface, EnvironmentVariablesService } from './config';
 import { HandlerMethodDecorator, TracerOptions, MethodDecorator } from './types';


### PR DESCRIPTION
## Importing Common Index in Logger Folder raises Module Error #664

* Import Commons Utility from the commons using `import { Utility } from '@aws-lambda-powertools/commons/lib/Utility';` instead of directly from the package's index
* The index exports contain `tests/resources` references. Pruning tools removes `tests` folder within the code during build 
* Hence importing the Utility directly from its inner package

<!--- Please include also relevant motivation and context. -->

<!--- List any dependencies that are required for this change. -->

<!--- If this PR is part of a sequence of related PRs or TODOs, list the high level TODO items. -->

### How to verify this change

<!--- Add any applicable config, projects, screenshots or other resources -->
<!--- that can help us verify your changes. -->

<!--- Examples: -->
<!--- Screenshots, cloud configuration, anything helping us evaluate better. -->

### Related issues, RFCs

<!--- Add here the link to one or more Github Issues or RFCs that are related to this PR. -->
[#664](https://github.com/awslabs/aws-lambda-powertools-typescript/issues/664)  

### PR status

***Is this ready for review?:*** NO  
***Is it a breaking change?:*** NO

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [x] I have made corresponding changes to the *documentation*
- [x] I have made corresponding changes to the *examples*
- [x] My changes generate *no new warnings*
- [x] The *code coverage* hasn't decreased
- [x] I have *added tests* that prove my change is effective and works
- [x] New and existing *unit tests pass* locally and in Github Actions
- [x] Any *dependent changes have been merged and published* in downstream module
- [ ] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

- [ ] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
