### PR TITLE
docs: added note about active tracing

### DIFF
--- a/docs/core/tracer.md
+++ b/docs/core/tracer.md
@@ -61,12 +61,7 @@ Setting | Description                                                           
 For a **complete list** of supported environment variables, refer to [this section](./../index.md#environment-variables).
 
 !!! note
-    Before your use this utility, your AWS Lambda function must have 
-[Active Tracing 
-enabled](https://docs.aws.amazon.com/lambda/latest/dg/services-xray.html) 
-as well as [have 
-permissions](https://docs.aws.amazon.com/lambda/latest/dg/services-xray.html#services-xray-permissions) 
-to send traces to AWS X-Ray
+    Before your use this utility, your AWS Lambda function must have [Active Tracing enabled](https://docs.aws.amazon.com/lambda/latest/dg/services-xray.html) as well as [have permissions](https://docs.aws.amazon.com/lambda/latest/dg/services-xray.html#services-xray-permissions) to send traces to AWS X-Ray
 
 #### Example using AWS Serverless Application Model (SAM)
 

--- a/docs/core/tracer.md
+++ b/docs/core/tracer.md
@@ -61,7 +61,12 @@ Setting | Description                                                           
 For a **complete list** of supported environment variables, refer to [this section](./../index.md#environment-variables).
 
 !!! note
-    Before your use this utility, your AWS Lambda function [must have permissions](https://docs.aws.amazon.com/lambda/latest/dg/services-xray.html#services-xray-permissions) to send traces to AWS X-Ray.
+    Before your use this utility, your AWS Lambda function must have 
+[Active Tracing 
+enabled](https://docs.aws.amazon.com/lambda/latest/dg/services-xray.html) 
+as well as [have 
+permissions](https://docs.aws.amazon.com/lambda/latest/dg/services-xray.html#services-xray-permissions) 
+to send traces to AWS X-Ray
 
 #### Example using AWS Serverless Application Model (SAM)
 


### PR DESCRIPTION
## Description of your changes

After some feedback raised by a user we have realised that it's not exactly explicit that [Active Tracing](https://docs.aws.amazon.com/lambda/latest/dg/services-xray.html) should be enabled in your Lambda function in order to see traces in X-Ray. This PR adds a sentence to the already existing note about permission to make this detail explicit in an effort to reduce confusion for future users who might not be familiar with the service.

### How to verify this change

See the diff, only added a sentence.

### Related issues, RFCs

N/A

### PR status

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have made corresponding changes to the *documentation*
- [x] My changes generate *no new warnings*
- [x] The *code coverage* hasn't decreased
- [x] New and existing *unit tests pass* locally and in Github Actions
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

N/A

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
