### PR TITLE
chore: updated rc release flow

### DIFF
--- a/.github/workflows/on-release-prod.yml
+++ b/.github/workflows/on-release-prod.yml
@@ -60,7 +60,7 @@ jobs:
         git config --global user.name 'github-actions[bot]'
         git config --global user.email 'github-actions[bot]@users.noreply.github.com'
         git remote set-url origin https://x-access-token:${GH_TOKEN}@github.com/$GITHUB_REPOSITORY
-        npx lerna version --conventional-commits --force-publish=* --yes
+        npx lerna version --conventional-commits --force-publish --conventional-prerelease --preid rc --yes
         npx lerna publish from-git --no-verify-access --yes
       #########################    
       # Generate documentation

--- a/.github/workflows/on-release-prod.yml
+++ b/.github/workflows/on-release-prod.yml
@@ -60,7 +60,7 @@ jobs:
         git config --global user.name 'github-actions[bot]'
         git config --global user.email 'github-actions[bot]@users.noreply.github.com'
         git remote set-url origin https://x-access-token:${GH_TOKEN}@github.com/$GITHUB_REPOSITORY
-        npx lerna version --conventional-commits --force-publish --conventional-prerelease --preid rc --yes
+        npx lerna version --conventional-commits --force-publish --preid rc --yes
         npx lerna publish from-git --no-verify-access --yes
       #########################    
       # Generate documentation

--- a/.github/workflows/on-release-prod.yml
+++ b/.github/workflows/on-release-prod.yml
@@ -60,7 +60,7 @@ jobs:
         git config --global user.name 'github-actions[bot]'
         git config --global user.email 'github-actions[bot]@users.noreply.github.com'
         git remote set-url origin https://x-access-token:${GH_TOKEN}@github.com/$GITHUB_REPOSITORY
-        npx lerna version --conventional-commits --force-publish --preid rc --yes
+        npx lerna version --conventional-commits --force-publish --conventional-prerelease --preid rc --yes
         npx lerna publish from-git --no-verify-access --yes
       #########################    
       # Generate documentation

--- a/examples/cdk/package-lock.json
+++ b/examples/cdk/package-lock.json
@@ -9,9 +9,9 @@
       "version": "0.10.0",
       "license": "MIT-0",
       "dependencies": {
-        "@aws-lambda-powertools/logger": "^0.10.0",
-        "@aws-lambda-powertools/metrics": "^0.10.0",
-        "@aws-lambda-powertools/tracer": "^0.10.0",
+        "@aws-lambda-powertools/logger": "^0.11.0",
+        "@aws-lambda-powertools/metrics": "^0.11.0",
+        "@aws-lambda-powertools/tracer": "^0.11.0",
         "@aws-sdk/client-sts": "^3.53.0",
         "@middy/core": "^2.5.6",
         "@types/aws-lambda": "^8.10.86",
@@ -123,36 +123,36 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-lambda-powertools/commons": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/commons/-/commons-0.10.0.tgz",
-      "integrity": "sha512-p2YDo2XIniMEw1a+NtPMvcALnpwJKpznOcKVZyEzwUEvluLl/cJwwVa0c4y6ye6iw+xD0Tp1T7I2t8gKYtU5zQ=="
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/commons/-/commons-0.11.0.tgz",
+      "integrity": "sha512-3kOq1lqcyRc7K/UlwD3XC0GXc5ckatanu0lOGFz7VJLjlv4VSCBC7KomGLoSInKGCdieJnmkg0ZcJnKD9RqJlQ=="
     },
     "node_modules/@aws-lambda-powertools/logger": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/logger/-/logger-0.10.0.tgz",
-      "integrity": "sha512-S+lJfXK74Qo3yedj8QdmXnl88YjOD6jOMcxiCqlyzCL77oMcvHXZpsEsofW9EjaYKKQZHpKgZWtm3FcalZ/+fg==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/logger/-/logger-0.11.0.tgz",
+      "integrity": "sha512-C4Sz8OkOe+2tpp8lZK/Ch7DqVgz5OyaTMU96yrNqnKPzlff7RKffuPKDi74IBDmYR+HnKimLr9H0rQuxhibStw==",
       "dependencies": {
-        "@aws-lambda-powertools/commons": "^0.10.0",
+        "@aws-lambda-powertools/commons": "^0.11.0",
         "lodash.clonedeep": "^4.5.0",
         "lodash.merge": "^4.6.2",
         "lodash.pickby": "^4.6.0"
       }
     },
     "node_modules/@aws-lambda-powertools/metrics": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/metrics/-/metrics-0.10.0.tgz",
