### PR TITLE
build(deps): bump broken Depdendabot deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -316,12 +316,12 @@
       "link": true
     },
     "node_modules/@aws-sdk/abort-controller": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.55.0.tgz",
-      "integrity": "sha512-rCcTxJDEFnmvo/PgbhCRv24/Uv03lEGfRslKZq7SjaMcOubflS/ZXYaMEgsjYHgAT0zlpSsyCIkJXmhFaM7H7w==",
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.78.0.tgz",
+      "integrity": "sha512-iz1YLwM2feJUj/y97yO4XmDeTxs+yZ1XJwQgoawKuc8IDBKUutnJNCHL5jL04WUKU7Nrlq+Hr2fCTScFh2z9zg==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.55.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -329,45 +329,45 @@
       }
     },
     "node_modules/@aws-sdk/client-dynamodb": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.58.0.tgz",
-      "integrity": "sha512-54uclCvSVREutcty19NqfzC5V/0ebYSz51lz5jQpHYObP2uUAKOunTAWx1lnWACZ9U9Ka6SHWN/NhKFXeMKwgw==",
+      "version": "3.100.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.100.0.tgz",
+      "integrity": "sha512-0/PDutv4DDEpckH89x0hn6yFJGjtGhV+JnVimMw0dT+f+plWt706RTqPKgLCPftKTEDWncoQlSux+FO7vvXb4Q==",
       "dev": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.58.0",
-        "@aws-sdk/config-resolver": "3.58.0",
-        "@aws-sdk/credential-provider-node": "3.58.0",
-        "@aws-sdk/fetch-http-handler": "3.58.0",
-        "@aws-sdk/hash-node": "3.55.0",
-        "@aws-sdk/invalid-dependency": "3.55.0",
-        "@aws-sdk/middleware-content-length": "3.58.0",
-        "@aws-sdk/middleware-endpoint-discovery": "3.58.0",
-        "@aws-sdk/middleware-host-header": "3.58.0",
-        "@aws-sdk/middleware-logger": "3.55.0",
-        "@aws-sdk/middleware-retry": "3.58.0",
-        "@aws-sdk/middleware-serde": "3.55.0",
-        "@aws-sdk/middleware-signing": "3.58.0",
-        "@aws-sdk/middleware-stack": "3.55.0",
-        "@aws-sdk/middleware-user-agent": "3.58.0",
-        "@aws-sdk/node-config-provider": "3.58.0",
-        "@aws-sdk/node-http-handler": "3.58.0",
-        "@aws-sdk/protocol-http": "3.58.0",
-        "@aws-sdk/smithy-client": "3.55.0",
-        "@aws-sdk/types": "3.55.0",
-        "@aws-sdk/url-parser": "3.55.0",
+        "@aws-sdk/client-sts": "3.100.0",
+        "@aws-sdk/config-resolver": "3.80.0",
+        "@aws-sdk/credential-provider-node": "3.100.0",
+        "@aws-sdk/fetch-http-handler": "3.78.0",
+        "@aws-sdk/hash-node": "3.78.0",
+        "@aws-sdk/invalid-dependency": "3.78.0",
+        "@aws-sdk/middleware-content-length": "3.78.0",
+        "@aws-sdk/middleware-endpoint-discovery": "3.80.0",
+        "@aws-sdk/middleware-host-header": "3.78.0",
+        "@aws-sdk/middleware-logger": "3.78.0",
+        "@aws-sdk/middleware-retry": "3.80.0",
+        "@aws-sdk/middleware-serde": "3.78.0",
+        "@aws-sdk/middleware-signing": "3.78.0",
+        "@aws-sdk/middleware-stack": "3.78.0",
+        "@aws-sdk/middleware-user-agent": "3.78.0",
+        "@aws-sdk/node-config-provider": "3.80.0",
+        "@aws-sdk/node-http-handler": "3.94.0",
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/smithy-client": "3.99.0",
+        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/url-parser": "3.78.0",
         "@aws-sdk/util-base64-browser": "3.58.0",
         "@aws-sdk/util-base64-node": "3.55.0",
         "@aws-sdk/util-body-length-browser": "3.55.0",
         "@aws-sdk/util-body-length-node": "3.55.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.55.0",
-        "@aws-sdk/util-defaults-mode-node": "3.58.0",
-        "@aws-sdk/util-user-agent-browser": "3.58.0",
-        "@aws-sdk/util-user-agent-node": "3.58.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.99.0",
+        "@aws-sdk/util-defaults-mode-node": "3.99.0",
+        "@aws-sdk/util-user-agent-browser": "3.78.0",
+        "@aws-sdk/util-user-agent-node": "3.80.0",
         "@aws-sdk/util-utf8-browser": "3.55.0",
         "@aws-sdk/util-utf8-node": "3.55.0",
-        "@aws-sdk/util-waiter": "3.55.0",
+        "@aws-sdk/util-waiter": "3.78.0",
         "tslib": "^2.3.1",
         "uuid": "^8.3.2"
       },
@@ -376,38 +376,38 @@
       }
     },
     "node_modules/@aws-sdk/client-sso": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.58.0.tgz",
-      "integrity": "sha512-nS5G/OX8Bg4ajBa6+jLcbbr4PpEO+l5eJfGUzoJQwS4Zqa0lF/wC0kyjKm61gLp4JuvhrQskxIC/3IXUqB1XVQ==",
+      "version": "3.100.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.100.0.tgz",
+      "integrity": "sha512-nmBRUO5QfQ2IO8fHb37p8HT3n1ZooPb3sfTQejrpFH9Eq82VEOatIGt6yH3yTQ8+mhbabEhV5aY2wt/0D7wGVA==",
       "dev": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.58.0",
-        "@aws-sdk/fetch-http-handler": "3.58.0",
-        "@aws-sdk/hash-node": "3.55.0",
-        "@aws-sdk/invalid-dependency": "3.55.0",
-        "@aws-sdk/middleware-content-length": "3.58.0",
-        "@aws-sdk/middleware-host-header": "3.58.0",
-        "@aws-sdk/middleware-logger": "3.55.0",
-        "@aws-sdk/middleware-retry": "3.58.0",
-        "@aws-sdk/middleware-serde": "3.55.0",
-        "@aws-sdk/middleware-stack": "3.55.0",
-        "@aws-sdk/middleware-user-agent": "3.58.0",
-        "@aws-sdk/node-config-provider": "3.58.0",
-        "@aws-sdk/node-http-handler": "3.58.0",
-        "@aws-sdk/protocol-http": "3.58.0",
-        "@aws-sdk/smithy-client": "3.55.0",
-        "@aws-sdk/types": "3.55.0",
-        "@aws-sdk/url-parser": "3.55.0",
+        "@aws-sdk/config-resolver": "3.80.0",
+        "@aws-sdk/fetch-http-handler": "3.78.0",
+        "@aws-sdk/hash-node": "3.78.0",
+        "@aws-sdk/invalid-dependency": "3.78.0",
+        "@aws-sdk/middleware-content-length": "3.78.0",
+        "@aws-sdk/middleware-host-header": "3.78.0",
+        "@aws-sdk/middleware-logger": "3.78.0",
+        "@aws-sdk/middleware-retry": "3.80.0",
+        "@aws-sdk/middleware-serde": "3.78.0",
+        "@aws-sdk/middleware-stack": "3.78.0",
+        "@aws-sdk/middleware-user-agent": "3.78.0",
+        "@aws-sdk/node-config-provider": "3.80.0",
+        "@aws-sdk/node-http-handler": "3.94.0",
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/smithy-client": "3.99.0",
+        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/url-parser": "3.78.0",
         "@aws-sdk/util-base64-browser": "3.58.0",
         "@aws-sdk/util-base64-node": "3.55.0",
         "@aws-sdk/util-body-length-browser": "3.55.0",
         "@aws-sdk/util-body-length-node": "3.55.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.55.0",
-        "@aws-sdk/util-defaults-mode-node": "3.58.0",
-        "@aws-sdk/util-user-agent-browser": "3.58.0",
-        "@aws-sdk/util-user-agent-node": "3.58.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.99.0",
+        "@aws-sdk/util-defaults-mode-node": "3.99.0",
+        "@aws-sdk/util-user-agent-browser": "3.78.0",
+        "@aws-sdk/util-user-agent-node": "3.80.0",
         "@aws-sdk/util-utf8-browser": "3.55.0",
         "@aws-sdk/util-utf8-node": "3.55.0",
         "tslib": "^2.3.1"
@@ -417,41 +417,41 @@
       }
     },
     "node_modules/@aws-sdk/client-sts": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.58.0.tgz",
-      "integrity": "sha512-2cHZsG2eXv/Zl0hvsG9+rdHEuAclMFfkma/3LC3RRwSuZXo1rXoIhFkzHfGfIbivdk738YAo7FT3ZYGlrsK4ow==",
+      "version": "3.100.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.100.0.tgz",
+      "integrity": "sha512-WHy0e6COf6/LfMsYqG9H4SGaQRDjuckMtwOLtu6cYr4cro3bOU5pNuyEjAdUHCpuhZgiE6gkZozhTlxMJqIuRQ==",
       "dev": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.58.0",
-        "@aws-sdk/credential-provider-node": "3.58.0",
-        "@aws-sdk/fetch-http-handler": "3.58.0",
-        "@aws-sdk/hash-node": "3.55.0",
-        "@aws-sdk/invalid-dependency": "3.55.0",
-        "@aws-sdk/middleware-content-length": "3.58.0",
-        "@aws-sdk/middleware-host-header": "3.58.0",
-        "@aws-sdk/middleware-logger": "3.55.0",
-        "@aws-sdk/middleware-retry": "3.58.0",
-        "@aws-sdk/middleware-sdk-sts": "3.58.0",
-        "@aws-sdk/middleware-serde": "3.55.0",
-        "@aws-sdk/middleware-signing": "3.58.0",
-        "@aws-sdk/middleware-stack": "3.55.0",
-        "@aws-sdk/middleware-user-agent": "3.58.0",
-        "@aws-sdk/node-config-provider": "3.58.0",
-        "@aws-sdk/node-http-handler": "3.58.0",
-        "@aws-sdk/protocol-http": "3.58.0",
-        "@aws-sdk/smithy-client": "3.55.0",
-        "@aws-sdk/types": "3.55.0",
-        "@aws-sdk/url-parser": "3.55.0",
+        "@aws-sdk/config-resolver": "3.80.0",
+        "@aws-sdk/credential-provider-node": "3.100.0",
+        "@aws-sdk/fetch-http-handler": "3.78.0",
+        "@aws-sdk/hash-node": "3.78.0",
+        "@aws-sdk/invalid-dependency": "3.78.0",
+        "@aws-sdk/middleware-content-length": "3.78.0",
+        "@aws-sdk/middleware-host-header": "3.78.0",
+        "@aws-sdk/middleware-logger": "3.78.0",
+        "@aws-sdk/middleware-retry": "3.80.0",
+        "@aws-sdk/middleware-sdk-sts": "3.78.0",
+        "@aws-sdk/middleware-serde": "3.78.0",
+        "@aws-sdk/middleware-signing": "3.78.0",
+        "@aws-sdk/middleware-stack": "3.78.0",
+        "@aws-sdk/middleware-user-agent": "3.78.0",
+        "@aws-sdk/node-config-provider": "3.80.0",
+        "@aws-sdk/node-http-handler": "3.94.0",
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/smithy-client": "3.99.0",
+        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/url-parser": "3.78.0",
         "@aws-sdk/util-base64-browser": "3.58.0",
         "@aws-sdk/util-base64-node": "3.55.0",
         "@aws-sdk/util-body-length-browser": "3.55.0",
         "@aws-sdk/util-body-length-node": "3.55.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.55.0",
-        "@aws-sdk/util-defaults-mode-node": "3.58.0",
-        "@aws-sdk/util-user-agent-browser": "3.58.0",
-        "@aws-sdk/util-user-agent-node": "3.58.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.99.0",
+        "@aws-sdk/util-defaults-mode-node": "3.99.0",
+        "@aws-sdk/util-user-agent-browser": "3.78.0",
+        "@aws-sdk/util-user-agent-node": "3.80.0",
         "@aws-sdk/util-utf8-browser": "3.55.0",
         "@aws-sdk/util-utf8-node": "3.55.0",
         "entities": "2.2.0",
@@ -463,15 +463,15 @@
       }
     },
     "node_modules/@aws-sdk/config-resolver": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.58.0.tgz",
