### PR TITLE
build: bump examples version

### DIFF
--- a/examples/cdk/package-lock.json
+++ b/examples/cdk/package-lock.json
@@ -9,9 +9,9 @@
       "version": "0.10.0",
       "license": "MIT-0",
       "dependencies": {
-        "@aws-lambda-powertools/logger": "^0.7.0",
-        "@aws-lambda-powertools/metrics": "^0.7.0",
-        "@aws-lambda-powertools/tracer": "^0.7.0",
+        "@aws-lambda-powertools/logger": "^0.10.0",
+        "@aws-lambda-powertools/metrics": "^0.10.0",
+        "@aws-lambda-powertools/tracer": "^0.10.0",
         "@aws-sdk/client-sts": "^3.53.0",
         "@middy/core": "^2.5.6",
         "@types/aws-lambda": "^8.10.86",
@@ -123,36 +123,36 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-lambda-powertools/commons": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/commons/-/commons-0.7.0.tgz",
-      "integrity": "sha512-IrgZBlIyHn0qVtK4fxVP2js+mB2sapos3VgX0xECohQaHON7xYiLBphWB7qy8PrR7JNSpZGOKbZsHAqgpQzs2Q=="
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/commons/-/commons-0.10.0.tgz",
+      "integrity": "sha512-p2YDo2XIniMEw1a+NtPMvcALnpwJKpznOcKVZyEzwUEvluLl/cJwwVa0c4y6ye6iw+xD0Tp1T7I2t8gKYtU5zQ=="
     },
     "node_modules/@aws-lambda-powertools/logger": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/logger/-/logger-0.7.0.tgz",
-      "integrity": "sha512-bylPCFpfib7+6qGUd5TbR4Ifw1zyEo3sbQbJ/LwDAsAtrLeSPkhQaa4B2e6AytzP9Rdy33thAxXZbUAK2JotTA==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/logger/-/logger-0.10.0.tgz",
+      "integrity": "sha512-S+lJfXK74Qo3yedj8QdmXnl88YjOD6jOMcxiCqlyzCL77oMcvHXZpsEsofW9EjaYKKQZHpKgZWtm3FcalZ/+fg==",
       "dependencies": {
-        "@aws-lambda-powertools/commons": "^0.7.0",
+        "@aws-lambda-powertools/commons": "^0.10.0",
         "lodash.clonedeep": "^4.5.0",
         "lodash.merge": "^4.6.2",
         "lodash.pickby": "^4.6.0"
       }
     },
     "node_modules/@aws-lambda-powertools/metrics": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/metrics/-/metrics-0.7.0.tgz",
-      "integrity": "sha512-JNkttp0h5YxpXSDwt6WIRhR8TZzW12oq/cfWmsIMn+/4SBr1kX74QHDvCJxIq4YcT/1oKXpPZSjJOdupg9SEIA==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/metrics/-/metrics-0.10.0.tgz",
+      "integrity": "sha512-t1d3rKjnp/f8YqvarUbmQV2F47vvYygetxDzECSFBSV72PDa38bILBmulzdSYQT5mb33EHoz4Hq2v70nAWeDLA==",
       "dependencies": {
-        "@aws-lambda-powertools/commons": "^0.7.0"
+        "@aws-lambda-powertools/commons": "^0.10.0"
       }
     },
     "node_modules/@aws-lambda-powertools/tracer": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/tracer/-/tracer-0.7.0.tgz",
-      "integrity": "sha512-mpC7B5wzxV7i13TXGw8VpmtvujdZLFcZW46++aJRlhaBT3EYWIDYKadBQDbLN5UnRq+UU2UGUWmjTgMbycw+RQ==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/tracer/-/tracer-0.10.0.tgz",
+      "integrity": "sha512-RDlrJhPe4C/PvFOrIUDEnf/6mvpVdFjmHI+WYsXWbMvQwfvRkN9Bv+0m2JMaJg+n7vm/ho1qAC7TvyhUPYZPrg==",
       "dependencies": {
-        "@aws-lambda-powertools/commons": "^0.7.0",
-        "aws-xray-sdk-core": "^3.3.3"
+        "@aws-lambda-powertools/commons": "^0.10.0",
+        "aws-xray-sdk-core": "^3.3.4"
       }
     },
     "node_modules/@aws-sdk/abort-controller": {
@@ -6717,36 +6717,36 @@
       }
     },
     "@aws-lambda-powertools/commons": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/commons/-/commons-0.7.0.tgz",
