### PR TITLE
feat(tracer): auto disable when running inside amplify mock

### DIFF
--- a/docs/core/tracer.md
+++ b/docs/core/tracer.md
@@ -65,7 +65,7 @@ For a **complete list** of supported environment variables, refer to [this secti
 
 #### Example using AWS Serverless Application Model (SAM)
 
-The `Tracer` utility is instantiated outside of the Lambda handler. In doing this, the same instance can be used across multiple invocations inside the same execution environment. This allows `Metrics` to be aware of things like whether or not a given invocation had a cold start or not.
+The `Tracer` utility is instantiated outside of the Lambda handler. In doing this, the same instance can be used across multiple invocations inside the same execution environment. This allows `Tracer` to be aware of things like whether or not a given invocation had a cold start or not.
 
 === "handler.ts"
 

--- a/packages/tracer/src/Tracer.ts
+++ b/packages/tracer/src/Tracer.ts
@@ -597,6 +597,14 @@ class Tracer extends Utility implements TracerInterface {
   private getEnvVarsService(): EnvironmentVariablesService {
     return this.envVarsService;
   }
+
+  /**
+   * Determine if we are running inside an Amplify CLI process.
+   * Used internally during initialization.
+   */
+  private isAmplifyCli(): boolean {
+    return this.getEnvVarsService().getAwsExecutionEnv() === 'AWS_Lambda_amplify-mock';
+  }
   
   /**
    * Determine if we are running in a Lambda execution environment.
@@ -795,7 +803,7 @@ class Tracer extends Utility implements TracerInterface {
       return;
     }
 
-    if (this.isLambdaSamCli() || !this.isLambdaExecutionEnv()) {
+    if (this.isAmplifyCli() || this.isLambdaSamCli() || !this.isLambdaExecutionEnv()) {
       this.tracingEnabled = false;
     }
   }

--- a/packages/tracer/tests/unit/helpers.test.ts
+++ b/packages/tracer/tests/unit/helpers.test.ts
@@ -204,6 +204,20 @@ describe('Helper: createTracer function', () => {
 
   describe('Environment Variables configs', () => {
 
+    test('when AWS_EXECUTION_ENV environment variable is equal to AWS_Lambda_amplify-mock, tracing is disabled', () => {
+      // Prepare
+      process.env.AWS_EXECUTION_ENV = 'AWS_Lambda_amplify-mock';
+
+      // Act
+      const tracer = createTracer();
+
+      // Assess
+      expect(tracer).toEqual(expect.objectContaining({
+        tracingEnabled: false,
+      }));
+
+    });
+
     test('when AWS_SAM_LOCAL environment variable is set, tracing is disabled', () => {
       // Prepare
       process.env.AWS_SAM_LOCAL = 'true';


### PR DESCRIPTION
## Description of your changes

As discussed in #1007, the Amplify CLI allows developers to run Lambda functions locally during development. When not running inside the AWS Lambda execution environment the `xray-sdk`, and by extension `Tracer`, will not be able to work properly as there isn't any X-Ray Daemon to connect to and send traces. Unless explicitly accounted for, the default behaviour of the SDK is to throw an exception.

This is a problem as it requires developers using Tracer to make changes to their code only to be able to test locally. Similarly to what we already do with SAM CLI, in this PR I introduced some logic to leverage a special value set by the Amplify CLI in the environment variables ([details here](https://github.com/aws-amplify/amplify-cli/blob/master/packages/amplify-util-mock/src/utils/lambda/populate-lambda-mock-env-vars.ts#L46)) to detect that Tracer is indeed running inside a process started by the Amplify CLI and automatically disable itself to avoid attempting to send traces and segments.

When merged this PR will close #1007.

### How to verify this change

Check the newly added test cases as well as the result of the e2e tests (link in the comments below).

### Related issues, RFCs

#1007

### PR status

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [x] I have made corresponding changes to the *documentation*
- [x] My changes generate *no new warnings*
- [x] The *code coverage* hasn't decreased
- [x] I have *added tests* that prove my change is effective and works
- [x] New and existing *unit tests pass* locally and in Github Actions
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

N/A

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