-      "integrity": "sha512-NXEwYw0JrXcvenu42QpNMQXK+6pgZ+6bDGfCgOfCC0FmyI+w/CuF36lApwm7InHvHazOaDlwArXm2pfntErKoA==",
+      "version": "3.80.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.80.0.tgz",
+      "integrity": "sha512-vFruNKlmhsaC8yjnHmasi1WW/7EELlEuFTj4mqcqNqR4dfraf0maVvpqF1VSR8EstpFMsGYI5dmoWAnnG4PcLQ==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/signature-v4": "3.58.0",
-        "@aws-sdk/types": "3.55.0",
+        "@aws-sdk/signature-v4": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
         "@aws-sdk/util-config-provider": "3.55.0",
-        "@aws-sdk/util-middleware": "3.55.0",
+        "@aws-sdk/util-middleware": "3.78.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -479,13 +479,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.55.0.tgz",
-      "integrity": "sha512-4AIIXEdvinLlWNFtrUbUgoB7dkuV04RTcTruVWI4Ub4WSsuSCa72ZU1vqyvcEAOgGGLBmcSaGTWByjiD2sGcGA==",
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.78.0.tgz",
+      "integrity": "sha512-K41VTIzVHm2RyIwtBER8Hte3huUBXdV1WKO+i7olYVgLFmaqcZUNrlyoGDRqZcQ/u4AbxTzBU9jeMIbIfzMOWg==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/property-provider": "3.55.0",
-        "@aws-sdk/types": "3.55.0",
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -493,15 +493,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-imds": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.58.0.tgz",
-      "integrity": "sha512-CdtnTQ9zqLx1FbXdbgjijLbMcIWOyQM03TFaLSCjI3FNbUwyt3T7StBU9tj/LtbypHhSdXyQBpzUtXTOMWCEhg==",
+      "version": "3.81.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.81.0.tgz",
+      "integrity": "sha512-BHopP+gaovTYj+4tSrwCk8NNCR48gE9CWmpIOLkP9ell0gOL81Qh7aCEiIK0BZBZkccv1s16cYq1MSZZGS7PEQ==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/node-config-provider": "3.58.0",
-        "@aws-sdk/property-provider": "3.55.0",
-        "@aws-sdk/types": "3.55.0",
-        "@aws-sdk/url-parser": "3.55.0",
+        "@aws-sdk/node-config-provider": "3.80.0",
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/url-parser": "3.78.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -509,18 +509,18 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.58.0.tgz",
-      "integrity": "sha512-uM62hcHUVaHP1YFnbrjf2RlrRj1m/BvMPE+T5jdNRWdE3lvnunhEMawB26HZs9nQqCV6d25I8G9/fGWVL7g3Og==",
+      "version": "3.100.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.100.0.tgz",
+      "integrity": "sha512-2pCtth/Iv4mATRwb2g1nJdd9TolMyhTnhcskopukFvzp13VS5cgtz0hgYmJNnztTF8lpKJhJaidtKS5JJTWnHg==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.55.0",
-        "@aws-sdk/credential-provider-imds": "3.58.0",
-        "@aws-sdk/credential-provider-sso": "3.58.0",
-        "@aws-sdk/credential-provider-web-identity": "3.55.0",
-        "@aws-sdk/property-provider": "3.55.0",
-        "@aws-sdk/shared-ini-file-loader": "3.58.0",
-        "@aws-sdk/types": "3.55.0",
+        "@aws-sdk/credential-provider-env": "3.78.0",
+        "@aws-sdk/credential-provider-imds": "3.81.0",
+        "@aws-sdk/credential-provider-sso": "3.100.0",
+        "@aws-sdk/credential-provider-web-identity": "3.78.0",
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/shared-ini-file-loader": "3.80.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -528,20 +528,20 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.58.0.tgz",
-      "integrity": "sha512-f0wzcgMYCQUrii6TLP2ggCxkQP4HH8PW8tbbWEgt4cdIXcjE9KEuxN5yOV6sFHzL3eJh0QM9Yaz8WzhWn6fT2A==",
+      "version": "3.100.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.100.0.tgz",
+      "integrity": "sha512-PMIPnn/dhv9tlWR0qXnANJpTumujWfhKnLAsV3BUqB1K9IzWqz/zXjCT0jcSUTY8X/VkSuehtBdCKvOOM5mMqg==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.55.0",
-        "@aws-sdk/credential-provider-imds": "3.58.0",
-        "@aws-sdk/credential-provider-ini": "3.58.0",
-        "@aws-sdk/credential-provider-process": "3.58.0",
-        "@aws-sdk/credential-provider-sso": "3.58.0",
-        "@aws-sdk/credential-provider-web-identity": "3.55.0",
-        "@aws-sdk/property-provider": "3.55.0",
-        "@aws-sdk/shared-ini-file-loader": "3.58.0",
-        "@aws-sdk/types": "3.55.0",
+        "@aws-sdk/credential-provider-env": "3.78.0",
+        "@aws-sdk/credential-provider-imds": "3.81.0",
+        "@aws-sdk/credential-provider-ini": "3.100.0",
+        "@aws-sdk/credential-provider-process": "3.80.0",
+        "@aws-sdk/credential-provider-sso": "3.100.0",
+        "@aws-sdk/credential-provider-web-identity": "3.78.0",
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/shared-ini-file-loader": "3.80.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -549,14 +549,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.58.0.tgz",
-      "integrity": "sha512-npgFqPUjMhUamf1FvJjBYUdpbWx8XWkKCwJsX73I7IYQAvAi2atCOkdtKq+4rds0VWAYu6vzlaI1tXgFxjOPNQ==",
+      "version": "3.80.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.80.0.tgz",
+      "integrity": "sha512-3Ro+kMMyLUJHefOhGc5pOO/ibGcJi8bkj0z/Jtqd5I2Sm1qi7avoztST67/k48KMW1OqPnD/FUqxz5T8B2d+FQ==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/property-provider": "3.55.0",
-        "@aws-sdk/shared-ini-file-loader": "3.58.0",
-        "@aws-sdk/types": "3.55.0",
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/shared-ini-file-loader": "3.80.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -564,15 +564,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.58.0.tgz",
-      "integrity": "sha512-2qO34s9lJqvCC6zOF4UpopW6xURZpYfVC8xTUDpAUnvTOt4nS5hkx4vNyqPAXILoRHuFJsnlWsBH1UP5ZnBiZg==",
+      "version": "3.100.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.100.0.tgz",
+      "integrity": "sha512-DwJvrh77vBJ1/fS9z0i2QuIvSk4pATA4DH8AEWoQ8LQX97tp3es7gZV5Wu93wFsEyIYC8penz6pNVq5QajMk2A==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/client-sso": "3.58.0",
-        "@aws-sdk/property-provider": "3.55.0",
-        "@aws-sdk/shared-ini-file-loader": "3.58.0",
-        "@aws-sdk/types": "3.55.0",
+        "@aws-sdk/client-sso": "3.100.0",
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/shared-ini-file-loader": "3.80.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -580,13 +580,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.55.0.tgz",
-      "integrity": "sha512-aKnXfZNGohTuF9rCGYLg4JEIOvWIZ/sb66XMq7bOUrx13KRPDwL/eUQL8quS5jGRLpjXVNvrS17AFf65GbdUBg==",
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.78.0.tgz",
+      "integrity": "sha512-9/IvqHdJaVqMEABA8xZE3t5YF1S2PepfckVu0Ws9YUglj6oO+2QyVX6aRgMF1xph6781+Yc31TDh8/3eaDja7w==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/property-provider": "3.55.0",
-        "@aws-sdk/types": "3.55.0",
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -607,25 +607,25 @@
       }
     },
     "node_modules/@aws-sdk/fetch-http-handler": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.58.0.tgz",
-      "integrity": "sha512-timF3FjPV5Bd+Kgph83LIKVlPCFObVYzious1a6doeLAT6YFwZpRrWbfP/HzS+DCoYiwUsH69oVJ91BoV66oyA==",
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.78.0.tgz",
+      "integrity": "sha512-cR6r2h2kJ1DNEZSXC6GknQB7OKmy+s9ZNV+g3AsNqkrUmNNOaHpFoSn+m6SC3qaclcGd0eQBpqzSu/TDn23Ihw==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.58.0",
-        "@aws-sdk/querystring-builder": "3.55.0",
-        "@aws-sdk/types": "3.55.0",
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/querystring-builder": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
         "@aws-sdk/util-base64-browser": "3.58.0",
         "tslib": "^2.3.1"
       }
     },
     "node_modules/@aws-sdk/hash-node": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.55.0.tgz",
-      "integrity": "sha512-2UdYwY/++AlzWEAFaK9wOed2QSxbzV527vmqKjReLHpPKPrSIlooUxlTH3LU6Y6WVDAzDRtLK43KUVXTLgGK1A==",
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.78.0.tgz",
+      "integrity": "sha512-ev48yXaqZVtMeuKy52LUZPHCyKvkKQ9uiUebqkA+zFxIk+eN8SMPFHmsififIHWuS6ZkXBUSctjH9wmLebH60A==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.55.0",
+        "@aws-sdk/types": "3.78.0",
         "@aws-sdk/util-buffer-from": "3.55.0",
         "tslib": "^2.3.1"
       },
@@ -634,12 +634,12 @@
       }
     },
     "node_modules/@aws-sdk/invalid-dependency": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.55.0.tgz",
-      "integrity": "sha512-delH0lV+78fdD/8MXIt9kTLS6IwHvdhqq9dw/ow5VjTUw+xBwUlfPfZplaai+3hKTKWh6a2WZCeDasNItBv9aA==",
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.78.0.tgz",
+      "integrity": "sha512-zUo+PbeRMN/Mzj6y+6p9qqk/znuFetT1gmpOcZGL9Rp2T+b9WJWd+daq5ktsL10sVCzIt2UvneJRz6b+aU+bfw==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.55.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       }
     },
@@ -656,13 +656,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-content-length": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.58.0.tgz",
-      "integrity": "sha512-h/BypPkhjv2CpCUbXA8Fa2s7V2GPiz9l11XhYK+sKSuQvQ7Lbq6VhaKaLqfeD3gLVZHgJZSLGl2btdHV1qHNNA==",
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.78.0.tgz",
+      "integrity": "sha512-5MpKt6lB9TdFy25/AGrpOjPY0iDHZAKpEHc+jSOJBXLl6xunXA7qHdiYaVqkWodLxy70nIckGNHqQ3drabidkA==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.58.0",
-        "@aws-sdk/types": "3.55.0",
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -670,15 +670,15 @@
       }
     },
     "node_modules/@aws-sdk/middleware-endpoint-discovery": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.58.0.tgz",
-      "integrity": "sha512-Ll42zMPP8dDTHesv5VdnM0vgT4mW+kR2SgXCWBMuwnZdBn0FDH1A3E0BqJkLuuq2TKIah0/l1sA1qVC68GkAeA==",
+      "version": "3.80.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.80.0.tgz",
+      "integrity": "sha512-73pKz8ossZKisG684raP1dn2u3fQRktWY29oa9Q3cBvRYdyu5UOhwayt2MObgSC8S6NfNdTGC/DGf7+/JRSY7A==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/config-resolver": "3.58.0",
+        "@aws-sdk/config-resolver": "3.80.0",
         "@aws-sdk/endpoint-cache": "3.55.0",
-        "@aws-sdk/protocol-http": "3.58.0",
-        "@aws-sdk/types": "3.55.0",
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -686,13 +686,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.58.0.tgz",
-      "integrity": "sha512-q/UKGcanm9e6DBRNN6UKhVqLvpRRdZWbmmPCeDNr4HqhCmgT6i1OvWdhAMOnT++hvCX8DpTsIXzNSlY6zWAxBg==",
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.78.0.tgz",
+      "integrity": "sha512-1zL8uaDWGmH50c8B8jjz75e0ePj6/3QeZEhjJgTgL6DTdiqvRt32p3t+XWHW+yDI14fZZUYeTklAaLVxqFrHqQ==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.58.0",
-        "@aws-sdk/types": "3.55.0",
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -700,12 +700,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.55.0.tgz",
-      "integrity": "sha512-PtRbVrxEzDmeV9prBIP4/9or7R5Dj66mjbFSvNRGZ0n+UBfBFfVRfNrhQPNzQpfV9A3KVl9YyWCVXDSW+/rk9Q==",
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.78.0.tgz",
+      "integrity": "sha512-GBhwxNjhCJUIeQQDaGasX/C23Jay77al2vRyGwmxf8no0DdFsa4J1Ik6/2hhIqkqko+WM4SpCnpZrY4MtnxNvA==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.55.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -713,15 +713,15 @@
       }
     },
     "node_modules/@aws-sdk/middleware-retry": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.58.0.tgz",