-      "integrity": "sha512-IrgZBlIyHn0qVtK4fxVP2js+mB2sapos3VgX0xECohQaHON7xYiLBphWB7qy8PrR7JNSpZGOKbZsHAqgpQzs2Q=="
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/commons/-/commons-0.10.0.tgz",
+      "integrity": "sha512-p2YDo2XIniMEw1a+NtPMvcALnpwJKpznOcKVZyEzwUEvluLl/cJwwVa0c4y6ye6iw+xD0Tp1T7I2t8gKYtU5zQ=="
     },
     "@aws-lambda-powertools/logger": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/logger/-/logger-0.7.0.tgz",
-      "integrity": "sha512-bylPCFpfib7+6qGUd5TbR4Ifw1zyEo3sbQbJ/LwDAsAtrLeSPkhQaa4B2e6AytzP9Rdy33thAxXZbUAK2JotTA==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/logger/-/logger-0.10.0.tgz",
+      "integrity": "sha512-S+lJfXK74Qo3yedj8QdmXnl88YjOD6jOMcxiCqlyzCL77oMcvHXZpsEsofW9EjaYKKQZHpKgZWtm3FcalZ/+fg==",
       "requires": {
-        "@aws-lambda-powertools/commons": "^0.7.0",
+        "@aws-lambda-powertools/commons": "^0.10.0",
         "lodash.clonedeep": "^4.5.0",
         "lodash.merge": "^4.6.2",
         "lodash.pickby": "^4.6.0"
       }
     },
     "@aws-lambda-powertools/metrics": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/metrics/-/metrics-0.7.0.tgz",
-      "integrity": "sha512-JNkttp0h5YxpXSDwt6WIRhR8TZzW12oq/cfWmsIMn+/4SBr1kX74QHDvCJxIq4YcT/1oKXpPZSjJOdupg9SEIA==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/metrics/-/metrics-0.10.0.tgz",
+      "integrity": "sha512-t1d3rKjnp/f8YqvarUbmQV2F47vvYygetxDzECSFBSV72PDa38bILBmulzdSYQT5mb33EHoz4Hq2v70nAWeDLA==",
       "requires": {
-        "@aws-lambda-powertools/commons": "^0.7.0"
+        "@aws-lambda-powertools/commons": "^0.10.0"
       }
     },
     "@aws-lambda-powertools/tracer": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/tracer/-/tracer-0.7.0.tgz",
-      "integrity": "sha512-mpC7B5wzxV7i13TXGw8VpmtvujdZLFcZW46++aJRlhaBT3EYWIDYKadBQDbLN5UnRq+UU2UGUWmjTgMbycw+RQ==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/tracer/-/tracer-0.10.0.tgz",
+      "integrity": "sha512-RDlrJhPe4C/PvFOrIUDEnf/6mvpVdFjmHI+WYsXWbMvQwfvRkN9Bv+0m2JMaJg+n7vm/ho1qAC7TvyhUPYZPrg==",
       "requires": {
-        "@aws-lambda-powertools/commons": "^0.7.0",
-        "aws-xray-sdk-core": "^3.3.3"
+        "@aws-lambda-powertools/commons": "^0.10.0",
+        "aws-xray-sdk-core": "^3.3.4"
       }
     },
     "@aws-sdk/abort-controller": {

--- a/examples/cdk/package.json
+++ b/examples/cdk/package.json
@@ -31,9 +31,9 @@
     "typescript": "^4.1.3"
   },
   "dependencies": {
-    "@aws-lambda-powertools/logger": "^0.7.0",
-    "@aws-lambda-powertools/metrics": "^0.7.0",
-    "@aws-lambda-powertools/tracer": "^0.7.0",
+    "@aws-lambda-powertools/logger": "^0.10.0",
+    "@aws-lambda-powertools/metrics": "^0.10.0",
+    "@aws-lambda-powertools/tracer": "^0.10.0",
     "@aws-sdk/client-sts": "^3.53.0",
     "@middy/core": "^2.5.6",
     "@types/aws-lambda": "^8.10.86",

--- a/examples/sam/package-lock.json
+++ b/examples/sam/package-lock.json
@@ -9,9 +9,9 @@
       "version": "0.10.0",
       "license": "MIT-0",
       "dependencies": {
-        "@aws-lambda-powertools/logger": "^0.7.0",
-        "@aws-lambda-powertools/metrics": "^0.7.0",
-        "@aws-lambda-powertools/tracer": "^0.7.0",
+        "@aws-lambda-powertools/logger": "^0.10.0",
+        "@aws-lambda-powertools/metrics": "^0.10.0",
+        "@aws-lambda-powertools/tracer": "^0.10.0",
         "aws-sdk": "^2.1122.0"
       },
       "devDependencies": {
@@ -39,36 +39,36 @@
       }
     },
     "node_modules/@aws-lambda-powertools/commons": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/commons/-/commons-0.7.2.tgz",
