### PR TITLE
fix(logger): enable logging of arbitrary objects

### DIFF
--- a/docs/core/logger.md
+++ b/docs/core/logger.md
@@ -286,7 +286,7 @@ If you already have an object containing a `message` key and an additional prope
 
     const logger = new Logger();
     
-    export const handler = async (_event: any, _context: any): Promise<unknown> => {
+    export const handler = async (event: any, _context: any): Promise<unknown> => {
     
         const myImportantVariable = {
             foo: 'bar'
@@ -301,7 +301,7 @@ If you already have an object containing a `message` key and an additional prope
         logger.info('This is a log with 3 extra objects',
             { data: myImportantVariable },
             { correlationIds: { myCustomCorrelationId: 'foo-bar-baz' } },
-            { lambdaEvent: _event }
+            { lambdaEvent: event }
         );
 
         // Simply pass a string for logging additional data

--- a/docs/core/logger.md
+++ b/docs/core/logger.md
@@ -298,9 +298,10 @@ If you already have an object containing a `message` key and an additional prope
         logger.info('This is a log with an extra variable', { data: myImportantVariable });
         
         // You can also pass multiple parameters
-        logger.info('This is a log with 2 extra variables',
+        logger.info('This is a log with 3 extra objects',
             { data: myImportantVariable },
-            { correlationIds: { myCustomCorrelationId: 'foo-bar-baz' } }
+            { correlationIds: { myCustomCorrelationId: 'foo-bar-baz' } },
+            { lambdaEvent: _event }
         );
 
         // Simply pass a string for logging additional data

--- a/docs/core/logger.md
+++ b/docs/core/logger.md
@@ -273,15 +273,17 @@ You can append additional persistent keys and values in the logs generated durin
 
 !!! tip "Logger will automatically ignore any key with an `undefined` value"
 
-### Appending additional log keys and values to a single log item
+### Appending additional data to a single log item
 
-You can append additional keys and values in a single log item passing them as parameters.
-Pass a string for logging it with default key name `extra`. Alternatively, pass one or multiple objects with custom keys.
-If you already have an object containing a `message` key and an additional property, you can pass this object directly.
+You can append additional data to a single log item by passing objects as additional parameters.
+
+* Pass a simple string for logging it with default key name `extra`
+* Pass one or multiple objects containing arbitrary data to be logged. Each data object should be placed in an enclosing object as a single property value, you can name this property as you need: `{ myData: arbitraryObjectToLog }`
+* If you already have an object containing a `message` key and an additional property, you can pass this object directly
 
 === "handler.ts"
 
-    ```typescript hl_lines="14 18-19 23 31"
+    ```typescript hl_lines="14 18-20 24 32"
     import { Logger } from '@aws-lambda-powertools/logger';
 
     const logger = new Logger();
@@ -292,12 +294,12 @@ If you already have an object containing a `message` key and an additional prope
             foo: 'bar'
         };
         
-        // Pass additional keys and values in single log items
+        // Log additional data in single log items
         
         // As second parameter
         logger.info('This is a log with an extra variable', { data: myImportantVariable });
         
-        // You can also pass multiple parameters
+        // You can also pass multiple parameters containing arbitrary objects
         logger.info('This is a log with 3 extra objects',
             { data: myImportantVariable },
             { correlationIds: { myCustomCorrelationId: 'foo-bar-baz' } },
@@ -323,14 +325,14 @@ If you already have an object containing a `message` key and an additional prope
     ```
 === "Example CloudWatch Logs excerpt"
 
-    ```json hl_lines="7 15-16 24 32"
+    ```json hl_lines="7 15-21 28 37"
     {
         "level": "INFO",
         "message": "This is a log with an extra variable",
         "service": "serverlessAirline",
         "timestamp": "2021-12-12T22:06:17.463Z",
         "xray_trace_id": "abcdef123456abcdef123456abcdef123456",
-        "data": { foo: "bar" }
+        "data": { "foo": "bar" }
     }
     {
         "level": "INFO",
@@ -339,7 +341,12 @@ If you already have an object containing a `message` key and an additional prope
         "timestamp": "2021-12-12T22:06:17.466Z",
         "xray_trace_id": "abcdef123456abcdef123456abcdef123456",
         "data": { "foo": "bar" },
-        "correlationIds": { "myCustomCorrelationId": "foo-bar-baz" }
+        "correlationIds": { "myCustomCorrelationId": "foo-bar-baz" },
+        "lambdaEvent": { 
+            "exampleEventData": {
+                "eventValue": 42
+            }
+        }
     }
     {
         "level": "INFO",

--- a/packages/logger/examples/additional-keys.ts
+++ b/packages/logger/examples/additional-keys.ts
@@ -12,7 +12,7 @@ import { Logger } from '../src';
 
 const logger = new Logger();
 
-const lambdaHandler: Handler = async () => {
+const lambdaHandler: Handler = async (event) => {
 
   // Pass a custom correlation ID
   logger.warn('This is a WARN log', { correlationIds: { myCustomCorrelationId: 'foo-bar-baz' } });
@@ -22,6 +22,9 @@ const lambdaHandler: Handler = async () => {
 
   // Pass a simple string as additional data
   logger.info('This is an INFO log', 'Extra log data');
+
+  // Pass an arbitrary object as additional data
+  logger.debug('This is a DEBUG log', { lambdaEvent: event });
 
   return {
     foo: 'bar'

--- a/packages/logger/src/types/Log.ts
+++ b/packages/logger/src/types/Log.ts
@@ -9,7 +9,7 @@ type LogLevelThresholds = {
   [key in LogLevel]: number;
 };
 
-type LogAttributeValue = string | number | boolean | null | undefined | LogAttributeValue[] | { [key: string]: LogAttributeValue } | Error;
+type LogAttributeValue = unknown;
 type LogAttributes = { [key: string]: LogAttributeValue };
 
 type LogAttributesWithMessage = LogAttributes & {

--- a/packages/logger/tests/e2e/basicFeatures.middy.test.FunctionCode.ts
+++ b/packages/logger/tests/e2e/basicFeatures.middy.test.FunctionCode.ts
@@ -1,5 +1,5 @@
 import { injectLambdaContext, Logger } from '../../src';
-import { APIGatewayProxyEvent, APIGatewayProxyResult, Context } from 'aws-lambda';
+import { APIGatewayProxyEvent, Context, APIGatewayAuthorizerResult } from 'aws-lambda';
 import middy from '@middy/core';
 
 const PERSISTENT_KEY = process.env.PERSISTENT_KEY;
@@ -37,9 +37,16 @@ const testFunction = async (event: APIGatewayProxyEvent, context: Context): Prom
   }
 
   // Test feature 7: Logging an arbitrary object
-  const obj: APIGatewayProxyResult = {
-    body: ARBITRARY_OBJECT_DATA,
-    statusCode: ARBITRARY_OBJECT_DATA.length
+  const obj: APIGatewayAuthorizerResult = {
+    principalId: ARBITRARY_OBJECT_DATA,
+    policyDocument: {
+      Version: 'Version' + ARBITRARY_OBJECT_DATA,
+      Statement: [{
+        Effect: 'Effect' + ARBITRARY_OBJECT_DATA,
+        Action: 'Action' + ARBITRARY_OBJECT_DATA,
+        Resource: 'Resource' + ARBITRARY_OBJECT_DATA
+      }]
+    }
   };
 
   logger.info('A log entry with an object', { [ARBITRARY_OBJECT_KEY]: obj });

--- a/packages/logger/tests/e2e/basicFeatures.middy.test.FunctionCode.ts
+++ b/packages/logger/tests/e2e/basicFeatures.middy.test.FunctionCode.ts
@@ -1,5 +1,5 @@
 import { injectLambdaContext, Logger } from '../../src';
-import { APIGatewayProxyEvent, Context } from 'aws-lambda';
+import { APIGatewayProxyEvent, APIGatewayProxyResult, Context } from 'aws-lambda';
 import middy from '@middy/core';
 
 const PERSISTENT_KEY = process.env.PERSISTENT_KEY;
@@ -7,6 +7,8 @@ const PERSISTENT_VALUE = process.env.PERSISTENT_VALUE;
 const ERROR_MSG = process.env.ERROR_MSG || 'error';
 const SINGLE_LOG_ITEM_KEY = process.env.SINGLE_LOG_ITEM_KEY;
 const SINGLE_LOG_ITEM_VALUE = process.env.SINGLE_LOG_ITEM_VALUE;
+const ARBITRARY_OBJECT_KEY = process.env.ARBITRARY_OBJECT_KEY;
+const ARBITRARY_OBJECT_DATA = process.env.ARBITRARY_OBJECT_DATA;
 
 const logger = new Logger({
   persistentLogAttributes: {
@@ -33,6 +35,14 @@ const testFunction = async (event: APIGatewayProxyEvent, context: Context): Prom
   } catch (e) {
     logger.error(ERROR_MSG, e as Error);
   }
+
+  // Test feature 7: Logging an arbitrary object
+  const obj: APIGatewayProxyResult = {
+    body: ARBITRARY_OBJECT_DATA,
+    statusCode: ARBITRARY_OBJECT_DATA.length
+  };
+
+  logger.info('A log entry with an object', { [ARBITRARY_OBJECT_KEY]: obj });
 
   return {
     requestId: context.awsRequestId,

--- a/packages/logger/tests/e2e/basicFeatures.middy.test.ts
+++ b/packages/logger/tests/e2e/basicFeatures.middy.test.ts
@@ -10,7 +10,7 @@
 import path from 'path';
 import { randomUUID } from 'crypto';
 import { App, Stack } from 'aws-cdk-lib';
-import { APIGatewayProxyResult } from 'aws-lambda';
+import { APIGatewayAuthorizerResult } from 'aws-lambda';
 import {
   createStackWithLambdaFunction,
   generateUniqueName,
@@ -175,9 +175,18 @@ describe(`logger E2E tests basic functionalities (middy) for runtime: ${runtime}
 
       const logObject = InvocationLogs.parseFunctionLog(logMessages[0]);
       expect(logObject).toHaveProperty(ARBITRARY_OBJECT_KEY);
-      const arbitrary = logObject[ARBITRARY_OBJECT_KEY] as APIGatewayProxyResult;
-      expect(arbitrary.body).toBe(ARBITRARY_OBJECT_DATA);
-      expect(arbitrary.statusCode).toBe(ARBITRARY_OBJECT_DATA.length);
+      const arbitrary = logObject[ARBITRARY_OBJECT_KEY] as APIGatewayAuthorizerResult;
+      expect(arbitrary.principalId).toBe(ARBITRARY_OBJECT_DATA);
+      expect(arbitrary.policyDocument).toEqual(expect.objectContaining(
+        {
+          Version: 'Version' + ARBITRARY_OBJECT_DATA,
+          Statement: [{
+            Effect: 'Effect' + ARBITRARY_OBJECT_DATA,
+            Action: 'Action' + ARBITRARY_OBJECT_DATA,
+            Resource: 'Resource' + ARBITRARY_OBJECT_DATA
+          }]
+        }
+      ));
     }, TEST_CASE_TIMEOUT);
   });
 