-      "integrity": "sha512-sfSq+t0Yy47DQwrWGpA8iOx9sd26l4l1JDVTwHNi7+OKD4ClRPVCEdw3bTbbyYz/PV4f9AEfAZ6jwtSff4wkGw==",
+      "version": "3.80.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.80.0.tgz",
+      "integrity": "sha512-CTk+tA4+WMUNOcUfR6UQrkhwvPYFpnMsQ1vuHlpLFOGG3nCqywA2hueLMRQmVcDXzP0sGeygce6dzRI9dJB/GA==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.58.0",
-        "@aws-sdk/service-error-classification": "3.55.0",
-        "@aws-sdk/types": "3.55.0",
-        "@aws-sdk/util-middleware": "3.55.0",
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/service-error-classification": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/util-middleware": "3.78.0",
         "tslib": "^2.3.1",
         "uuid": "^8.3.2"
       },
@@ -730,16 +730,16 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-sts": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.58.0.tgz",
-      "integrity": "sha512-HUz7MhcsSDDTGygOwL61l4voc0pZco06J3z06JjTX19D5XxcQ7hSCtkHHHz0oMb9M1himVSiEon2tjhjsnB99g==",
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.78.0.tgz",
+      "integrity": "sha512-Lu/kN0J0/Kt0ON1hvwNel+y8yvf35licfIgtedHbBCa/ju8qQ9j+uL9Lla6Y5Tqu29yVaye1JxhiIDhscSwrLA==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/middleware-signing": "3.58.0",
-        "@aws-sdk/property-provider": "3.55.0",
-        "@aws-sdk/protocol-http": "3.58.0",
-        "@aws-sdk/signature-v4": "3.58.0",
-        "@aws-sdk/types": "3.55.0",
+        "@aws-sdk/middleware-signing": "3.78.0",
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/signature-v4": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -747,12 +747,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-serde": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.55.0.tgz",
-      "integrity": "sha512-NkEbTDrSZcC2NhuvfjXHKJEl0xgI2B5tMAwi/rMOq/TEnARwVUL9qAy+5lgeiPCqebiNllWatARrFgAaYf0VeA==",
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.78.0.tgz",
+      "integrity": "sha512-4DPsNOxsl1bxRzfo1WXEZjmD7OEi7qGNpxrDWucVe96Fqj2dH08jR8wxvBIVV1e6bAad07IwdPuCGmivNvwRuQ==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.55.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -760,15 +760,15 @@
       }
     },
     "node_modules/@aws-sdk/middleware-signing": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.58.0.tgz",
-      "integrity": "sha512-4FXubHB66GbhyZUlo6YPQoWpYfED15GNbEmHbJLSONzrVzZR3IkViSPLasDngVm1a050JqKuqNkFYGJBP4No/Q==",
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.78.0.tgz",
+      "integrity": "sha512-OEjJJCNhHHSOprLZ9CzjHIXEKFtPHWP/bG9pMhkV3/6Bmscsgcf8gWHcOnmIrjqX+hT1VALDNpl/RIh0J6/eQw==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/property-provider": "3.55.0",
-        "@aws-sdk/protocol-http": "3.58.0",
-        "@aws-sdk/signature-v4": "3.58.0",
-        "@aws-sdk/types": "3.55.0",
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/signature-v4": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -776,9 +776,9 @@
       }
     },
     "node_modules/@aws-sdk/middleware-stack": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.55.0.tgz",
-      "integrity": "sha512-ouD+wFz8W2R0ZQ8HrbhgN8tg1jyINEg9lPEEXY79w1Q5sf94LJ90XKAMVk02rw3dJalUWjLHf0OQe1/qxZfHyA==",
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.78.0.tgz",
+      "integrity": "sha512-UoNfRh6eAJN3BJHlG1eb+KeuSe+zARTC2cglroJRyHc2j7GxH2i9FD3IJbj5wvzopJEnQzuY/VCs6STFkqWL1g==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.1"
@@ -788,13 +788,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.58.0.tgz",
-      "integrity": "sha512-1c69bIWM63JwXijXvb9IWwcwQ/gViKMZ1lhxv52NvdG5VSxWXXsFJ2jETEXZoAypwT97Hmf3xo9SYuaHcKoq+g==",
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.78.0.tgz",
+      "integrity": "sha512-wdN5uoq8RxxhLhj0EPeuDSRFuXfUwKeEqRzCKMsYAOC0cAm+PryaP2leo0oTGJ9LUK8REK7zyfFcmtC4oOzlkA==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.58.0",
-        "@aws-sdk/types": "3.55.0",
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -802,14 +802,14 @@
       }
     },
     "node_modules/@aws-sdk/node-config-provider": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.58.0.tgz",
-      "integrity": "sha512-AMcPqPhKxo/3/yOMS9PsKlI0GWp2/8eD6gSlhzdBpznPCKplyqXOSnSX7wS814Cyh373hFSjCaOrCOA9/EYtDg==",
+      "version": "3.80.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.80.0.tgz",
+      "integrity": "sha512-vyTOMK04huB7n10ZUv0thd2TE6KlY8livOuLqFTMtj99AJ6vyeB5XBNwKnQtJIt/P7CijYgp8KcFvI9fndOmKg==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/property-provider": "3.55.0",
-        "@aws-sdk/shared-ini-file-loader": "3.58.0",
-        "@aws-sdk/types": "3.55.0",
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/shared-ini-file-loader": "3.80.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -817,15 +817,15 @@
       }
     },
     "node_modules/@aws-sdk/node-http-handler": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.58.0.tgz",
-      "integrity": "sha512-D9xVZG2nfo4GbPsby3JuBiAhpqXTFk1+CfuQU0AZv0gQvE3fFTCnB3za83jo7JV/pyRPU+s+/LHIpxCWUHzStg==",
+      "version": "3.94.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.94.0.tgz",
+      "integrity": "sha512-g9q6k+PS+BrtOzt8jrBWr9D543uB3ZoYZ2JCriwuCwnP4uIHlMf9wAOGcOgqgykfUAPBOLvz2rTwVs3Xl8GUmQ==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/abort-controller": "3.55.0",
-        "@aws-sdk/protocol-http": "3.58.0",
-        "@aws-sdk/querystring-builder": "3.55.0",
-        "@aws-sdk/types": "3.55.0",
+        "@aws-sdk/abort-controller": "3.78.0",
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/querystring-builder": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -833,12 +833,12 @@
       }
     },
     "node_modules/@aws-sdk/property-provider": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.55.0.tgz",
-      "integrity": "sha512-o7cKFJSHq5WOhwPsspYrzNto35oKKZvESZuWDtLxaZKSI6l7zpA366BI4kDG6Tc9i2+teV553MbxyZ9eya5A8g==",
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.78.0.tgz",
+      "integrity": "sha512-PZpLvV0hF6lqg3CSN9YmphrB/t5LVJVWGJLB9d9qm7sJs5ksjTYBb5bY91OQ3zit0F4cqBMU8xt2GQ9J6d4DvQ==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.55.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -846,12 +846,12 @@
       }
     },
     "node_modules/@aws-sdk/protocol-http": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.58.0.tgz",
-      "integrity": "sha512-0yFFRPbR+CCa9eOQBBQ2qtrIDLYqSMN0y7G4iqVM8wQdIw7n3QK1PsTI3RNPGJ3Oi2krFTw5uUKqQQZPZEBuVQ==",
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.78.0.tgz",
+      "integrity": "sha512-SQB26MhEK96yDxyXd3UAaxLz1Y/ZvgE4pzv7V3wZiokdEedM0kawHKEn1UQJlqJLEZcQI9QYyysh3rTvHZ3fyg==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.55.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -859,12 +859,12 @@
       }
     },
     "node_modules/@aws-sdk/querystring-builder": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.55.0.tgz",
-      "integrity": "sha512-/ZAXNipt9nRR8k+eowwukE/YjXnQ49p5w/MkaQxsBk3IuIf7MAcgVg8glHr0igH84GfUQ7ZVP8v+G2S3tKUG+Q==",
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.78.0.tgz",
+      "integrity": "sha512-aib6RW1WAaTQDqVgRU1Ku9idkhm90gJKbCxVaGId+as6QHNUqMChEfK2v+0afuKiPNOs5uWmqvOXI9+Gt+UGDg==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.55.0",
+        "@aws-sdk/types": "3.78.0",
         "@aws-sdk/util-uri-escape": "3.55.0",
         "tslib": "^2.3.1"
       },
@@ -873,12 +873,12 @@
       }
     },
     "node_modules/@aws-sdk/querystring-parser": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.55.0.tgz",
-      "integrity": "sha512-e+2FLgo+eDx7oh7ap5HngN9XSVMxredAVztLHxCcSN0lFHHHzMa8b2SpXbaowUxQHh7ziymSqvOrPYFQ71Filg==",
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.78.0.tgz",
+      "integrity": "sha512-csaH8YTyN+KMNczeK6fBS8l7iJaqcQcKOIbpQFg5upX4Ly5A56HJn4sVQhY1LSgfSk4xRsNfMy5mu6BlsIiaXA==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.55.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -886,17 +886,17 @@
       }
     },
     "node_modules/@aws-sdk/service-error-classification": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.55.0.tgz",
-      "integrity": "sha512-HdjnDyarsa1Avq1MJurkLyEe9c3eRa76dPmK4TmRGgwJ+tInEzGHL0rBW7V8xBK+PDF+fJQ71hvm8jPYmzvBwQ==",
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.78.0.tgz",
+      "integrity": "sha512-x7Lx8KWctJa01q4Q72Zb4ol9L/era3vy2daASu8l2paHHxsAPBE0PThkvLdUSLZSzlHSVdh3YHESIsT++VsK4w==",
       "engines": {
         "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/shared-ini-file-loader": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.58.0.tgz",
-      "integrity": "sha512-ARDKQerIzgNs/MFNdCEuK2lgRJ1lneAaJw0p9O1LkJUvcSibvkSATwny7vwJMueOf+ae1Pf+8+54OMNIt0nTkQ==",
+      "version": "3.80.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.80.0.tgz",
+      "integrity": "sha512-3d5EBJjnWWkjLK9skqLLHYbagtFaZZy+3jUTlbTuOKhlOwe8jF7CUM3j6I4JA6yXNcB3w0exDKKHa8w+l+05aA==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.1"
@@ -906,15 +906,15 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.58.0.tgz",
-      "integrity": "sha512-flEo8p3XkzWoBDqnIUQre4jLuT5aLnmfQNI8c2uSjyJ3OBxpJ0iS1cDu3E++d1/pN6Q8o0KOmr2ypHeiyBOujw==",
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.78.0.tgz",
+      "integrity": "sha512-eePjRYuzKoi3VMr/lgrUEF1ytLeH4fA/NMCykr/uR6NMo4bSJA59KrFLYSM7SlWLRIyB0UvJqygVEvSxFluyDw==",
       "dev": true,
       "dependencies": {
         "@aws-sdk/is-array-buffer": "3.55.0",
-        "@aws-sdk/types": "3.55.0",
+        "@aws-sdk/types": "3.78.0",
         "@aws-sdk/util-hex-encoding": "3.58.0",
-        "@aws-sdk/util-middleware": "3.55.0",
+        "@aws-sdk/util-middleware": "3.78.0",
         "@aws-sdk/util-uri-escape": "3.55.0",
         "tslib": "^2.3.1"
       },
@@ -923,13 +923,13 @@
       }
     },
     "node_modules/@aws-sdk/smithy-client": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.55.0.tgz",
-      "integrity": "sha512-YgBpqg6R3Qg8CH9biOP1N1lYTvh8VLGD6AoDGgy/R1dQSqRQuxgKANLl3DOVcZnIZLsw4TdB0m7U+ZPtirPR1Q==",
+      "version": "3.99.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.99.0.tgz",
+      "integrity": "sha512-N9xgCcwbOBZ4/WuROzlErExXV6+vFrFkNJzeBT31/avvrHXjxgxwQlMoXoQCfM8PyRuDuVSfZeoh1iIRfoxidA==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/middleware-stack": "3.55.0",
-        "@aws-sdk/types": "3.55.0",
+        "@aws-sdk/middleware-stack": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -937,21 +937,21 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.55.0.tgz",
-      "integrity": "sha512-wrDZjuy1CVAYxDCbm3bWQIKMGfNs7XXmG0eG4858Ixgqmq2avsIn5TORy8ynBxcXn9aekV/+tGEQ7BBSYzIVNQ==",
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.78.0.tgz",
+      "integrity": "sha512-I9PTlVNSbwhIgMfmDM5as1tqRIkVZunjVmfogb2WVVPp4CaX0Ll01S0FSMSLL9k6tcQLXqh45pFRjrxCl9WKdQ==",
       "engines": {
         "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/url-parser": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.55.0.tgz",
-      "integrity": "sha512-qrTwN5xIgTLreqLnZ+x3cAudjNKfxi6srW1H/px2mk4lb2U9B4fpGjZ6VU+XV8U2kR+YlT8J6Jo5iwuVGfC91A==",
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.78.0.tgz",
+      "integrity": "sha512-iQn2AjECUoJE0Ae9XtgHtGGKvUkvE8hhbktGopdj+zsPBe4WrBN2DgVxlKPPrBonG/YlcL1D7a5EXaujWSlUUw==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/querystring-parser": "3.55.0",
-        "@aws-sdk/types": "3.55.0",
+        "@aws-sdk/querystring-parser": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       }
     },