-      "integrity": "sha512-GhOuenLRJTbmK7YuthRODOL/bEYhgXqwmz7uKEFyN4lkt+ZTb5+vDMTuj0eiry6jGKEw0u9ainfUxd0x/QjFxw=="
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/commons/-/commons-0.10.0.tgz",
+      "integrity": "sha512-p2YDo2XIniMEw1a+NtPMvcALnpwJKpznOcKVZyEzwUEvluLl/cJwwVa0c4y6ye6iw+xD0Tp1T7I2t8gKYtU5zQ=="
     },
     "node_modules/@aws-lambda-powertools/logger": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/logger/-/logger-0.7.0.tgz",
-      "integrity": "sha512-bylPCFpfib7+6qGUd5TbR4Ifw1zyEo3sbQbJ/LwDAsAtrLeSPkhQaa4B2e6AytzP9Rdy33thAxXZbUAK2JotTA==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/logger/-/logger-0.10.0.tgz",
+      "integrity": "sha512-S+lJfXK74Qo3yedj8QdmXnl88YjOD6jOMcxiCqlyzCL77oMcvHXZpsEsofW9EjaYKKQZHpKgZWtm3FcalZ/+fg==",
       "dependencies": {
-        "@aws-lambda-powertools/commons": "^0.7.0",
+        "@aws-lambda-powertools/commons": "^0.10.0",
         "lodash.clonedeep": "^4.5.0",
         "lodash.merge": "^4.6.2",
         "lodash.pickby": "^4.6.0"
       }
     },
     "node_modules/@aws-lambda-powertools/metrics": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/metrics/-/metrics-0.7.0.tgz",
-      "integrity": "sha512-JNkttp0h5YxpXSDwt6WIRhR8TZzW12oq/cfWmsIMn+/4SBr1kX74QHDvCJxIq4YcT/1oKXpPZSjJOdupg9SEIA==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/metrics/-/metrics-0.10.0.tgz",
+      "integrity": "sha512-t1d3rKjnp/f8YqvarUbmQV2F47vvYygetxDzECSFBSV72PDa38bILBmulzdSYQT5mb33EHoz4Hq2v70nAWeDLA==",
       "dependencies": {
-        "@aws-lambda-powertools/commons": "^0.7.0"
+        "@aws-lambda-powertools/commons": "^0.10.0"
       }
     },
     "node_modules/@aws-lambda-powertools/tracer": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/tracer/-/tracer-0.7.0.tgz",
-      "integrity": "sha512-mpC7B5wzxV7i13TXGw8VpmtvujdZLFcZW46++aJRlhaBT3EYWIDYKadBQDbLN5UnRq+UU2UGUWmjTgMbycw+RQ==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/tracer/-/tracer-0.10.0.tgz",
+      "integrity": "sha512-RDlrJhPe4C/PvFOrIUDEnf/6mvpVdFjmHI+WYsXWbMvQwfvRkN9Bv+0m2JMaJg+n7vm/ho1qAC7TvyhUPYZPrg==",
       "dependencies": {
-        "@aws-lambda-powertools/commons": "^0.7.0",
-        "aws-xray-sdk-core": "^3.3.3"
+        "@aws-lambda-powertools/commons": "^0.10.0",
+        "aws-xray-sdk-core": "^3.3.4"
       }
     },
     "node_modules/@aws-sdk/service-error-classification": {
@@ -5409,36 +5409,36 @@
       }
     },
     "@aws-lambda-powertools/commons": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/commons/-/commons-0.7.2.tgz",