--- a/packages/logger/tests/e2e/basicFeatures.middy.test.ts
+++ b/packages/logger/tests/e2e/basicFeatures.middy.test.ts
@@ -10,6 +10,7 @@
 import path from 'path';
 import { randomUUID } from 'crypto';
 import { App, Stack } from 'aws-cdk-lib';
+import { APIGatewayProxyResult } from 'aws-lambda';
 import {
   createStackWithLambdaFunction,
   generateUniqueName,
@@ -45,6 +46,8 @@ const PERSISTENT_VALUE = `a persistent value that will be put in every log ${uui
 const SINGLE_LOG_ITEM_KEY = `keyForSingleLogItem${uuid}`;
 const SINGLE_LOG_ITEM_VALUE = `a value for a single log item${uuid}`;
 const ERROR_MSG = `error-${uuid}`;
+const ARBITRARY_OBJECT_KEY = `keyForArbitraryObject${uuid}`;
+const ARBITRARY_OBJECT_DATA = `arbitrary object data ${uuid}`;
 
 const integTestApp = new App();
 let logGroupName: string; // We do not know it until deployment
@@ -72,6 +75,8 @@ describe(`logger E2E tests basic functionalities (middy) for runtime: ${runtime}
         SINGLE_LOG_ITEM_KEY,
         SINGLE_LOG_ITEM_VALUE,
         ERROR_MSG,
+        ARBITRARY_OBJECT_KEY,
+        ARBITRARY_OBJECT_DATA,
       },
       logGroupOutputKey: STACK_OUTPUT_LOG_GROUP,
       runtime: runtime,