@@ -1024,13 +1024,13 @@
       }
     },
     "node_modules/@aws-sdk/util-defaults-mode-browser": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.55.0.tgz",
-      "integrity": "sha512-OS3gAwR84bHz7ObhjsSJM+grfeaBq3leGrj7xiX4BH3C8J+c10GMo3fqx1pV8Fq5F+9lMmhHpfOocD63SN5Q8A==",
+      "version": "3.99.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.99.0.tgz",
+      "integrity": "sha512-qSYjUGuN8n7Q/zAi0tzU4BrU389jQosXtjp7eHpLATl0pKGpaHx6rJNwbiNhvBhBEfmSgqsJ09b4gZUpUezHEw==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/property-provider": "3.55.0",
-        "@aws-sdk/types": "3.55.0",
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
         "bowser": "^2.11.0",
         "tslib": "^2.3.1"
       },
@@ -1039,16 +1039,16 @@
       }
     },
     "node_modules/@aws-sdk/util-defaults-mode-node": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.58.0.tgz",
-      "integrity": "sha512-KNUCp0MXI+z3Z3pQCKDkx3Stdy1TXDjcUB+ZJFxRTJGIuBYwX4fV6G8s/zeFJi5Qv1ztR3CJ9fWJGsrx9mQ5EA==",
+      "version": "3.99.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.99.0.tgz",
+      "integrity": "sha512-8TUO0kEnQcgT1gAW9y9oO6a5gKhfEGEUeKidEgbTczEUrjr3aCXIC+p0DI5FJfImwPrTKXra8A22utDM92phWw==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/config-resolver": "3.58.0",
-        "@aws-sdk/credential-provider-imds": "3.58.0",
-        "@aws-sdk/node-config-provider": "3.58.0",
-        "@aws-sdk/property-provider": "3.55.0",
-        "@aws-sdk/types": "3.55.0",
+        "@aws-sdk/config-resolver": "3.80.0",
+        "@aws-sdk/credential-provider-imds": "3.81.0",
+        "@aws-sdk/node-config-provider": "3.80.0",
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -1080,9 +1080,9 @@
       }
     },
     "node_modules/@aws-sdk/util-middleware": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.55.0.tgz",
-      "integrity": "sha512-82fW2XV+rUalv8lkd4VlhpPp6xnXO5n9sckMp1N+TrQ+p8eqxqT0+o8n1/6s9Qsnkw64Y3m6+EfCdc8/uFOY2g==",
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.78.0.tgz",
+      "integrity": "sha512-Hi3wv2b0VogO4mzyeEaeU5KgIt4qeo0LXU5gS6oRrG0T7s2FyKbMBkJW3YDh/Y8fNwqArZ+/QQFujpP0PIKwkA==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.1"
@@ -1104,24 +1104,24 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.58.0.tgz",
-      "integrity": "sha512-aJpqCvT09giJRg5xFTBDBRAVF0k0yq3OEf6UTuiOVf5azlL2MGp6PJ/xkJp9Z06PuQQkwBJ/2nIQZemo02a5Sw==",
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.78.0.tgz",
+      "integrity": "sha512-diGO/Bf4ggBOEnfD7lrrXaaXOwOXGz0bAJ0HhpizwEMlBld5zfDlWXjNpslh+8+u3EHRjPJQ16KGT6mp/Dm+aw==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.55.0",
+        "@aws-sdk/types": "3.78.0",
         "bowser": "^2.11.0",
         "tslib": "^2.3.1"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.58.0.tgz",
-      "integrity": "sha512-VlbY/nzWdN2pfLUHqKvnlGBQ6tEeV4jyK9ggAD2Szjj0bkYvaaKwpBKswQmuJpi5/J2v7Bo4ayBLnqDL7PgzLA==",
+      "version": "3.80.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.80.0.tgz",
+      "integrity": "sha512-QV26qIXws1m6sZXg65NS+XrQ5NhAzbDVQLtEVE4nC39UN8fuieP6Uet/gZm9mlLI9hllwvcV7EfgBM3GSC7pZg==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/node-config-provider": "3.58.0",
-        "@aws-sdk/types": "3.55.0",
+        "@aws-sdk/node-config-provider": "3.80.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -1151,13 +1151,13 @@
       }
     },
     "node_modules/@aws-sdk/util-waiter": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.55.0.tgz",
-      "integrity": "sha512-Do34MKPFSC/+zVN6vY+FZ+0WN61hzga4nPoAC590AOjs8rW6/H6sDN6Gz1KAZbPnuQUZfvsIJjMxN7lblXHJkQ==",
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.78.0.tgz",
+      "integrity": "sha512-8pWd0XiNOS8AkWQyac8VNEI+gz/cGWlC2TAE2CJp0rOK5XhvlcNBINai4D6TxQ+9foyJXLOI1b8nuXemekoG8A==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/abort-controller": "3.55.0",
-        "@aws-sdk/types": "3.55.0",
+        "@aws-sdk/abort-controller": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -3899,27 +3899,27 @@
       "dev": true
     },
     "node_modules/@types/lodash.clonedeep": {
-      "version": "4.5.6",
-      "resolved": "https://registry.npmjs.org/@types/lodash.clonedeep/-/lodash.clonedeep-4.5.6.tgz",
-      "integrity": "sha512-cE1jYr2dEg1wBImvXlNtp0xDoS79rfEdGozQVgliDZj1uERH4k+rmEMTudP9b4VQ8O6nRb5gPqft0QzEQGMQgA==",
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/@types/lodash.clonedeep/-/lodash.clonedeep-4.5.7.tgz",
+      "integrity": "sha512-ccNqkPptFIXrpVqUECi60/DFxjNKsfoQxSQsgcBJCX/fuX1wgyQieojkcWH/KpE3xzLoWN/2k+ZeGqIN3paSvw==",
       "dev": true,
       "dependencies": {
         "@types/lodash": "*"
       }
     },
     "node_modules/@types/lodash.merge": {
-      "version": "4.6.6",
-      "resolved": "https://registry.npmjs.org/@types/lodash.merge/-/lodash.merge-4.6.6.tgz",
-      "integrity": "sha512-IB90krzMf7YpfgP3u/EvZEdXVvm4e3gJbUvh5ieuI+o+XqiNEt6fCzqNRaiLlPVScLI59RxIGZMQ3+Ko/DJ8vQ==",
+      "version": "4.6.7",
+      "resolved": "https://registry.npmjs.org/@types/lodash.merge/-/lodash.merge-4.6.7.tgz",
+      "integrity": "sha512-OwxUJ9E50gw3LnAefSHJPHaBLGEKmQBQ7CZe/xflHkyy/wH2zVyEIAKReHvVrrn7zKdF58p16We9kMfh7v0RRQ==",
       "dev": true,
       "dependencies": {
         "@types/lodash": "*"
       }
     },
     "node_modules/@types/lodash.pickby": {
-      "version": "4.6.6",
-      "resolved": "https://registry.npmjs.org/@types/lodash.pickby/-/lodash.pickby-4.6.6.tgz",
-      "integrity": "sha512-NFa13XxlMd9eFi0UFZFWIztpMpXhozbijrx3Yb1viYZphT7jyopIFVoIRF4eYMjruWNEG1rnyrRmg/8ej9T8Iw==",
+      "version": "4.6.7",
+      "resolved": "https://registry.npmjs.org/@types/lodash.pickby/-/lodash.pickby-4.6.7.tgz",
+      "integrity": "sha512-4ebXRusuLflfscbD0PUX4eVknDHD9Yf+uMtBIvA/hrnTqeAzbuHuDjvnYriLjUrI9YrhCPVKUf4wkRSXJQ6gig==",
       "dev": true,
       "dependencies": {
         "@types/lodash": "*"
@@ -4972,9 +4972,9 @@
       }
     },
     "node_modules/aws-xray-sdk-core": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/aws-xray-sdk-core/-/aws-xray-sdk-core-3.3.4.tgz",
-      "integrity": "sha512-GGnYAQgtclLHIBReOtsUgbDDCar0LR2TaHCWlQhPrEVVayrSAZQ4y+SlXN5YIadxMec4/f5dbF69wMbug9D5Ww==",
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/aws-xray-sdk-core/-/aws-xray-sdk-core-3.3.6.tgz",
+      "integrity": "sha512-5pJnix2mNBshzBtVsJxus3YOX2gM8+AirjyAJ0U+4ZkLRAcofNzBJUabZyHZPoVKud/YjEmcRr36bh4T3vOL2A==",
       "dependencies": {
         "@aws-sdk/service-error-classification": "^3.4.1",
         "@aws-sdk/types": "^3.4.1",
@@ -4984,7 +4984,7 @@
         "semver": "^5.3.0"
       },
       "engines": {
-        "node": ">= 10.x"
+        "node": ">= 12.x"
       }
     },
     "node_modules/aws-xray-sdk-core/node_modules/semver": {
@@ -5002,9 +5002,9 @@
       "dev": true
     },
     "node_modules/axios": {
-      "version": "0.27.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.1.tgz",
-      "integrity": "sha512-ePNMai55xo5GsXajb/k756AqZqpqeDaGwGcdvbZLSSELbbYwsIn2jNmGfUPEwd8j/yu4OoMstLLIVa4t0MneEA==",
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
       "dev": true,
       "dependencies": {
         "follow-redirects": "^1.14.9",
@@ -15557,9 +15557,9 @@
         "lodash.pickby": "^4.6.0"
       },
       "devDependencies": {
-        "@types/lodash.clonedeep": "^4.5.6",
-        "@types/lodash.merge": "^4.6.6",
-        "@types/lodash.pickby": "^4.6.6"
+        "@types/lodash.clonedeep": "^4.5.7",
+        "@types/lodash.merge": "^4.6.7",
+        "@types/lodash.pickby": "^4.6.7"
       }
     },
     "packages/metrics": {
@@ -15580,12 +15580,12 @@
       "license": "MIT-0",
       "dependencies": {
         "@aws-lambda-powertools/commons": "^0.10.0",
-        "aws-xray-sdk-core": "^3.3.4"
+        "aws-xray-sdk-core": "^3.3.6"
       },
       "devDependencies": {
-        "@aws-sdk/client-dynamodb": "^3.58.0",
+        "@aws-sdk/client-dynamodb": "^3.100.0",
         "@types/promise-retry": "^1.1.3",
-        "axios": "^0.27.1",
+        "axios": "^0.27.2",
         "promise-retry": "^2.0.1"
       }
     }
@@ -15807,9 +15807,9 @@
       "version": "file:packages/logger",
       "requires": {
         "@aws-lambda-powertools/commons": "^0.10.0",
-        "@types/lodash.clonedeep": "^4.5.6",
-        "@types/lodash.merge": "^4.6.6",
-        "@types/lodash.pickby": "^4.6.6",
+        "@types/lodash.clonedeep": "4.5.7",
+        "@types/lodash.merge": "4.6.7",
+        "@types/lodash.pickby": "4.6.7",
         "lodash.clonedeep": "^4.5.0",
         "lodash.merge": "^4.6.2",
         "lodash.pickby": "^4.6.0"
@@ -15827,141 +15827,141 @@
       "version": "file:packages/tracer",
       "requires": {
         "@aws-lambda-powertools/commons": "^0.10.0",
-        "@aws-sdk/client-dynamodb": "^3.58.0",
+        "@aws-sdk/client-dynamodb": "^3.100.0",
         "@types/promise-retry": "^1.1.3",
-        "aws-xray-sdk-core": "^3.3.4",
-        "axios": "^0.27.1",
+        "aws-xray-sdk-core": "^3.3.6",
+        "axios": "^0.27.2",
         "promise-retry": "^2.0.1"
       }
     },
     "@aws-sdk/abort-controller": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.55.0.tgz",