-      "integrity": "sha512-t1d3rKjnp/f8YqvarUbmQV2F47vvYygetxDzECSFBSV72PDa38bILBmulzdSYQT5mb33EHoz4Hq2v70nAWeDLA==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/metrics/-/metrics-0.11.0.tgz",
+      "integrity": "sha512-/1ERp6lCeFyuvHfytyRHcpXbXi3fuSxIg54w6YwfaVAErWQ5/O+7J+Mk63qWOUr8wijMBytuRGH/aYiYZCuD2A==",
       "dependencies": {
-        "@aws-lambda-powertools/commons": "^0.10.0"
+        "@aws-lambda-powertools/commons": "^0.11.0"
       }
     },
     "node_modules/@aws-lambda-powertools/tracer": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/tracer/-/tracer-0.10.0.tgz",
-      "integrity": "sha512-RDlrJhPe4C/PvFOrIUDEnf/6mvpVdFjmHI+WYsXWbMvQwfvRkN9Bv+0m2JMaJg+n7vm/ho1qAC7TvyhUPYZPrg==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/tracer/-/tracer-0.11.0.tgz",
+      "integrity": "sha512-EzyJv2tU1OV2cfB9A9DJrzQYjRHBMqjdImRzphNqhqSEkhyTyanE2vX4yb+Fcj00HWExXhTGfmLiMMERpGwtTw==",
       "dependencies": {
-        "@aws-lambda-powertools/commons": "^0.10.0",
-        "aws-xray-sdk-core": "^3.3.4"
+        "@aws-lambda-powertools/commons": "^0.11.0",
+        "aws-xray-sdk-core": "^3.3.6"
       }
     },
     "node_modules/@aws-sdk/abort-controller": {
@@ -2261,7 +2261,7 @@
     "node_modules/atomic-batcher": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/atomic-batcher/-/atomic-batcher-1.0.2.tgz",
-      "integrity": "sha1-0WkB0QzOxZUWwZe5zNiTBom4E7Q="
+      "integrity": "sha512-EFGCRj4kLX1dHv1cDzTk+xbjBFj1GnJDpui52YmEcxxHHEWjYyT6l51U7n6WQ28osZH4S9gSybxe56Vm7vB61Q=="
     },
     "node_modules/aws-cdk": {
       "version": "2.15.0",
@@ -2490,9 +2490,9 @@
       }
     },
     "node_modules/aws-xray-sdk-core": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/aws-xray-sdk-core/-/aws-xray-sdk-core-3.3.4.tgz",
-      "integrity": "sha512-GGnYAQgtclLHIBReOtsUgbDDCar0LR2TaHCWlQhPrEVVayrSAZQ4y+SlXN5YIadxMec4/f5dbF69wMbug9D5Ww==",
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/aws-xray-sdk-core/-/aws-xray-sdk-core-3.3.6.tgz",
+      "integrity": "sha512-5pJnix2mNBshzBtVsJxus3YOX2gM8+AirjyAJ0U+4ZkLRAcofNzBJUabZyHZPoVKud/YjEmcRr36bh4T3vOL2A==",
       "dependencies": {
         "@aws-sdk/service-error-classification": "^3.4.1",
         "@aws-sdk/types": "^3.4.1",
@@ -2502,7 +2502,7 @@
         "semver": "^5.3.0"
       },
       "engines": {
-        "node": ">= 10.x"
+        "node": ">= 12.x"
       }
     },
     "node_modules/babel-jest": {
@@ -5960,7 +5960,7 @@
     "node_modules/stack-chain": {
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/stack-chain/-/stack-chain-1.3.7.tgz",
-      "integrity": "sha1-0ZLJ/06moiyUxN1FkXHj8AzqEoU="
+      "integrity": "sha512-D8cWtWVdIe/jBA7v5p5Hwl5yOSOrmZPWDPe2KxQ5UAGD+nxbxU0lKXA4h85Ta6+qgdKVL3vUxsbIZjc1kBG7ug=="
     },
     "node_modules/stack-utils": {
       "version": "2.0.5",
@@ -6731,36 +6731,36 @@
       }
     },
     "@aws-lambda-powertools/commons": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/commons/-/commons-0.10.0.tgz",