-      "integrity": "sha512-GhOuenLRJTbmK7YuthRODOL/bEYhgXqwmz7uKEFyN4lkt+ZTb5+vDMTuj0eiry6jGKEw0u9ainfUxd0x/QjFxw=="
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/commons/-/commons-0.10.0.tgz",
+      "integrity": "sha512-p2YDo2XIniMEw1a+NtPMvcALnpwJKpznOcKVZyEzwUEvluLl/cJwwVa0c4y6ye6iw+xD0Tp1T7I2t8gKYtU5zQ=="
     },
     "@aws-lambda-powertools/logger": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/logger/-/logger-0.7.0.tgz",
-      "integrity": "sha512-bylPCFpfib7+6qGUd5TbR4Ifw1zyEo3sbQbJ/LwDAsAtrLeSPkhQaa4B2e6AytzP9Rdy33thAxXZbUAK2JotTA==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/logger/-/logger-0.10.0.tgz",
+      "integrity": "sha512-S+lJfXK74Qo3yedj8QdmXnl88YjOD6jOMcxiCqlyzCL77oMcvHXZpsEsofW9EjaYKKQZHpKgZWtm3FcalZ/+fg==",
       "requires": {
-        "@aws-lambda-powertools/commons": "^0.7.0",
+        "@aws-lambda-powertools/commons": "^0.10.0",
         "lodash.clonedeep": "^4.5.0",
         "lodash.merge": "^4.6.2",
         "lodash.pickby": "^4.6.0"
       }
     },
     "@aws-lambda-powertools/metrics": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/metrics/-/metrics-0.7.0.tgz",
-      "integrity": "sha512-JNkttp0h5YxpXSDwt6WIRhR8TZzW12oq/cfWmsIMn+/4SBr1kX74QHDvCJxIq4YcT/1oKXpPZSjJOdupg9SEIA==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/metrics/-/metrics-0.10.0.tgz",
+      "integrity": "sha512-t1d3rKjnp/f8YqvarUbmQV2F47vvYygetxDzECSFBSV72PDa38bILBmulzdSYQT5mb33EHoz4Hq2v70nAWeDLA==",
       "requires": {
-        "@aws-lambda-powertools/commons": "^0.7.0"
+        "@aws-lambda-powertools/commons": "^0.10.0"
       }
     },
     "@aws-lambda-powertools/tracer": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/tracer/-/tracer-0.7.0.tgz",
-      "integrity": "sha512-mpC7B5wzxV7i13TXGw8VpmtvujdZLFcZW46++aJRlhaBT3EYWIDYKadBQDbLN5UnRq+UU2UGUWmjTgMbycw+RQ==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/tracer/-/tracer-0.10.0.tgz",
+      "integrity": "sha512-RDlrJhPe4C/PvFOrIUDEnf/6mvpVdFjmHI+WYsXWbMvQwfvRkN9Bv+0m2JMaJg+n7vm/ho1qAC7TvyhUPYZPrg==",
       "requires": {
-        "@aws-lambda-powertools/commons": "^0.7.0",
-        "aws-xray-sdk-core": "^3.3.3"
+        "@aws-lambda-powertools/commons": "^0.10.0",
+        "aws-xray-sdk-core": "^3.3.4"
       }
     },
     "@aws-sdk/service-error-classification": {

--- a/examples/sam/package.json
+++ b/examples/sam/package.json
@@ -26,9 +26,9 @@
     "typescript": "^4.1.3"
   },
   "dependencies": {
-    "@aws-lambda-powertools/logger": "^0.7.0",
-    "@aws-lambda-powertools/metrics": "^0.7.0",
-    "@aws-lambda-powertools/tracer": "^0.7.0",
+    "@aws-lambda-powertools/logger": "^0.10.0",
+    "@aws-lambda-powertools/metrics": "^0.10.0",
+    "@aws-lambda-powertools/tracer": "^0.10.0",
     "aws-sdk": "^2.1122.0"
   }
 }


### PR DESCRIPTION
## Description of your changes

In #925 we moved to `es2019` as a build target in an effort to support the Node.js 12.x in AWS Lambda. Now that the version (`v0.10.0`) has been released, this PR bumps the version in the `examples/*` folders to use it.

### How to verify this change

Check the result of the GitHub Actions that should be passing.

### Related issues, RFCs

#925 

### PR status

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have made corresponding changes to the *examples*
- [x] My changes generate *no new warnings*
- [x] The *code coverage* hasn't decreased
- [x] New and existing *unit tests pass* locally and in Github Actions
- [x] Any *dependent changes have been merged and published* in downstream module
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

N/A

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