-      "integrity": "sha512-rCcTxJDEFnmvo/PgbhCRv24/Uv03lEGfRslKZq7SjaMcOubflS/ZXYaMEgsjYHgAT0zlpSsyCIkJXmhFaM7H7w==",
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.78.0.tgz",
+      "integrity": "sha512-iz1YLwM2feJUj/y97yO4XmDeTxs+yZ1XJwQgoawKuc8IDBKUutnJNCHL5jL04WUKU7Nrlq+Hr2fCTScFh2z9zg==",
       "dev": true,
       "requires": {
-        "@aws-sdk/types": "3.55.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/client-dynamodb": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.58.0.tgz",
-      "integrity": "sha512-54uclCvSVREutcty19NqfzC5V/0ebYSz51lz5jQpHYObP2uUAKOunTAWx1lnWACZ9U9Ka6SHWN/NhKFXeMKwgw==",
+      "version": "3.100.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.100.0.tgz",
+      "integrity": "sha512-0/PDutv4DDEpckH89x0hn6yFJGjtGhV+JnVimMw0dT+f+plWt706RTqPKgLCPftKTEDWncoQlSux+FO7vvXb4Q==",
       "dev": true,
       "requires": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.58.0",
-        "@aws-sdk/config-resolver": "3.58.0",
-        "@aws-sdk/credential-provider-node": "3.58.0",
-        "@aws-sdk/fetch-http-handler": "3.58.0",
-        "@aws-sdk/hash-node": "3.55.0",
-        "@aws-sdk/invalid-dependency": "3.55.0",
-        "@aws-sdk/middleware-content-length": "3.58.0",
-        "@aws-sdk/middleware-endpoint-discovery": "3.58.0",
-        "@aws-sdk/middleware-host-header": "3.58.0",
-        "@aws-sdk/middleware-logger": "3.55.0",
-        "@aws-sdk/middleware-retry": "3.58.0",
-        "@aws-sdk/middleware-serde": "3.55.0",
-        "@aws-sdk/middleware-signing": "3.58.0",
-        "@aws-sdk/middleware-stack": "3.55.0",
-        "@aws-sdk/middleware-user-agent": "3.58.0",
-        "@aws-sdk/node-config-provider": "3.58.0",
-        "@aws-sdk/node-http-handler": "3.58.0",
-        "@aws-sdk/protocol-http": "3.58.0",
-        "@aws-sdk/smithy-client": "3.55.0",
-        "@aws-sdk/types": "3.55.0",
-        "@aws-sdk/url-parser": "3.55.0",
+        "@aws-sdk/client-sts": "3.100.0",
+        "@aws-sdk/config-resolver": "3.80.0",
+        "@aws-sdk/credential-provider-node": "3.100.0",
+        "@aws-sdk/fetch-http-handler": "3.78.0",
+        "@aws-sdk/hash-node": "3.78.0",
+        "@aws-sdk/invalid-dependency": "3.78.0",
+        "@aws-sdk/middleware-content-length": "3.78.0",
+        "@aws-sdk/middleware-endpoint-discovery": "3.80.0",
+        "@aws-sdk/middleware-host-header": "3.78.0",
+        "@aws-sdk/middleware-logger": "3.78.0",
+        "@aws-sdk/middleware-retry": "3.80.0",
+        "@aws-sdk/middleware-serde": "3.78.0",
+        "@aws-sdk/middleware-signing": "3.78.0",
+        "@aws-sdk/middleware-stack": "3.78.0",
+        "@aws-sdk/middleware-user-agent": "3.78.0",
+        "@aws-sdk/node-config-provider": "3.80.0",
+        "@aws-sdk/node-http-handler": "3.94.0",
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/smithy-client": "3.99.0",
+        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/url-parser": "3.78.0",
         "@aws-sdk/util-base64-browser": "3.58.0",
         "@aws-sdk/util-base64-node": "3.55.0",
         "@aws-sdk/util-body-length-browser": "3.55.0",
         "@aws-sdk/util-body-length-node": "3.55.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.55.0",
-        "@aws-sdk/util-defaults-mode-node": "3.58.0",
-        "@aws-sdk/util-user-agent-browser": "3.58.0",
-        "@aws-sdk/util-user-agent-node": "3.58.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.99.0",
+        "@aws-sdk/util-defaults-mode-node": "3.99.0",
+        "@aws-sdk/util-user-agent-browser": "3.78.0",
+        "@aws-sdk/util-user-agent-node": "3.80.0",
         "@aws-sdk/util-utf8-browser": "3.55.0",
         "@aws-sdk/util-utf8-node": "3.55.0",
-        "@aws-sdk/util-waiter": "3.55.0",
+        "@aws-sdk/util-waiter": "3.78.0",
         "tslib": "^2.3.1",
         "uuid": "^8.3.2"
       }
     },
     "@aws-sdk/client-sso": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.58.0.tgz",
-      "integrity": "sha512-nS5G/OX8Bg4ajBa6+jLcbbr4PpEO+l5eJfGUzoJQwS4Zqa0lF/wC0kyjKm61gLp4JuvhrQskxIC/3IXUqB1XVQ==",
+      "version": "3.100.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.100.0.tgz",
+      "integrity": "sha512-nmBRUO5QfQ2IO8fHb37p8HT3n1ZooPb3sfTQejrpFH9Eq82VEOatIGt6yH3yTQ8+mhbabEhV5aY2wt/0D7wGVA==",
       "dev": true,
       "requires": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.58.0",
-        "@aws-sdk/fetch-http-handler": "3.58.0",
-        "@aws-sdk/hash-node": "3.55.0",
-        "@aws-sdk/invalid-dependency": "3.55.0",
-        "@aws-sdk/middleware-content-length": "3.58.0",
-        "@aws-sdk/middleware-host-header": "3.58.0",
-        "@aws-sdk/middleware-logger": "3.55.0",
-        "@aws-sdk/middleware-retry": "3.58.0",
-        "@aws-sdk/middleware-serde": "3.55.0",
-        "@aws-sdk/middleware-stack": "3.55.0",
-        "@aws-sdk/middleware-user-agent": "3.58.0",
-        "@aws-sdk/node-config-provider": "3.58.0",
-        "@aws-sdk/node-http-handler": "3.58.0",
-        "@aws-sdk/protocol-http": "3.58.0",
-        "@aws-sdk/smithy-client": "3.55.0",
-        "@aws-sdk/types": "3.55.0",
-        "@aws-sdk/url-parser": "3.55.0",
+        "@aws-sdk/config-resolver": "3.80.0",
+        "@aws-sdk/fetch-http-handler": "3.78.0",
+        "@aws-sdk/hash-node": "3.78.0",
+        "@aws-sdk/invalid-dependency": "3.78.0",
+        "@aws-sdk/middleware-content-length": "3.78.0",
+        "@aws-sdk/middleware-host-header": "3.78.0",
+        "@aws-sdk/middleware-logger": "3.78.0",
+        "@aws-sdk/middleware-retry": "3.80.0",
+        "@aws-sdk/middleware-serde": "3.78.0",
+        "@aws-sdk/middleware-stack": "3.78.0",
+        "@aws-sdk/middleware-user-agent": "3.78.0",
+        "@aws-sdk/node-config-provider": "3.80.0",
+        "@aws-sdk/node-http-handler": "3.94.0",
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/smithy-client": "3.99.0",
+        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/url-parser": "3.78.0",
         "@aws-sdk/util-base64-browser": "3.58.0",
         "@aws-sdk/util-base64-node": "3.55.0",
         "@aws-sdk/util-body-length-browser": "3.55.0",
         "@aws-sdk/util-body-length-node": "3.55.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.55.0",
-        "@aws-sdk/util-defaults-mode-node": "3.58.0",
-        "@aws-sdk/util-user-agent-browser": "3.58.0",
-        "@aws-sdk/util-user-agent-node": "3.58.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.99.0",
+        "@aws-sdk/util-defaults-mode-node": "3.99.0",
+        "@aws-sdk/util-user-agent-browser": "3.78.0",
+        "@aws-sdk/util-user-agent-node": "3.80.0",
         "@aws-sdk/util-utf8-browser": "3.55.0",
         "@aws-sdk/util-utf8-node": "3.55.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/client-sts": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.58.0.tgz",
-      "integrity": "sha512-2cHZsG2eXv/Zl0hvsG9+rdHEuAclMFfkma/3LC3RRwSuZXo1rXoIhFkzHfGfIbivdk738YAo7FT3ZYGlrsK4ow==",
+      "version": "3.100.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.100.0.tgz",
+      "integrity": "sha512-WHy0e6COf6/LfMsYqG9H4SGaQRDjuckMtwOLtu6cYr4cro3bOU5pNuyEjAdUHCpuhZgiE6gkZozhTlxMJqIuRQ==",
       "dev": true,
       "requires": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.58.0",
-        "@aws-sdk/credential-provider-node": "3.58.0",
-        "@aws-sdk/fetch-http-handler": "3.58.0",
-        "@aws-sdk/hash-node": "3.55.0",
-        "@aws-sdk/invalid-dependency": "3.55.0",
-        "@aws-sdk/middleware-content-length": "3.58.0",
-        "@aws-sdk/middleware-host-header": "3.58.0",
-        "@aws-sdk/middleware-logger": "3.55.0",
-        "@aws-sdk/middleware-retry": "3.58.0",
-        "@aws-sdk/middleware-sdk-sts": "3.58.0",
-        "@aws-sdk/middleware-serde": "3.55.0",
-        "@aws-sdk/middleware-signing": "3.58.0",
-        "@aws-sdk/middleware-stack": "3.55.0",
-        "@aws-sdk/middleware-user-agent": "3.58.0",
-        "@aws-sdk/node-config-provider": "3.58.0",
-        "@aws-sdk/node-http-handler": "3.58.0",
-        "@aws-sdk/protocol-http": "3.58.0",
-        "@aws-sdk/smithy-client": "3.55.0",
-        "@aws-sdk/types": "3.55.0",
-        "@aws-sdk/url-parser": "3.55.0",
+        "@aws-sdk/config-resolver": "3.80.0",
+        "@aws-sdk/credential-provider-node": "3.100.0",
+        "@aws-sdk/fetch-http-handler": "3.78.0",
+        "@aws-sdk/hash-node": "3.78.0",
+        "@aws-sdk/invalid-dependency": "3.78.0",
+        "@aws-sdk/middleware-content-length": "3.78.0",
+        "@aws-sdk/middleware-host-header": "3.78.0",
+        "@aws-sdk/middleware-logger": "3.78.0",
+        "@aws-sdk/middleware-retry": "3.80.0",
+        "@aws-sdk/middleware-sdk-sts": "3.78.0",
+        "@aws-sdk/middleware-serde": "3.78.0",
+        "@aws-sdk/middleware-signing": "3.78.0",
+        "@aws-sdk/middleware-stack": "3.78.0",
+        "@aws-sdk/middleware-user-agent": "3.78.0",
+        "@aws-sdk/node-config-provider": "3.80.0",
+        "@aws-sdk/node-http-handler": "3.94.0",
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/smithy-client": "3.99.0",
+        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/url-parser": "3.78.0",
         "@aws-sdk/util-base64-browser": "3.58.0",
         "@aws-sdk/util-base64-node": "3.55.0",
         "@aws-sdk/util-body-length-browser": "3.55.0",
         "@aws-sdk/util-body-length-node": "3.55.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.55.0",
-        "@aws-sdk/util-defaults-mode-node": "3.58.0",
-        "@aws-sdk/util-user-agent-browser": "3.58.0",
-        "@aws-sdk/util-user-agent-node": "3.58.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.99.0",
+        "@aws-sdk/util-defaults-mode-node": "3.99.0",
+        "@aws-sdk/util-user-agent-browser": "3.78.0",
+        "@aws-sdk/util-user-agent-node": "3.80.0",
         "@aws-sdk/util-utf8-browser": "3.55.0",
         "@aws-sdk/util-utf8-node": "3.55.0",
         "entities": "2.2.0",
@@ -15970,109 +15970,109 @@
       }
     },
     "@aws-sdk/config-resolver": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.58.0.tgz",