-      "integrity": "sha512-p2YDo2XIniMEw1a+NtPMvcALnpwJKpznOcKVZyEzwUEvluLl/cJwwVa0c4y6ye6iw+xD0Tp1T7I2t8gKYtU5zQ=="
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/commons/-/commons-0.11.0.tgz",
+      "integrity": "sha512-3kOq1lqcyRc7K/UlwD3XC0GXc5ckatanu0lOGFz7VJLjlv4VSCBC7KomGLoSInKGCdieJnmkg0ZcJnKD9RqJlQ=="
     },
     "@aws-lambda-powertools/logger": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/logger/-/logger-0.10.0.tgz",
-      "integrity": "sha512-S+lJfXK74Qo3yedj8QdmXnl88YjOD6jOMcxiCqlyzCL77oMcvHXZpsEsofW9EjaYKKQZHpKgZWtm3FcalZ/+fg==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/logger/-/logger-0.11.0.tgz",
+      "integrity": "sha512-C4Sz8OkOe+2tpp8lZK/Ch7DqVgz5OyaTMU96yrNqnKPzlff7RKffuPKDi74IBDmYR+HnKimLr9H0rQuxhibStw==",
       "requires": {
-        "@aws-lambda-powertools/commons": "^0.10.0",
+        "@aws-lambda-powertools/commons": "^0.11.0",
         "lodash.clonedeep": "^4.5.0",
         "lodash.merge": "^4.6.2",
         "lodash.pickby": "^4.6.0"
       }
     },
     "@aws-lambda-powertools/metrics": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/metrics/-/metrics-0.10.0.tgz",
-      "integrity": "sha512-t1d3rKjnp/f8YqvarUbmQV2F47vvYygetxDzECSFBSV72PDa38bILBmulzdSYQT5mb33EHoz4Hq2v70nAWeDLA==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/metrics/-/metrics-0.11.0.tgz",
+      "integrity": "sha512-/1ERp6lCeFyuvHfytyRHcpXbXi3fuSxIg54w6YwfaVAErWQ5/O+7J+Mk63qWOUr8wijMBytuRGH/aYiYZCuD2A==",
       "requires": {
-        "@aws-lambda-powertools/commons": "^0.10.0"
+        "@aws-lambda-powertools/commons": "^0.11.0"
       }
     },
     "@aws-lambda-powertools/tracer": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/tracer/-/tracer-0.10.0.tgz",
-      "integrity": "sha512-RDlrJhPe4C/PvFOrIUDEnf/6mvpVdFjmHI+WYsXWbMvQwfvRkN9Bv+0m2JMaJg+n7vm/ho1qAC7TvyhUPYZPrg==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/tracer/-/tracer-0.11.0.tgz",
+      "integrity": "sha512-EzyJv2tU1OV2cfB9A9DJrzQYjRHBMqjdImRzphNqhqSEkhyTyanE2vX4yb+Fcj00HWExXhTGfmLiMMERpGwtTw==",
       "requires": {
-        "@aws-lambda-powertools/commons": "^0.10.0",
-        "aws-xray-sdk-core": "^3.3.4"
+        "@aws-lambda-powertools/commons": "^0.11.0",
+        "aws-xray-sdk-core": "^3.3.6"
       }
     },
     "@aws-sdk/abort-controller": {
@@ -8485,7 +8485,7 @@
     "atomic-batcher": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/atomic-batcher/-/atomic-batcher-1.0.2.tgz",
-      "integrity": "sha1-0WkB0QzOxZUWwZe5zNiTBom4E7Q="
+      "integrity": "sha512-EFGCRj4kLX1dHv1cDzTk+xbjBFj1GnJDpui52YmEcxxHHEWjYyT6l51U7n6WQ28osZH4S9gSybxe56Vm7vB61Q=="
     },
     "aws-cdk": {
       "version": "2.15.0",
@@ -8633,9 +8633,9 @@
       }
     },
     "aws-xray-sdk-core": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/aws-xray-sdk-core/-/aws-xray-sdk-core-3.3.4.tgz",