@@ -161,10 +166,23 @@ describe(`logger E2E tests basic functionalities (middy) for runtime: ${runtime}
 
       expect(logMessages).toHaveLength(1);
     }, TEST_CASE_TIMEOUT);
+
+    it('should log additional arbitrary object only once', async () => {
+      const logMessages = invocationLogs[0].getFunctionLogs()
+        .filter(message => message.includes(ARBITRARY_OBJECT_DATA));
+
+      expect(logMessages).toHaveLength(1);
+
+      const logObject = InvocationLogs.parseFunctionLog(logMessages[0]);
+      expect(logObject).toHaveProperty(ARBITRARY_OBJECT_KEY);
+      const arbitrary = logObject[ARBITRARY_OBJECT_KEY] as APIGatewayProxyResult;
+      expect(arbitrary.body).toBe(ARBITRARY_OBJECT_DATA);
+      expect(arbitrary.statusCode).toBe(ARBITRARY_OBJECT_DATA.length);
+    }, TEST_CASE_TIMEOUT);
   });
 
   describe('Logging an error object', () => {
-    it('should log additional keys and value only once', async () => {
+    it('should log error only once', async () => {
       const logMessages = invocationLogs[0].getFunctionLogs(LEVEL.ERROR)
         .filter(message => message.includes(ERROR_MSG));
 

--- a/packages/logger/tests/unit/Logger.test.ts
+++ b/packages/logger/tests/unit/Logger.test.ts
@@ -280,6 +280,9 @@ describe('Class: Logger', () => {
           });
           const consoleSpy = jest.spyOn(logger['console'], methodOfLogger).mockImplementation();
 
+          interface ArbitraryObject { value: 'CUSTOM' | 'USER_DEFINED' }
+          const arbitraryObject: ArbitraryObject = { value: 'CUSTOM' };
+
           // Act
           if (logger[methodOfLogger]) {
             logger[methodOfLogger]('A log item without extra parameters');
@@ -289,6 +292,8 @@ describe('Class: Logger', () => {
             logger[methodOfLogger]('A log item with a string as first parameter, and an error as second parameter', new Error('Something happened!'));
             logger[methodOfLogger]('A log item with a string as first parameter, and an error with custom key as second parameter', { myCustomErrorKey: new Error('Something happened!') });
             logger[methodOfLogger]('A log item with a string as first parameter, and a string as second parameter', 'parameter');
+            logger[methodOfLogger]('A log item with a string as first parameter, and an inline object as second parameter', { extra: { custom: mockDate } });
+            logger[methodOfLogger]('A log item with a string as first parameter, and an arbitrary object as second parameter', { extra: arbitraryObject });
           }
 
           // Assess
@@ -359,6 +364,22 @@ describe('Class: Logger', () => {
             timestamp: '2016-06-20T12:08:10.000Z',
             xray_trace_id: '1-5759e988-bd862e3fe1be46a994272793',
             extra: 'parameter',
+          }));
+          expect(consoleSpy).toHaveBeenNthCalledWith(8, JSON.stringify({
+            level: method.toUpperCase(),
+            message: 'A log item with a string as first parameter, and an inline object as second parameter',
+            service: 'hello-world',
+            timestamp: '2016-06-20T12:08:10.000Z',
+            xray_trace_id: '1-5759e988-bd862e3fe1be46a994272793',
+            extra: { custom: '2016-06-20T12:08:10.000Z' }
+          }));
+          expect(consoleSpy).toHaveBeenNthCalledWith(9, JSON.stringify({
+            level: method.toUpperCase(),
+            message: 'A log item with a string as first parameter, and an arbitrary object as second parameter',
+            service: 'hello-world',
+            timestamp: '2016-06-20T12:08:10.000Z',
+            xray_trace_id: '1-5759e988-bd862e3fe1be46a994272793',
+            extra: { value: 'CUSTOM' }
           }));
         });
       });


### PR DESCRIPTION
## Description of your changes

This PR relaxes the restrictions introduced by #614. In #565, we decided to restrict the additional logging data objects in their shape. It turned out, that this restriction prevents from logging of arbitrary objects, which is inconvenient.  
In this PR, the type restrictions are removed, so it is now possible to specify any object as additional payload when calling the logger methods directly.

### How to verify this change

- Run unit tests
- Run E2E tests
- Review docs and examples
- Try to log an arbitrary object by providing it as a property of a string-indexed object, e.g.

```typescript
import { Logger } from '@aws-lambda-powertools/logger';

const logger = new Logger({ logLevel: 'DEBUG' });

export const handler = async (event) => {
  logger.debug('Lambda invoked', { details: { event } });
};
```

No compile time errors should be generated for the above example. The code should generate a valid log entry when executed.

### Related issues, RFCs

[#880](https://github.com/awslabs/aws-lambda-powertools-typescript/issues/880)  

### PR status

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [x] I have made corresponding changes to the *documentation*
- [x] I have made corresponding changes to the *examples*
- [x] My changes generate *no new warnings*
- [x] The *code coverage* hasn't decreased
- [x] I have *added tests* that prove my change is effective and works
- [x] New and existing *unit tests pass* locally and in Github Actions
- [ ] Any *dependent changes have been merged and published* in downstream module
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

- [ ] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