-      "integrity": "sha512-NXEwYw0JrXcvenu42QpNMQXK+6pgZ+6bDGfCgOfCC0FmyI+w/CuF36lApwm7InHvHazOaDlwArXm2pfntErKoA==",
+      "version": "3.80.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.80.0.tgz",
+      "integrity": "sha512-vFruNKlmhsaC8yjnHmasi1WW/7EELlEuFTj4mqcqNqR4dfraf0maVvpqF1VSR8EstpFMsGYI5dmoWAnnG4PcLQ==",
       "dev": true,
       "requires": {
-        "@aws-sdk/signature-v4": "3.58.0",
-        "@aws-sdk/types": "3.55.0",
+        "@aws-sdk/signature-v4": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
         "@aws-sdk/util-config-provider": "3.55.0",
-        "@aws-sdk/util-middleware": "3.55.0",
+        "@aws-sdk/util-middleware": "3.78.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/credential-provider-env": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.55.0.tgz",
-      "integrity": "sha512-4AIIXEdvinLlWNFtrUbUgoB7dkuV04RTcTruVWI4Ub4WSsuSCa72ZU1vqyvcEAOgGGLBmcSaGTWByjiD2sGcGA==",
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.78.0.tgz",
+      "integrity": "sha512-K41VTIzVHm2RyIwtBER8Hte3huUBXdV1WKO+i7olYVgLFmaqcZUNrlyoGDRqZcQ/u4AbxTzBU9jeMIbIfzMOWg==",
       "dev": true,
       "requires": {
-        "@aws-sdk/property-provider": "3.55.0",
-        "@aws-sdk/types": "3.55.0",
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/credential-provider-imds": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.58.0.tgz",
-      "integrity": "sha512-CdtnTQ9zqLx1FbXdbgjijLbMcIWOyQM03TFaLSCjI3FNbUwyt3T7StBU9tj/LtbypHhSdXyQBpzUtXTOMWCEhg==",
+      "version": "3.81.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.81.0.tgz",
+      "integrity": "sha512-BHopP+gaovTYj+4tSrwCk8NNCR48gE9CWmpIOLkP9ell0gOL81Qh7aCEiIK0BZBZkccv1s16cYq1MSZZGS7PEQ==",
       "dev": true,
       "requires": {
-        "@aws-sdk/node-config-provider": "3.58.0",
-        "@aws-sdk/property-provider": "3.55.0",
-        "@aws-sdk/types": "3.55.0",
-        "@aws-sdk/url-parser": "3.55.0",
+        "@aws-sdk/node-config-provider": "3.80.0",
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/url-parser": "3.78.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/credential-provider-ini": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.58.0.tgz",
-      "integrity": "sha512-uM62hcHUVaHP1YFnbrjf2RlrRj1m/BvMPE+T5jdNRWdE3lvnunhEMawB26HZs9nQqCV6d25I8G9/fGWVL7g3Og==",
+      "version": "3.100.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.100.0.tgz",
+      "integrity": "sha512-2pCtth/Iv4mATRwb2g1nJdd9TolMyhTnhcskopukFvzp13VS5cgtz0hgYmJNnztTF8lpKJhJaidtKS5JJTWnHg==",
       "dev": true,
       "requires": {
-        "@aws-sdk/credential-provider-env": "3.55.0",
-        "@aws-sdk/credential-provider-imds": "3.58.0",
-        "@aws-sdk/credential-provider-sso": "3.58.0",
-        "@aws-sdk/credential-provider-web-identity": "3.55.0",
-        "@aws-sdk/property-provider": "3.55.0",
-        "@aws-sdk/shared-ini-file-loader": "3.58.0",
-        "@aws-sdk/types": "3.55.0",
+        "@aws-sdk/credential-provider-env": "3.78.0",
+        "@aws-sdk/credential-provider-imds": "3.81.0",
+        "@aws-sdk/credential-provider-sso": "3.100.0",
+        "@aws-sdk/credential-provider-web-identity": "3.78.0",
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/shared-ini-file-loader": "3.80.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/credential-provider-node": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.58.0.tgz",
-      "integrity": "sha512-f0wzcgMYCQUrii6TLP2ggCxkQP4HH8PW8tbbWEgt4cdIXcjE9KEuxN5yOV6sFHzL3eJh0QM9Yaz8WzhWn6fT2A==",
+      "version": "3.100.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.100.0.tgz",
+      "integrity": "sha512-PMIPnn/dhv9tlWR0qXnANJpTumujWfhKnLAsV3BUqB1K9IzWqz/zXjCT0jcSUTY8X/VkSuehtBdCKvOOM5mMqg==",
       "dev": true,
       "requires": {
-        "@aws-sdk/credential-provider-env": "3.55.0",
-        "@aws-sdk/credential-provider-imds": "3.58.0",
-        "@aws-sdk/credential-provider-ini": "3.58.0",
-        "@aws-sdk/credential-provider-process": "3.58.0",
-        "@aws-sdk/credential-provider-sso": "3.58.0",
-        "@aws-sdk/credential-provider-web-identity": "3.55.0",
-        "@aws-sdk/property-provider": "3.55.0",
-        "@aws-sdk/shared-ini-file-loader": "3.58.0",
-        "@aws-sdk/types": "3.55.0",
+        "@aws-sdk/credential-provider-env": "3.78.0",
+        "@aws-sdk/credential-provider-imds": "3.81.0",
+        "@aws-sdk/credential-provider-ini": "3.100.0",
+        "@aws-sdk/credential-provider-process": "3.80.0",
+        "@aws-sdk/credential-provider-sso": "3.100.0",
+        "@aws-sdk/credential-provider-web-identity": "3.78.0",
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/shared-ini-file-loader": "3.80.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/credential-provider-process": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.58.0.tgz",
-      "integrity": "sha512-npgFqPUjMhUamf1FvJjBYUdpbWx8XWkKCwJsX73I7IYQAvAi2atCOkdtKq+4rds0VWAYu6vzlaI1tXgFxjOPNQ==",
+      "version": "3.80.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.80.0.tgz",
+      "integrity": "sha512-3Ro+kMMyLUJHefOhGc5pOO/ibGcJi8bkj0z/Jtqd5I2Sm1qi7avoztST67/k48KMW1OqPnD/FUqxz5T8B2d+FQ==",
       "dev": true,
       "requires": {
-        "@aws-sdk/property-provider": "3.55.0",
-        "@aws-sdk/shared-ini-file-loader": "3.58.0",
-        "@aws-sdk/types": "3.55.0",
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/shared-ini-file-loader": "3.80.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/credential-provider-sso": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.58.0.tgz",
-      "integrity": "sha512-2qO34s9lJqvCC6zOF4UpopW6xURZpYfVC8xTUDpAUnvTOt4nS5hkx4vNyqPAXILoRHuFJsnlWsBH1UP5ZnBiZg==",
+      "version": "3.100.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.100.0.tgz",
+      "integrity": "sha512-DwJvrh77vBJ1/fS9z0i2QuIvSk4pATA4DH8AEWoQ8LQX97tp3es7gZV5Wu93wFsEyIYC8penz6pNVq5QajMk2A==",
       "dev": true,
       "requires": {
-        "@aws-sdk/client-sso": "3.58.0",
-        "@aws-sdk/property-provider": "3.55.0",
-        "@aws-sdk/shared-ini-file-loader": "3.58.0",
-        "@aws-sdk/types": "3.55.0",
+        "@aws-sdk/client-sso": "3.100.0",
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/shared-ini-file-loader": "3.80.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/credential-provider-web-identity": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.55.0.tgz",
-      "integrity": "sha512-aKnXfZNGohTuF9rCGYLg4JEIOvWIZ/sb66XMq7bOUrx13KRPDwL/eUQL8quS5jGRLpjXVNvrS17AFf65GbdUBg==",
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.78.0.tgz",
+      "integrity": "sha512-9/IvqHdJaVqMEABA8xZE3t5YF1S2PepfckVu0Ws9YUglj6oO+2QyVX6aRgMF1xph6781+Yc31TDh8/3eaDja7w==",
       "dev": true,
       "requires": {
-        "@aws-sdk/property-provider": "3.55.0",
-        "@aws-sdk/types": "3.55.0",
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       }
     },
@@ -16087,36 +16087,36 @@
       }
     },
     "@aws-sdk/fetch-http-handler": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.58.0.tgz",
-      "integrity": "sha512-timF3FjPV5Bd+Kgph83LIKVlPCFObVYzious1a6doeLAT6YFwZpRrWbfP/HzS+DCoYiwUsH69oVJ91BoV66oyA==",
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.78.0.tgz",
+      "integrity": "sha512-cR6r2h2kJ1DNEZSXC6GknQB7OKmy+s9ZNV+g3AsNqkrUmNNOaHpFoSn+m6SC3qaclcGd0eQBpqzSu/TDn23Ihw==",
       "dev": true,
       "requires": {
-        "@aws-sdk/protocol-http": "3.58.0",
-        "@aws-sdk/querystring-builder": "3.55.0",
-        "@aws-sdk/types": "3.55.0",
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/querystring-builder": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
         "@aws-sdk/util-base64-browser": "3.58.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/hash-node": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.55.0.tgz",
-      "integrity": "sha512-2UdYwY/++AlzWEAFaK9wOed2QSxbzV527vmqKjReLHpPKPrSIlooUxlTH3LU6Y6WVDAzDRtLK43KUVXTLgGK1A==",
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.78.0.tgz",
+      "integrity": "sha512-ev48yXaqZVtMeuKy52LUZPHCyKvkKQ9uiUebqkA+zFxIk+eN8SMPFHmsififIHWuS6ZkXBUSctjH9wmLebH60A==",
       "dev": true,
       "requires": {
-        "@aws-sdk/types": "3.55.0",
+        "@aws-sdk/types": "3.78.0",
         "@aws-sdk/util-buffer-from": "3.55.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/invalid-dependency": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.55.0.tgz",
-      "integrity": "sha512-delH0lV+78fdD/8MXIt9kTLS6IwHvdhqq9dw/ow5VjTUw+xBwUlfPfZplaai+3hKTKWh6a2WZCeDasNItBv9aA==",
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.78.0.tgz",
+      "integrity": "sha512-zUo+PbeRMN/Mzj6y+6p9qqk/znuFetT1gmpOcZGL9Rp2T+b9WJWd+daq5ktsL10sVCzIt2UvneJRz6b+aU+bfw==",
       "dev": true,
       "requires": {
-        "@aws-sdk/types": "3.55.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       }
     },
@@ -16130,239 +16130,239 @@
       }
     },
     "@aws-sdk/middleware-content-length": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.58.0.tgz",
-      "integrity": "sha512-h/BypPkhjv2CpCUbXA8Fa2s7V2GPiz9l11XhYK+sKSuQvQ7Lbq6VhaKaLqfeD3gLVZHgJZSLGl2btdHV1qHNNA==",
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.78.0.tgz",
+      "integrity": "sha512-5MpKt6lB9TdFy25/AGrpOjPY0iDHZAKpEHc+jSOJBXLl6xunXA7qHdiYaVqkWodLxy70nIckGNHqQ3drabidkA==",
       "dev": true,
       "requires": {
-        "@aws-sdk/protocol-http": "3.58.0",
-        "@aws-sdk/types": "3.55.0",
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-endpoint-discovery": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.58.0.tgz",
-      "integrity": "sha512-Ll42zMPP8dDTHesv5VdnM0vgT4mW+kR2SgXCWBMuwnZdBn0FDH1A3E0BqJkLuuq2TKIah0/l1sA1qVC68GkAeA==",
+      "version": "3.80.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.80.0.tgz",
+      "integrity": "sha512-73pKz8ossZKisG684raP1dn2u3fQRktWY29oa9Q3cBvRYdyu5UOhwayt2MObgSC8S6NfNdTGC/DGf7+/JRSY7A==",
       "dev": true,
       "requires": {
-        "@aws-sdk/config-resolver": "3.58.0",
+        "@aws-sdk/config-resolver": "3.80.0",
         "@aws-sdk/endpoint-cache": "3.55.0",
-        "@aws-sdk/protocol-http": "3.58.0",
-        "@aws-sdk/types": "3.55.0",
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-host-header": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.58.0.tgz",
-      "integrity": "sha512-q/UKGcanm9e6DBRNN6UKhVqLvpRRdZWbmmPCeDNr4HqhCmgT6i1OvWdhAMOnT++hvCX8DpTsIXzNSlY6zWAxBg==",
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.78.0.tgz",
+      "integrity": "sha512-1zL8uaDWGmH50c8B8jjz75e0ePj6/3QeZEhjJgTgL6DTdiqvRt32p3t+XWHW+yDI14fZZUYeTklAaLVxqFrHqQ==",
       "dev": true,
       "requires": {
-        "@aws-sdk/protocol-http": "3.58.0",
-        "@aws-sdk/types": "3.55.0",
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-logger": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.55.0.tgz",
-      "integrity": "sha512-PtRbVrxEzDmeV9prBIP4/9or7R5Dj66mjbFSvNRGZ0n+UBfBFfVRfNrhQPNzQpfV9A3KVl9YyWCVXDSW+/rk9Q==",
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.78.0.tgz",
+      "integrity": "sha512-GBhwxNjhCJUIeQQDaGasX/C23Jay77al2vRyGwmxf8no0DdFsa4J1Ik6/2hhIqkqko+WM4SpCnpZrY4MtnxNvA==",
       "dev": true,
       "requires": {
-        "@aws-sdk/types": "3.55.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-retry": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.58.0.tgz",
-      "integrity": "sha512-sfSq+t0Yy47DQwrWGpA8iOx9sd26l4l1JDVTwHNi7+OKD4ClRPVCEdw3bTbbyYz/PV4f9AEfAZ6jwtSff4wkGw==",
+      "version": "3.80.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.80.0.tgz",
+      "integrity": "sha512-CTk+tA4+WMUNOcUfR6UQrkhwvPYFpnMsQ1vuHlpLFOGG3nCqywA2hueLMRQmVcDXzP0sGeygce6dzRI9dJB/GA==",
       "dev": true,
       "requires": {
-        "@aws-sdk/protocol-http": "3.58.0",
-        "@aws-sdk/service-error-classification": "3.55.0",
-        "@aws-sdk/types": "3.55.0",
-        "@aws-sdk/util-middleware": "3.55.0",
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/service-error-classification": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/util-middleware": "3.78.0",
         "tslib": "^2.3.1",
         "uuid": "^8.3.2"
       }
     },
     "@aws-sdk/middleware-sdk-sts": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.58.0.tgz",
-      "integrity": "sha512-HUz7MhcsSDDTGygOwL61l4voc0pZco06J3z06JjTX19D5XxcQ7hSCtkHHHz0oMb9M1himVSiEon2tjhjsnB99g==",
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.78.0.tgz",
+      "integrity": "sha512-Lu/kN0J0/Kt0ON1hvwNel+y8yvf35licfIgtedHbBCa/ju8qQ9j+uL9Lla6Y5Tqu29yVaye1JxhiIDhscSwrLA==",
       "dev": true,
       "requires": {
-        "@aws-sdk/middleware-signing": "3.58.0",
-        "@aws-sdk/property-provider": "3.55.0",
-        "@aws-sdk/protocol-http": "3.58.0",
-        "@aws-sdk/signature-v4": "3.58.0",
-        "@aws-sdk/types": "3.55.0",
+        "@aws-sdk/middleware-signing": "3.78.0",
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/signature-v4": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-serde": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.55.0.tgz",
-      "integrity": "sha512-NkEbTDrSZcC2NhuvfjXHKJEl0xgI2B5tMAwi/rMOq/TEnARwVUL9qAy+5lgeiPCqebiNllWatARrFgAaYf0VeA==",
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.78.0.tgz",
+      "integrity": "sha512-4DPsNOxsl1bxRzfo1WXEZjmD7OEi7qGNpxrDWucVe96Fqj2dH08jR8wxvBIVV1e6bAad07IwdPuCGmivNvwRuQ==",
       "dev": true,
       "requires": {
-        "@aws-sdk/types": "3.55.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-signing": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.58.0.tgz",
-      "integrity": "sha512-4FXubHB66GbhyZUlo6YPQoWpYfED15GNbEmHbJLSONzrVzZR3IkViSPLasDngVm1a050JqKuqNkFYGJBP4No/Q==",
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.78.0.tgz",
+      "integrity": "sha512-OEjJJCNhHHSOprLZ9CzjHIXEKFtPHWP/bG9pMhkV3/6Bmscsgcf8gWHcOnmIrjqX+hT1VALDNpl/RIh0J6/eQw==",
       "dev": true,
       "requires": {
-        "@aws-sdk/property-provider": "3.55.0",
-        "@aws-sdk/protocol-http": "3.58.0",
-        "@aws-sdk/signature-v4": "3.58.0",
-        "@aws-sdk/types": "3.55.0",
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/signature-v4": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-stack": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.55.0.tgz",
-      "integrity": "sha512-ouD+wFz8W2R0ZQ8HrbhgN8tg1jyINEg9lPEEXY79w1Q5sf94LJ90XKAMVk02rw3dJalUWjLHf0OQe1/qxZfHyA==",
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.78.0.tgz",
+      "integrity": "sha512-UoNfRh6eAJN3BJHlG1eb+KeuSe+zARTC2cglroJRyHc2j7GxH2i9FD3IJbj5wvzopJEnQzuY/VCs6STFkqWL1g==",
       "dev": true,
       "requires": {
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-user-agent": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.58.0.tgz",
-      "integrity": "sha512-1c69bIWM63JwXijXvb9IWwcwQ/gViKMZ1lhxv52NvdG5VSxWXXsFJ2jETEXZoAypwT97Hmf3xo9SYuaHcKoq+g==",
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.78.0.tgz",
+      "integrity": "sha512-wdN5uoq8RxxhLhj0EPeuDSRFuXfUwKeEqRzCKMsYAOC0cAm+PryaP2leo0oTGJ9LUK8REK7zyfFcmtC4oOzlkA==",
       "dev": true,
       "requires": {
-        "@aws-sdk/protocol-http": "3.58.0",
-        "@aws-sdk/types": "3.55.0",
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/node-config-provider": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.58.0.tgz",
-      "integrity": "sha512-AMcPqPhKxo/3/yOMS9PsKlI0GWp2/8eD6gSlhzdBpznPCKplyqXOSnSX7wS814Cyh373hFSjCaOrCOA9/EYtDg==",
+      "version": "3.80.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.80.0.tgz",
+      "integrity": "sha512-vyTOMK04huB7n10ZUv0thd2TE6KlY8livOuLqFTMtj99AJ6vyeB5XBNwKnQtJIt/P7CijYgp8KcFvI9fndOmKg==",
       "dev": true,
       "requires": {
-        "@aws-sdk/property-provider": "3.55.0",
-        "@aws-sdk/shared-ini-file-loader": "3.58.0",
-        "@aws-sdk/types": "3.55.0",
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/shared-ini-file-loader": "3.80.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/node-http-handler": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.58.0.tgz",
-      "integrity": "sha512-D9xVZG2nfo4GbPsby3JuBiAhpqXTFk1+CfuQU0AZv0gQvE3fFTCnB3za83jo7JV/pyRPU+s+/LHIpxCWUHzStg==",
+      "version": "3.94.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.94.0.tgz",
+      "integrity": "sha512-g9q6k+PS+BrtOzt8jrBWr9D543uB3ZoYZ2JCriwuCwnP4uIHlMf9wAOGcOgqgykfUAPBOLvz2rTwVs3Xl8GUmQ==",
       "dev": true,
       "requires": {
-        "@aws-sdk/abort-controller": "3.55.0",
-        "@aws-sdk/protocol-http": "3.58.0",
-        "@aws-sdk/querystring-builder": "3.55.0",
-        "@aws-sdk/types": "3.55.0",
+        "@aws-sdk/abort-controller": "3.78.0",
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/querystring-builder": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/property-provider": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.55.0.tgz",
-      "integrity": "sha512-o7cKFJSHq5WOhwPsspYrzNto35oKKZvESZuWDtLxaZKSI6l7zpA366BI4kDG6Tc9i2+teV553MbxyZ9eya5A8g==",
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.78.0.tgz",
+      "integrity": "sha512-PZpLvV0hF6lqg3CSN9YmphrB/t5LVJVWGJLB9d9qm7sJs5ksjTYBb5bY91OQ3zit0F4cqBMU8xt2GQ9J6d4DvQ==",
       "dev": true,
       "requires": {
-        "@aws-sdk/types": "3.55.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/protocol-http": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.58.0.tgz",
-      "integrity": "sha512-0yFFRPbR+CCa9eOQBBQ2qtrIDLYqSMN0y7G4iqVM8wQdIw7n3QK1PsTI3RNPGJ3Oi2krFTw5uUKqQQZPZEBuVQ==",
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.78.0.tgz",
+      "integrity": "sha512-SQB26MhEK96yDxyXd3UAaxLz1Y/ZvgE4pzv7V3wZiokdEedM0kawHKEn1UQJlqJLEZcQI9QYyysh3rTvHZ3fyg==",
       "dev": true,
       "requires": {
-        "@aws-sdk/types": "3.55.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/querystring-builder": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.55.0.tgz",
-      "integrity": "sha512-/ZAXNipt9nRR8k+eowwukE/YjXnQ49p5w/MkaQxsBk3IuIf7MAcgVg8glHr0igH84GfUQ7ZVP8v+G2S3tKUG+Q==",
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.78.0.tgz",
+      "integrity": "sha512-aib6RW1WAaTQDqVgRU1Ku9idkhm90gJKbCxVaGId+as6QHNUqMChEfK2v+0afuKiPNOs5uWmqvOXI9+Gt+UGDg==",
       "dev": true,
       "requires": {
-        "@aws-sdk/types": "3.55.0",
+        "@aws-sdk/types": "3.78.0",
         "@aws-sdk/util-uri-escape": "3.55.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/querystring-parser": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.55.0.tgz",
-      "integrity": "sha512-e+2FLgo+eDx7oh7ap5HngN9XSVMxredAVztLHxCcSN0lFHHHzMa8b2SpXbaowUxQHh7ziymSqvOrPYFQ71Filg==",
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.78.0.tgz",
+      "integrity": "sha512-csaH8YTyN+KMNczeK6fBS8l7iJaqcQcKOIbpQFg5upX4Ly5A56HJn4sVQhY1LSgfSk4xRsNfMy5mu6BlsIiaXA==",
       "dev": true,
       "requires": {
-        "@aws-sdk/types": "3.55.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/service-error-classification": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.55.0.tgz",
-      "integrity": "sha512-HdjnDyarsa1Avq1MJurkLyEe9c3eRa76dPmK4TmRGgwJ+tInEzGHL0rBW7V8xBK+PDF+fJQ71hvm8jPYmzvBwQ=="
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.78.0.tgz",
+      "integrity": "sha512-x7Lx8KWctJa01q4Q72Zb4ol9L/era3vy2daASu8l2paHHxsAPBE0PThkvLdUSLZSzlHSVdh3YHESIsT++VsK4w=="
     },
     "@aws-sdk/shared-ini-file-loader": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.58.0.tgz",
-      "integrity": "sha512-ARDKQerIzgNs/MFNdCEuK2lgRJ1lneAaJw0p9O1LkJUvcSibvkSATwny7vwJMueOf+ae1Pf+8+54OMNIt0nTkQ==",
+      "version": "3.80.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.80.0.tgz",
+      "integrity": "sha512-3d5EBJjnWWkjLK9skqLLHYbagtFaZZy+3jUTlbTuOKhlOwe8jF7CUM3j6I4JA6yXNcB3w0exDKKHa8w+l+05aA==",
       "dev": true,
       "requires": {
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/signature-v4": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.58.0.tgz",
-      "integrity": "sha512-flEo8p3XkzWoBDqnIUQre4jLuT5aLnmfQNI8c2uSjyJ3OBxpJ0iS1cDu3E++d1/pN6Q8o0KOmr2ypHeiyBOujw==",
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.78.0.tgz",
+      "integrity": "sha512-eePjRYuzKoi3VMr/lgrUEF1ytLeH4fA/NMCykr/uR6NMo4bSJA59KrFLYSM7SlWLRIyB0UvJqygVEvSxFluyDw==",
       "dev": true,
       "requires": {
         "@aws-sdk/is-array-buffer": "3.55.0",
-        "@aws-sdk/types": "3.55.0",
+        "@aws-sdk/types": "3.78.0",
         "@aws-sdk/util-hex-encoding": "3.58.0",
-        "@aws-sdk/util-middleware": "3.55.0",
+        "@aws-sdk/util-middleware": "3.78.0",
         "@aws-sdk/util-uri-escape": "3.55.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/smithy-client": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.55.0.tgz",
-      "integrity": "sha512-YgBpqg6R3Qg8CH9biOP1N1lYTvh8VLGD6AoDGgy/R1dQSqRQuxgKANLl3DOVcZnIZLsw4TdB0m7U+ZPtirPR1Q==",
+      "version": "3.99.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.99.0.tgz",
+      "integrity": "sha512-N9xgCcwbOBZ4/WuROzlErExXV6+vFrFkNJzeBT31/avvrHXjxgxwQlMoXoQCfM8PyRuDuVSfZeoh1iIRfoxidA==",
       "dev": true,
       "requires": {
-        "@aws-sdk/middleware-stack": "3.55.0",
-        "@aws-sdk/types": "3.55.0",
+        "@aws-sdk/middleware-stack": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/types": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.55.0.tgz",
-      "integrity": "sha512-wrDZjuy1CVAYxDCbm3bWQIKMGfNs7XXmG0eG4858Ixgqmq2avsIn5TORy8ynBxcXn9aekV/+tGEQ7BBSYzIVNQ=="
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.78.0.tgz",
+      "integrity": "sha512-I9PTlVNSbwhIgMfmDM5as1tqRIkVZunjVmfogb2WVVPp4CaX0Ll01S0FSMSLL9k6tcQLXqh45pFRjrxCl9WKdQ=="
     },
     "@aws-sdk/url-parser": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.55.0.tgz",
-      "integrity": "sha512-qrTwN5xIgTLreqLnZ+x3cAudjNKfxi6srW1H/px2mk4lb2U9B4fpGjZ6VU+XV8U2kR+YlT8J6Jo5iwuVGfC91A==",
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.78.0.tgz",
+      "integrity": "sha512-iQn2AjECUoJE0Ae9XtgHtGGKvUkvE8hhbktGopdj+zsPBe4WrBN2DgVxlKPPrBonG/YlcL1D7a5EXaujWSlUUw==",
       "dev": true,
       "requires": {
-        "@aws-sdk/querystring-parser": "3.55.0",
-        "@aws-sdk/types": "3.55.0",
+        "@aws-sdk/querystring-parser": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       }
     },
@@ -16423,28 +16423,28 @@
       }
     },
     "@aws-sdk/util-defaults-mode-browser": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.55.0.tgz",
-      "integrity": "sha512-OS3gAwR84bHz7ObhjsSJM+grfeaBq3leGrj7xiX4BH3C8J+c10GMo3fqx1pV8Fq5F+9lMmhHpfOocD63SN5Q8A==",
+      "version": "3.99.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.99.0.tgz",
+      "integrity": "sha512-qSYjUGuN8n7Q/zAi0tzU4BrU389jQosXtjp7eHpLATl0pKGpaHx6rJNwbiNhvBhBEfmSgqsJ09b4gZUpUezHEw==",
       "dev": true,
       "requires": {
-        "@aws-sdk/property-provider": "3.55.0",
-        "@aws-sdk/types": "3.55.0",
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
         "bowser": "^2.11.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-defaults-mode-node": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.58.0.tgz",
-      "integrity": "sha512-KNUCp0MXI+z3Z3pQCKDkx3Stdy1TXDjcUB+ZJFxRTJGIuBYwX4fV6G8s/zeFJi5Qv1ztR3CJ9fWJGsrx9mQ5EA==",
+      "version": "3.99.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.99.0.tgz",
+      "integrity": "sha512-8TUO0kEnQcgT1gAW9y9oO6a5gKhfEGEUeKidEgbTczEUrjr3aCXIC+p0DI5FJfImwPrTKXra8A22utDM92phWw==",
       "dev": true,
       "requires": {
-        "@aws-sdk/config-resolver": "3.58.0",
-        "@aws-sdk/credential-provider-imds": "3.58.0",
-        "@aws-sdk/node-config-provider": "3.58.0",
-        "@aws-sdk/property-provider": "3.55.0",
-        "@aws-sdk/types": "3.55.0",
+        "@aws-sdk/config-resolver": "3.80.0",
+        "@aws-sdk/credential-provider-imds": "3.81.0",
+        "@aws-sdk/node-config-provider": "3.80.0",
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       }
     },
@@ -16467,9 +16467,9 @@
       }
     },
     "@aws-sdk/util-middleware": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.55.0.tgz",
-      "integrity": "sha512-82fW2XV+rUalv8lkd4VlhpPp6xnXO5n9sckMp1N+TrQ+p8eqxqT0+o8n1/6s9Qsnkw64Y3m6+EfCdc8/uFOY2g==",
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.78.0.tgz",
+      "integrity": "sha512-Hi3wv2b0VogO4mzyeEaeU5KgIt4qeo0LXU5gS6oRrG0T7s2FyKbMBkJW3YDh/Y8fNwqArZ+/QQFujpP0PIKwkA==",
       "dev": true,
       "requires": {
         "tslib": "^2.3.1"
@@ -16485,24 +16485,24 @@
       }
     },
     "@aws-sdk/util-user-agent-browser": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.58.0.tgz",
-      "integrity": "sha512-aJpqCvT09giJRg5xFTBDBRAVF0k0yq3OEf6UTuiOVf5azlL2MGp6PJ/xkJp9Z06PuQQkwBJ/2nIQZemo02a5Sw==",
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.78.0.tgz",
+      "integrity": "sha512-diGO/Bf4ggBOEnfD7lrrXaaXOwOXGz0bAJ0HhpizwEMlBld5zfDlWXjNpslh+8+u3EHRjPJQ16KGT6mp/Dm+aw==",
       "dev": true,
       "requires": {
-        "@aws-sdk/types": "3.55.0",
+        "@aws-sdk/types": "3.78.0",
         "bowser": "^2.11.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-user-agent-node": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.58.0.tgz",
-      "integrity": "sha512-VlbY/nzWdN2pfLUHqKvnlGBQ6tEeV4jyK9ggAD2Szjj0bkYvaaKwpBKswQmuJpi5/J2v7Bo4ayBLnqDL7PgzLA==",
+      "version": "3.80.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.80.0.tgz",
+      "integrity": "sha512-QV26qIXws1m6sZXg65NS+XrQ5NhAzbDVQLtEVE4nC39UN8fuieP6Uet/gZm9mlLI9hllwvcV7EfgBM3GSC7pZg==",
       "dev": true,
       "requires": {
-        "@aws-sdk/node-config-provider": "3.58.0",
-        "@aws-sdk/types": "3.55.0",
+        "@aws-sdk/node-config-provider": "3.80.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       }
     },
@@ -16526,13 +16526,13 @@
       }
     },
     "@aws-sdk/util-waiter": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.55.0.tgz",
-      "integrity": "sha512-Do34MKPFSC/+zVN6vY+FZ+0WN61hzga4nPoAC590AOjs8rW6/H6sDN6Gz1KAZbPnuQUZfvsIJjMxN7lblXHJkQ==",
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.78.0.tgz",
+      "integrity": "sha512-8pWd0XiNOS8AkWQyac8VNEI+gz/cGWlC2TAE2CJp0rOK5XhvlcNBINai4D6TxQ+9foyJXLOI1b8nuXemekoG8A==",
       "dev": true,
       "requires": {
-        "@aws-sdk/abort-controller": "3.55.0",
-        "@aws-sdk/types": "3.55.0",
+        "@aws-sdk/abort-controller": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       }
     },
@@ -18768,27 +18768,27 @@
       "dev": true
     },
     "@types/lodash.clonedeep": {
-      "version": "4.5.6",
-      "resolved": "https://registry.npmjs.org/@types/lodash.clonedeep/-/lodash.clonedeep-4.5.6.tgz",
-      "integrity": "sha512-cE1jYr2dEg1wBImvXlNtp0xDoS79rfEdGozQVgliDZj1uERH4k+rmEMTudP9b4VQ8O6nRb5gPqft0QzEQGMQgA==",
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/@types/lodash.clonedeep/-/lodash.clonedeep-4.5.7.tgz",
+      "integrity": "sha512-ccNqkPptFIXrpVqUECi60/DFxjNKsfoQxSQsgcBJCX/fuX1wgyQieojkcWH/KpE3xzLoWN/2k+ZeGqIN3paSvw==",
       "dev": true,
       "requires": {
         "@types/lodash": "*"
       }
     },
     "@types/lodash.merge": {
-      "version": "4.6.6",
-      "resolved": "https://registry.npmjs.org/@types/lodash.merge/-/lodash.merge-4.6.6.tgz",
-      "integrity": "sha512-IB90krzMf7YpfgP3u/EvZEdXVvm4e3gJbUvh5ieuI+o+XqiNEt6fCzqNRaiLlPVScLI59RxIGZMQ3+Ko/DJ8vQ==",
+      "version": "4.6.7",
+      "resolved": "https://registry.npmjs.org/@types/lodash.merge/-/lodash.merge-4.6.7.tgz",
+      "integrity": "sha512-OwxUJ9E50gw3LnAefSHJPHaBLGEKmQBQ7CZe/xflHkyy/wH2zVyEIAKReHvVrrn7zKdF58p16We9kMfh7v0RRQ==",
       "dev": true,
       "requires": {
         "@types/lodash": "*"
       }
     },
     "@types/lodash.pickby": {
-      "version": "4.6.6",
-      "resolved": "https://registry.npmjs.org/@types/lodash.pickby/-/lodash.pickby-4.6.6.tgz",
-      "integrity": "sha512-NFa13XxlMd9eFi0UFZFWIztpMpXhozbijrx3Yb1viYZphT7jyopIFVoIRF4eYMjruWNEG1rnyrRmg/8ej9T8Iw==",
+      "version": "4.6.7",
+      "resolved": "https://registry.npmjs.org/@types/lodash.pickby/-/lodash.pickby-4.6.7.tgz",
+      "integrity": "sha512-4ebXRusuLflfscbD0PUX4eVknDHD9Yf+uMtBIvA/hrnTqeAzbuHuDjvnYriLjUrI9YrhCPVKUf4wkRSXJQ6gig==",
       "dev": true,
       "requires": {
         "@types/lodash": "*"
@@ -19549,9 +19549,9 @@
       "dev": true
     },
     "aws-xray-sdk-core": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/aws-xray-sdk-core/-/aws-xray-sdk-core-3.3.4.tgz",
-      "integrity": "sha512-GGnYAQgtclLHIBReOtsUgbDDCar0LR2TaHCWlQhPrEVVayrSAZQ4y+SlXN5YIadxMec4/f5dbF69wMbug9D5Ww==",
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/aws-xray-sdk-core/-/aws-xray-sdk-core-3.3.6.tgz",
+      "integrity": "sha512-5pJnix2mNBshzBtVsJxus3YOX2gM8+AirjyAJ0U+4ZkLRAcofNzBJUabZyHZPoVKud/YjEmcRr36bh4T3vOL2A==",
       "requires": {
         "@aws-sdk/service-error-classification": "^3.4.1",
         "@aws-sdk/types": "^3.4.1",
@@ -19575,9 +19575,9 @@
       "dev": true
     },
     "axios": {
-      "version": "0.27.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.1.tgz",
-      "integrity": "sha512-ePNMai55xo5GsXajb/k756AqZqpqeDaGwGcdvbZLSSELbbYwsIn2jNmGfUPEwd8j/yu4OoMstLLIVa4t0MneEA==",
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
       "dev": true,
       "requires": {
         "follow-redirects": "^1.14.9",

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -34,9 +34,9 @@
   "types": "./lib/index.d.ts",
   "typedocMain": "src/index.ts",
   "devDependencies": {
-    "@types/lodash.clonedeep": "^4.5.6",
-    "@types/lodash.merge": "^4.6.6",
-    "@types/lodash.pickby": "^4.6.6"
+    "@types/lodash.clonedeep": "^4.5.7",
+    "@types/lodash.merge": "^4.6.7",
+    "@types/lodash.pickby": "^4.6.7"
   },
   "files": [
     "lib"

--- a/packages/tracer/package.json
+++ b/packages/tracer/package.json
@@ -33,9 +33,9 @@
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "devDependencies": {
-    "@aws-sdk/client-dynamodb": "^3.58.0",
+    "@aws-sdk/client-dynamodb": "^3.100.0",
     "@types/promise-retry": "^1.1.3",
-    "axios": "^0.27.1",
+    "axios": "^0.27.2",
     "promise-retry": "^2.0.1"
   },
   "files": [
@@ -50,6 +50,6 @@
   },
   "dependencies": {
     "@aws-lambda-powertools/commons": "^0.10.0",
-    "aws-xray-sdk-core": "^3.3.4"
+    "aws-xray-sdk-core": "^3.3.6"
   }
 }


### PR DESCRIPTION
## Description of your changes

As reported in [this issue](https://github.com/dependabot/dependabot-core/issues/5226) there are a number of dependencies declared in packages part of the npm workspaces that are not being bumped by Depdendabot.

This PR bumps these dependencies manually in an effort to keep the dependencies up to date and avoid having noise in the PRs.

List of PRs:
https://github.com/awslabs/aws-lambda-powertools-typescript/pull/938
https://github.com/awslabs/aws-lambda-powertools-typescript/pull/936
https://github.com/awslabs/aws-lambda-powertools-typescript/pull/934
https://github.com/awslabs/aws-lambda-powertools-typescript/pull/932
https://github.com/awslabs/aws-lambda-powertools-typescript/pull/927
https://github.com/awslabs/aws-lambda-powertools-typescript/pull/915

### How to verify this change

See results of automated checks, optionally run e2e tests.

### Related issues, RFCs

N/A

### PR status

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] My changes generate *no new warnings*
- [x] The *code coverage* hasn't decreased
- [x] New and existing *unit tests pass* locally and in Github Actions
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

N/A

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