-      "integrity": "sha512-GGnYAQgtclLHIBReOtsUgbDDCar0LR2TaHCWlQhPrEVVayrSAZQ4y+SlXN5YIadxMec4/f5dbF69wMbug9D5Ww==",
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/aws-xray-sdk-core/-/aws-xray-sdk-core-3.3.6.tgz",
+      "integrity": "sha512-5pJnix2mNBshzBtVsJxus3YOX2gM8+AirjyAJ0U+4ZkLRAcofNzBJUabZyHZPoVKud/YjEmcRr36bh4T3vOL2A==",
       "requires": {
         "@aws-sdk/service-error-classification": "^3.4.1",
         "@aws-sdk/types": "^3.4.1",
@@ -11282,7 +11282,7 @@
     "stack-chain": {
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/stack-chain/-/stack-chain-1.3.7.tgz",
-      "integrity": "sha1-0ZLJ/06moiyUxN1FkXHj8AzqEoU="
+      "integrity": "sha512-D8cWtWVdIe/jBA7v5p5Hwl5yOSOrmZPWDPe2KxQ5UAGD+nxbxU0lKXA4h85Ta6+qgdKVL3vUxsbIZjc1kBG7ug=="
     },
     "stack-utils": {
       "version": "2.0.5",

--- a/examples/cdk/package.json
+++ b/examples/cdk/package.json
@@ -18,7 +18,7 @@
     "package-bundle": "echo 'Not applicable'",
     "test:unit": "npm run build && jest",
     "test:e2e": "echo 'To be implemented ...'",
-    "version": "npm install @aws-lambda-powertools/logger@0.7.0 @aws-lambda-powertools/tracer@0.7.0 @aws-lambda-powertools/metrics@0.7.0 && git add package.json",
+    "version": "npm install @aws-lambda-powertools/logger@0.11.0 @aws-lambda-powertools/tracer@0.11.0 @aws-lambda-powertools/metrics@0.11.0 && git add package.json",
     "cdk": "cdk"
   },
   "devDependencies": {
@@ -32,9 +32,9 @@
     "typescript": "^4.1.3"
   },
   "dependencies": {
-    "@aws-lambda-powertools/logger": "^0.10.0",
-    "@aws-lambda-powertools/metrics": "^0.10.0",
-    "@aws-lambda-powertools/tracer": "^0.10.0",
+    "@aws-lambda-powertools/logger": "^0.11.0",
+    "@aws-lambda-powertools/metrics": "^0.11.0",
+    "@aws-lambda-powertools/tracer": "^0.11.0",
     "@aws-sdk/client-sts": "^3.53.0",
     "@middy/core": "^2.5.6",
     "@types/aws-lambda": "^8.10.86",

--- a/examples/sam/package-lock.json
+++ b/examples/sam/package-lock.json
@@ -9,9 +9,9 @@
       "version": "0.10.0",
       "license": "MIT-0",
       "dependencies": {
-        "@aws-lambda-powertools/logger": "^0.10.0",
-        "@aws-lambda-powertools/metrics": "^0.10.0",
-        "@aws-lambda-powertools/tracer": "^0.10.0",
+        "@aws-lambda-powertools/logger": "^0.11.0",
+        "@aws-lambda-powertools/metrics": "^0.11.0",
+        "@aws-lambda-powertools/tracer": "^0.11.0",
         "aws-sdk": "^2.1122.0"
       },
       "devDependencies": {
@@ -39,50 +39,50 @@
       }
     },
     "node_modules/@aws-lambda-powertools/commons": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/commons/-/commons-0.10.0.tgz",
-      "integrity": "sha512-p2YDo2XIniMEw1a+NtPMvcALnpwJKpznOcKVZyEzwUEvluLl/cJwwVa0c4y6ye6iw+xD0Tp1T7I2t8gKYtU5zQ=="
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/commons/-/commons-0.11.0.tgz",
+      "integrity": "sha512-3kOq1lqcyRc7K/UlwD3XC0GXc5ckatanu0lOGFz7VJLjlv4VSCBC7KomGLoSInKGCdieJnmkg0ZcJnKD9RqJlQ=="
     },
     "node_modules/@aws-lambda-powertools/logger": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/logger/-/logger-0.10.0.tgz",
-      "integrity": "sha512-S+lJfXK74Qo3yedj8QdmXnl88YjOD6jOMcxiCqlyzCL77oMcvHXZpsEsofW9EjaYKKQZHpKgZWtm3FcalZ/+fg==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/logger/-/logger-0.11.0.tgz",
+      "integrity": "sha512-C4Sz8OkOe+2tpp8lZK/Ch7DqVgz5OyaTMU96yrNqnKPzlff7RKffuPKDi74IBDmYR+HnKimLr9H0rQuxhibStw==",
       "dependencies": {
-        "@aws-lambda-powertools/commons": "^0.10.0",
+        "@aws-lambda-powertools/commons": "^0.11.0",
         "lodash.clonedeep": "^4.5.0",
         "lodash.merge": "^4.6.2",
         "lodash.pickby": "^4.6.0"
       }
     },
     "node_modules/@aws-lambda-powertools/metrics": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/metrics/-/metrics-0.10.0.tgz",
-      "integrity": "sha512-t1d3rKjnp/f8YqvarUbmQV2F47vvYygetxDzECSFBSV72PDa38bILBmulzdSYQT5mb33EHoz4Hq2v70nAWeDLA==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/metrics/-/metrics-0.11.0.tgz",
+      "integrity": "sha512-/1ERp6lCeFyuvHfytyRHcpXbXi3fuSxIg54w6YwfaVAErWQ5/O+7J+Mk63qWOUr8wijMBytuRGH/aYiYZCuD2A==",
       "dependencies": {
-        "@aws-lambda-powertools/commons": "^0.10.0"
+        "@aws-lambda-powertools/commons": "^0.11.0"
       }
     },
     "node_modules/@aws-lambda-powertools/tracer": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/tracer/-/tracer-0.10.0.tgz",
-      "integrity": "sha512-RDlrJhPe4C/PvFOrIUDEnf/6mvpVdFjmHI+WYsXWbMvQwfvRkN9Bv+0m2JMaJg+n7vm/ho1qAC7TvyhUPYZPrg==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/tracer/-/tracer-0.11.0.tgz",
+      "integrity": "sha512-EzyJv2tU1OV2cfB9A9DJrzQYjRHBMqjdImRzphNqhqSEkhyTyanE2vX4yb+Fcj00HWExXhTGfmLiMMERpGwtTw==",
       "dependencies": {
-        "@aws-lambda-powertools/commons": "^0.10.0",
-        "aws-xray-sdk-core": "^3.3.4"
+        "@aws-lambda-powertools/commons": "^0.11.0",
+        "aws-xray-sdk-core": "^3.3.6"
       }
     },
     "node_modules/@aws-sdk/service-error-classification": {
-      "version": "3.78.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.78.0.tgz",
-      "integrity": "sha512-x7Lx8KWctJa01q4Q72Zb4ol9L/era3vy2daASu8l2paHHxsAPBE0PThkvLdUSLZSzlHSVdh3YHESIsT++VsK4w==",
+      "version": "3.110.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.110.0.tgz",
+      "integrity": "sha512-ccgCE0pU/4RmXR6CP3fLAdhPAve7bK/yXBbGzpSHGAQOXqNxYzOsAvQ30Jg6X+qjLHsI/HR2pLIE65z4k6tynw==",
       "engines": {
         "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.78.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.78.0.tgz",
-      "integrity": "sha512-I9PTlVNSbwhIgMfmDM5as1tqRIkVZunjVmfogb2WVVPp4CaX0Ll01S0FSMSLL9k6tcQLXqh45pFRjrxCl9WKdQ==",
+      "version": "3.110.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.110.0.tgz",
+      "integrity": "sha512-dLVoqODU3laaqNFPyN1QLtlQnwX4gNPMXptEBIt/iJpuZf66IYJe6WCzVZGt4Zfa1CnUmrlA428AzdcA/KCr2A==",
       "engines": {
         "node": ">= 12.0.0"
       }
@@ -1410,7 +1410,7 @@
     "node_modules/atomic-batcher": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/atomic-batcher/-/atomic-batcher-1.0.2.tgz",
-      "integrity": "sha1-0WkB0QzOxZUWwZe5zNiTBom4E7Q="
+      "integrity": "sha512-EFGCRj4kLX1dHv1cDzTk+xbjBFj1GnJDpui52YmEcxxHHEWjYyT6l51U7n6WQ28osZH4S9gSybxe56Vm7vB61Q=="
     },
     "node_modules/aws-sdk": {
       "version": "2.1157.0",
@@ -1432,9 +1432,9 @@
       }
     },
     "node_modules/aws-xray-sdk-core": {
-      "version": "3.3.5",
-      "resolved": "https://registry.npmjs.org/aws-xray-sdk-core/-/aws-xray-sdk-core-3.3.5.tgz",
-      "integrity": "sha512-oJ/zPZc0foeeA4G64SonN3Fw9jJetzcMc98QY0V8qc7G9Gp9WhPMEHU2mI2uP05hwYf63FJO22K4UmSKtKza+Q==",
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/aws-xray-sdk-core/-/aws-xray-sdk-core-3.3.6.tgz",
+      "integrity": "sha512-5pJnix2mNBshzBtVsJxus3YOX2gM8+AirjyAJ0U+4ZkLRAcofNzBJUabZyHZPoVKud/YjEmcRr36bh4T3vOL2A==",
       "dependencies": {
         "@aws-sdk/service-error-classification": "^3.4.1",
         "@aws-sdk/types": "^3.4.1",
@@ -1444,7 +1444,7 @@
         "semver": "^5.3.0"
       },
       "engines": {
-        "node": ">= 10.x"
+        "node": ">= 12.x"
       }
     },
     "node_modules/babel-jest": {
@@ -4706,7 +4706,7 @@
     "node_modules/stack-chain": {
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/stack-chain/-/stack-chain-1.3.7.tgz",
-      "integrity": "sha1-0ZLJ/06moiyUxN1FkXHj8AzqEoU="
+      "integrity": "sha512-D8cWtWVdIe/jBA7v5p5Hwl5yOSOrmZPWDPe2KxQ5UAGD+nxbxU0lKXA4h85Ta6+qgdKVL3vUxsbIZjc1kBG7ug=="
     },
     "node_modules/stack-utils": {
       "version": "2.0.5",
@@ -5408,47 +5408,47 @@
       }
     },
     "@aws-lambda-powertools/commons": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/commons/-/commons-0.10.0.tgz",
-      "integrity": "sha512-p2YDo2XIniMEw1a+NtPMvcALnpwJKpznOcKVZyEzwUEvluLl/cJwwVa0c4y6ye6iw+xD0Tp1T7I2t8gKYtU5zQ=="
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/commons/-/commons-0.11.0.tgz",
+      "integrity": "sha512-3kOq1lqcyRc7K/UlwD3XC0GXc5ckatanu0lOGFz7VJLjlv4VSCBC7KomGLoSInKGCdieJnmkg0ZcJnKD9RqJlQ=="
     },
     "@aws-lambda-powertools/logger": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/logger/-/logger-0.10.0.tgz",
-      "integrity": "sha512-S+lJfXK74Qo3yedj8QdmXnl88YjOD6jOMcxiCqlyzCL77oMcvHXZpsEsofW9EjaYKKQZHpKgZWtm3FcalZ/+fg==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/logger/-/logger-0.11.0.tgz",
+      "integrity": "sha512-C4Sz8OkOe+2tpp8lZK/Ch7DqVgz5OyaTMU96yrNqnKPzlff7RKffuPKDi74IBDmYR+HnKimLr9H0rQuxhibStw==",
       "requires": {
-        "@aws-lambda-powertools/commons": "^0.10.0",
+        "@aws-lambda-powertools/commons": "^0.11.0",
         "lodash.clonedeep": "^4.5.0",
         "lodash.merge": "^4.6.2",
         "lodash.pickby": "^4.6.0"
       }
     },
     "@aws-lambda-powertools/metrics": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/metrics/-/metrics-0.10.0.tgz",
-      "integrity": "sha512-t1d3rKjnp/f8YqvarUbmQV2F47vvYygetxDzECSFBSV72PDa38bILBmulzdSYQT5mb33EHoz4Hq2v70nAWeDLA==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/metrics/-/metrics-0.11.0.tgz",
+      "integrity": "sha512-/1ERp6lCeFyuvHfytyRHcpXbXi3fuSxIg54w6YwfaVAErWQ5/O+7J+Mk63qWOUr8wijMBytuRGH/aYiYZCuD2A==",
       "requires": {
-        "@aws-lambda-powertools/commons": "^0.10.0"
+        "@aws-lambda-powertools/commons": "^0.11.0"
       }
     },
     "@aws-lambda-powertools/tracer": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/tracer/-/tracer-0.10.0.tgz",
-      "integrity": "sha512-RDlrJhPe4C/PvFOrIUDEnf/6mvpVdFjmHI+WYsXWbMvQwfvRkN9Bv+0m2JMaJg+n7vm/ho1qAC7TvyhUPYZPrg==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/tracer/-/tracer-0.11.0.tgz",
+      "integrity": "sha512-EzyJv2tU1OV2cfB9A9DJrzQYjRHBMqjdImRzphNqhqSEkhyTyanE2vX4yb+Fcj00HWExXhTGfmLiMMERpGwtTw==",
       "requires": {
-        "@aws-lambda-powertools/commons": "^0.10.0",
-        "aws-xray-sdk-core": "^3.3.4"
+        "@aws-lambda-powertools/commons": "^0.11.0",
+        "aws-xray-sdk-core": "^3.3.6"
       }
     },
     "@aws-sdk/service-error-classification": {
-      "version": "3.78.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.78.0.tgz",
-      "integrity": "sha512-x7Lx8KWctJa01q4Q72Zb4ol9L/era3vy2daASu8l2paHHxsAPBE0PThkvLdUSLZSzlHSVdh3YHESIsT++VsK4w=="
+      "version": "3.110.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.110.0.tgz",
+      "integrity": "sha512-ccgCE0pU/4RmXR6CP3fLAdhPAve7bK/yXBbGzpSHGAQOXqNxYzOsAvQ30Jg6X+qjLHsI/HR2pLIE65z4k6tynw=="
     },
     "@aws-sdk/types": {
-      "version": "3.78.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.78.0.tgz",
-      "integrity": "sha512-I9PTlVNSbwhIgMfmDM5as1tqRIkVZunjVmfogb2WVVPp4CaX0Ll01S0FSMSLL9k6tcQLXqh45pFRjrxCl9WKdQ=="
+      "version": "3.110.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.110.0.tgz",
+      "integrity": "sha512-dLVoqODU3laaqNFPyN1QLtlQnwX4gNPMXptEBIt/iJpuZf66IYJe6WCzVZGt4Zfa1CnUmrlA428AzdcA/KCr2A=="
     },
     "@babel/code-frame": {
       "version": "7.16.7",
@@ -6511,7 +6511,7 @@
     "atomic-batcher": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/atomic-batcher/-/atomic-batcher-1.0.2.tgz",
-      "integrity": "sha1-0WkB0QzOxZUWwZe5zNiTBom4E7Q="
+      "integrity": "sha512-EFGCRj4kLX1dHv1cDzTk+xbjBFj1GnJDpui52YmEcxxHHEWjYyT6l51U7n6WQ28osZH4S9gSybxe56Vm7vB61Q=="
     },
     "aws-sdk": {
       "version": "2.1157.0",
@@ -6530,9 +6530,9 @@
       }
     },
     "aws-xray-sdk-core": {
-      "version": "3.3.5",
-      "resolved": "https://registry.npmjs.org/aws-xray-sdk-core/-/aws-xray-sdk-core-3.3.5.tgz",
-      "integrity": "sha512-oJ/zPZc0foeeA4G64SonN3Fw9jJetzcMc98QY0V8qc7G9Gp9WhPMEHU2mI2uP05hwYf63FJO22K4UmSKtKza+Q==",
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/aws-xray-sdk-core/-/aws-xray-sdk-core-3.3.6.tgz",
+      "integrity": "sha512-5pJnix2mNBshzBtVsJxus3YOX2gM8+AirjyAJ0U+4ZkLRAcofNzBJUabZyHZPoVKud/YjEmcRr36bh4T3vOL2A==",
       "requires": {
         "@aws-sdk/service-error-classification": "^3.4.1",
         "@aws-sdk/types": "^3.4.1",
@@ -8922,7 +8922,7 @@
     "stack-chain": {
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/stack-chain/-/stack-chain-1.3.7.tgz",
-      "integrity": "sha1-0ZLJ/06moiyUxN1FkXHj8AzqEoU="
+      "integrity": "sha512-D8cWtWVdIe/jBA7v5p5Hwl5yOSOrmZPWDPe2KxQ5UAGD+nxbxU0lKXA4h85Ta6+qgdKVL3vUxsbIZjc1kBG7ug=="
     },
     "stack-utils": {
       "version": "2.0.5",

--- a/examples/sam/package.json
+++ b/examples/sam/package.json
@@ -14,7 +14,7 @@
     "package-bundle": "echo 'Not applicable'",
     "test:unit": "npm run build && jest",
     "test:e2e": "echo 'To be implemented ...'",
-    "version": "npm install @aws-lambda-powertools/logger@0.7.0 @aws-lambda-powertools/tracer@0.7.0 @aws-lambda-powertools/metrics@0.7.0 && git add package.json"
+    "version": "npm install @aws-lambda-powertools/logger@0.11.0 @aws-lambda-powertools/tracer@0.11.0 @aws-lambda-powertools/metrics@0.11.0 && git add package.json"
   },
   "devDependencies": {
     "@types/aws-lambda": "^8.10.86",
@@ -27,9 +27,9 @@
     "typescript": "^4.1.3"
   },
   "dependencies": {
-    "@aws-lambda-powertools/logger": "^0.10.0",
-    "@aws-lambda-powertools/metrics": "^0.10.0",
-    "@aws-lambda-powertools/tracer": "^0.10.0",
+    "@aws-lambda-powertools/logger": "^0.11.0",
+    "@aws-lambda-powertools/metrics": "^0.11.0",
+    "@aws-lambda-powertools/tracer": "^0.11.0",
     "aws-sdk": "^2.1122.0"
   }
 }


### PR DESCRIPTION
## Description of your changes

This PR proposes a change that modifies the `lerna` command that is in charge of versioning. This command is executed as part of the `release` action/workflow. The change in this PR adds two flags that allow to perform pre-releases with a custom suffix.

The two flags added are:
- `--conventional-prerelease`
- `--preid rc`, this flag allows to set a custom suffix so that pre-releases will look like `0.11.0-rc.0`

The documentation for both flags can be found [here](https://github.com/lerna/lerna/tree/main/commands/version).

### How to verify this change

```sh
npx lerna version --conventional-commits --force-publish --conventional-prerelease --preid rc --yes
lerna notice cli v4.0.0
lerna info current version 0.10.0
lerna WARN force-publish all packages
lerna info Assuming all packages changed
lerna info getChangelogConfig Successfully resolved preset "conventional-changelog-angular"

Changes:
 - cdk-app: 0.10.0 => 0.11.0-rc.0
 - powertools-typescript-sam-example: 0.10.0 => 0.11.0-rc.0
 - @aws-lambda-powertools/commons: 0.10.0 => 0.11.0-rc.0
 - @aws-lambda-powertools/logger: 0.10.0 => 0.11.0-rc.0
 - @aws-lambda-powertools/metrics: 0.10.0 => 0.11.0-rc.0
 - @aws-lambda-powertools/tracer: 0.10.0 => 0.11.0-rc.0

... Additional log entries removed for brevity's sake
```
### Related issues, RFCs

N/A

### PR status

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] My changes generate *no new warnings*
- [x] The *code coverage* hasn't decreased
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

N/A

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
