### PR TITLE
fix(logger): POWERTOOLS_LOGGER_LOG_EVENT precedence is respected

### DIFF
--- a/packages/logger/src/Logger.ts
+++ b/packages/logger/src/Logger.ts
@@ -292,8 +292,11 @@ class Logger extends Utility implements ClassThatLogs {
         }
 
         this.addContext(context);
-        const logEvent = options ? options.hasOwnProperty('logEvent') ? options.logEvent : undefined : undefined;
-        this.logEventIfEnabled(event, logEvent);
+        let shouldLogEvent = undefined;
+        if ( options && options.hasOwnProperty('logEvent') ) {
+          shouldLogEvent = options.logEvent;
+        }
+        this.logEventIfEnabled(event, shouldLogEvent);
 
         /* eslint-disable  @typescript-eslint/no-non-null-assertion */
         const result = originalMethod!.apply(target, [ event, context, callback ]);

--- a/packages/logger/src/Logger.ts
+++ b/packages/logger/src/Logger.ts
@@ -637,6 +637,19 @@ class Logger extends Utility implements ClassThatLogs {
   }
 
   /**
+   * If the log event feature is enabled via env variable, it sets a property that tracks whether
+   * the event passed to the Lambda function handler should be logged or not.
+   *
+   * @private
+   * @returns {void}
+   */
+  private setLogEvent(): void {
+    if (this.getEnvVarsService().getLogEvent()) {
+      this.logEvent = true;
+    }
+  }
+
+  /**
    * It sets the log formatter instance, in charge of giving a custom format
    * to the structured logs
    *
@@ -716,7 +729,8 @@ class Logger extends Utility implements ClassThatLogs {
     this.setLogsSampled();
     this.setLogFormatter(logFormatter);
     this.setPowertoolLogData(serviceName, environment);
-
+    this.setLogEvent();
+    
     this.addPersistentLogAttributes(persistentLogAttributes);
 
     return this;

--- a/packages/logger/src/Logger.ts
+++ b/packages/logger/src/Logger.ts
@@ -292,9 +292,8 @@ class Logger extends Utility implements ClassThatLogs {
         }
 
         this.addContext(context);
-        if (options) {
-          this.logEventIfEnabled(event, options.logEvent);
-        }
+        const logEvent = options ? options.hasOwnProperty('logEvent') ? options.logEvent : undefined : undefined;
+        this.logEventIfEnabled(event, logEvent);
 
         /* eslint-disable  @typescript-eslint/no-non-null-assertion */
         const result = originalMethod!.apply(target, [ event, context, callback ]);

--- a/packages/logger/src/middleware/middy.ts
+++ b/packages/logger/src/middleware/middy.ts
@@ -38,8 +38,12 @@ const injectLambdaContext = (target: Logger | Logger[], options?: HandlerOptions
       if (options && options.clearState === true) {
         persistentAttributes.push({ ...logger.getPersistentLogAttributes() });
       }
-      const logEvent = options ? options.hasOwnProperty('logEvent') ? options.logEvent : undefined : undefined;
-      logger.logEventIfEnabled(request.event, logEvent);
+
+      let shouldLogEvent = undefined;
+      if ( options && options.hasOwnProperty('logEvent') ) {
+        shouldLogEvent = options.logEvent;
+      }
+      logger.logEventIfEnabled(request.event, shouldLogEvent);
     });
   };
 

--- a/packages/logger/src/middleware/middy.ts
+++ b/packages/logger/src/middleware/middy.ts
@@ -38,9 +38,8 @@ const injectLambdaContext = (target: Logger | Logger[], options?: HandlerOptions
       if (options && options.clearState === true) {
         persistentAttributes.push({ ...logger.getPersistentLogAttributes() });
       }
-      if (options) {
-        logger.logEventIfEnabled(request.event, options.logEvent);
-      }
+      const logEvent = options ? options.hasOwnProperty('logEvent') ? options.logEvent : undefined : undefined;
+      logger.logEventIfEnabled(request.event, logEvent);
     });
   };
 

--- a/packages/logger/tests/e2e/logEventEnvVarSetting.middy.test.FunctionCode.ts
+++ b/packages/logger/tests/e2e/logEventEnvVarSetting.middy.test.FunctionCode.ts
@@ -1,0 +1,16 @@
+import { injectLambdaContext, Logger } from '../../src';
+import { Context } from 'aws-lambda';
+import middy from '@middy/core';
+
+type LambdaEvent = {
+  invocation: number
+};
+
+const logger = new Logger();
+
+const testFunction = async (event: LambdaEvent, context: Context): Promise<{requestId: string}> => ({
+  requestId: context.awsRequestId,
+});
+
+export const handler = middy(testFunction)
+  .use(injectLambdaContext(logger));

--- a/packages/logger/tests/e2e/logEventEnvVarSetting.middy.test.ts
+++ b/packages/logger/tests/e2e/logEventEnvVarSetting.middy.test.ts
@@ -76,7 +76,7 @@ describe(`logger E2E tests log event via env var setting (middy) for runtime: ${
 
   describe('Log event', () => {
 
-    it('should log the event on the first invocation', async () => {
+    it('should log the event at both invocations', async () => {
       const firstInvocationMessages = invocationLogs[0].getAllFunctionLogs();
       let eventLoggedInFirstInvocation = false;
       for (const message of firstInvocationMessages) {

--- a/packages/logger/tests/e2e/logEventEnvVarSetting.middy.test.ts
+++ b/packages/logger/tests/e2e/logEventEnvVarSetting.middy.test.ts
@@ -1,0 +1,110 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+/**
+ * Test logger basic features
+ *
+ * @group e2e/logger/logEventEnvVarSetting
+ */
+
+import path from 'path';
+import { App, Stack } from 'aws-cdk-lib';
+import { v4 } from 'uuid';
+import {
+  createStackWithLambdaFunction,
+  generateUniqueName,
+  invokeFunction,
+  isValidRuntimeKey
+} from '../../../commons/tests/utils/e2eUtils';
+import { InvocationLogs } from '../../../commons/tests/utils/InvocationLogs';
+import { deployStack, destroyStack } from '../../../commons/tests/utils/cdk-cli';
+import {
+  RESOURCE_NAME_PREFIX,
+  STACK_OUTPUT_LOG_GROUP,
+  SETUP_TIMEOUT,
+  TEST_CASE_TIMEOUT,
+  TEARDOWN_TIMEOUT
+} from './constants';
+
+const runtime: string = process.env.RUNTIME || 'nodejs16x';
+
+if (!isValidRuntimeKey(runtime)) {
+  throw new Error(`Invalid runtime key value: ${runtime}`);
+}
+
+const uuid = v4();
+const stackName = generateUniqueName(RESOURCE_NAME_PREFIX, uuid, runtime, 'LogEventEnvVarSetting-Middy');
+const functionName = generateUniqueName(RESOURCE_NAME_PREFIX, uuid, runtime, 'LogEventEnvVarSetting-Middy');
+const lambdaFunctionCodeFile = 'logEventEnvVarSetting.middy.test.FunctionCode.ts';
+
+const integTestApp = new App();
+let logGroupName: string; // We do not know it until deployment
+let stack: Stack;
+
+describe(`logger E2E tests log event via env var setting (middy) for runtime: ${runtime}`, () => {
+
+  let invocationLogs: InvocationLogs[];
+
+  beforeAll(async () => {
+    // Create and deploy a stack with AWS CDK
+    stack = createStackWithLambdaFunction({
+      app: integTestApp,
+      stackName: stackName,
+      functionName: functionName,
+      functionEntry: path.join(__dirname, lambdaFunctionCodeFile),
+      environment: {
+        LOG_LEVEL: 'INFO',
+        POWERTOOLS_SERVICE_NAME: 'logger-e2e-testing',
+        UUID: uuid,
+
+        // Enabling the logger to log events via env var
+        POWERTOOLS_LOGGER_LOG_EVENT: 'true',
+      },
+      logGroupOutputKey: STACK_OUTPUT_LOG_GROUP,
+      runtime: runtime,
+    });
+
+    const result = await deployStack(integTestApp, stack);
+    logGroupName = result.outputs[STACK_OUTPUT_LOG_GROUP];
+
+    // Invoke the function twice (one for cold start, another for warm start)
+    invocationLogs = await invokeFunction(functionName, 2, 'SEQUENTIAL');
+
+    console.log('logGroupName', logGroupName);
+
+  }, SETUP_TIMEOUT);
+
+  describe('Log event', () => {
+
+    it('should log the event on the first invocation', async () => {
+      const firstInvocationMessages = invocationLogs[0].getAllFunctionLogs();
+      let eventLoggedInFirstInvocation = false;
+      for (const message of firstInvocationMessages) {
+        if (message.includes(`event`)) {
+          eventLoggedInFirstInvocation = true;
+          expect(message).toContain(`"event":{"invocation":0}`);
+        }
+      }
+
+      const secondInvocationMessages = invocationLogs[1].getAllFunctionLogs();
+      let eventLoggedInSecondInvocation = false;
+      for (const message of secondInvocationMessages) {
+        if (message.includes(`event`)) {
+          eventLoggedInSecondInvocation = true;
+          expect(message).toContain(`"event":{"invocation":1}`);
+        }
+      }
+
+      expect(eventLoggedInFirstInvocation).toBe(true);
+      expect(eventLoggedInSecondInvocation).toBe(true);
+
+    }, TEST_CASE_TIMEOUT);
+
+  });
+
+  afterAll(async () => {
+    if (!process.env.DISABLE_TEARDOWN) {
+      await destroyStack(integTestApp, stack);
+    }
+  }, TEARDOWN_TIMEOUT);
+});

--- a/packages/logger/tests/unit/middleware/middy.test.ts
+++ b/packages/logger/tests/unit/middleware/middy.test.ts
@@ -153,130 +153,6 @@ describe('Middy middleware', () => {
       });
 
     });
-    test('when a logger is passed with option logEvent set to true, it logs the event', async () => {
-
-      // Prepare
-      const logger = new Logger();
-      const consoleSpy = jest.spyOn(logger['console'], 'info').mockImplementation();
-      const lambdaHandler = (): void => {
-        logger.info('This is an INFO log with some context');
-      };
-      const handler = middy(lambdaHandler).use(injectLambdaContext(logger , { logEvent: true }));
-      const event = { foo: 'bar' };
-      const getRandomInt = (): number => Math.floor(Math.random() * 1000000000);
-      const awsRequestId = getRandomInt().toString();
-      const context = {
-        callbackWaitsForEmptyEventLoop: true,
-        functionVersion: '$LATEST',
-        functionName: 'foo-bar-function',
-        memoryLimitInMB: '128',
-        logGroupName: '/aws/lambda/foo-bar-function',
-        logStreamName: '2021/03/09/[$LATEST]abcdef123456abcdef123456abcdef123456',
-        invokedFunctionArn: 'arn:aws:lambda:eu-west-1:123456789012:function:foo-bar-function',
-        awsRequestId: awsRequestId,
-        getRemainingTimeInMillis: () => 1234,
-        done: () => console.log('Done!'),
-        fail: () => console.log('Failed!'),
-        succeed: () => console.log('Succeeded!'),
-      };
-
-      // Act
-      await handler(event, context, () => console.log('Lambda invoked!'));
-
-      // Assess
-      expect(consoleSpy).toBeCalledTimes(2);
-      expect(consoleSpy).toHaveBeenNthCalledWith(1, JSON.stringify({
-        cold_start: true,
-        function_arn: 'arn:aws:lambda:eu-west-1:123456789012:function:foo-bar-function',
-        function_memory_size: 128,
-        function_name: 'foo-bar-function',
-        function_request_id: awsRequestId,
-        level: 'INFO',
-        message: 'Lambda invocation event',
-        service: 'hello-world',
-        timestamp: '2016-06-20T12:08:10.000Z',
-        xray_trace_id: '1-5759e988-bd862e3fe1be46a994272793',
-        event: {
-          foo: 'bar'
-        }
-      }));
-
-    });
-
-    test('when a logger is passed with option logEvent set to true, it logs the event', async () => {
-
-      // Prepare
-      const configService: ConfigServiceInterface = {
-        get(name: string): string {
-          return `a-string-from-${name}`;
-        },
-        getCurrentEnvironment(): string {
-          return 'dev';
-        },
-        getLogEvent(): boolean {
-          return true;
-        },
-        getLogLevel(): string {
-          return 'INFO';
-        },
-        getSampleRateValue(): number | undefined {
-          return undefined;
-        },
-        getServiceName(): string {
-          return 'my-backend-service';
-        },
-
-      };
-      // Prepare
-
-      const logger = new Logger({
-        customConfigService: configService,
-      });
-      const consoleSpy = jest.spyOn(logger['console'], 'info').mockImplementation();
-      const lambdaHandler = (): void => {
-        logger.info('This is an INFO log with some context');
-      };
-      const handler = middy(lambdaHandler).use(injectLambdaContext(logger , { logEvent: true }));
-      const event = { foo: 'bar' };
-      const getRandomInt = (): number => Math.floor(Math.random() * 1000000000);
-      const awsRequestId = getRandomInt().toString();
-      const context = {
-        callbackWaitsForEmptyEventLoop: true,
-        functionVersion: '$LATEST',
-        functionName: 'foo-bar-function',
-        memoryLimitInMB: '128',
-        logGroupName: '/aws/lambda/foo-bar-function',
-        logStreamName: '2021/03/09/[$LATEST]abcdef123456abcdef123456abcdef123456',
-        invokedFunctionArn: 'arn:aws:lambda:eu-west-1:123456789012:function:foo-bar-function',
-        awsRequestId: awsRequestId,
-        getRemainingTimeInMillis: () => 1234,
-        done: () => console.log('Done!'),
-        fail: () => console.log('Failed!'),
-        succeed: () => console.log('Succeeded!'),
-      };
-
-      // Act
-      await handler(event, context, () => console.log('Lambda invoked!'));
-
-      // Assess
-      expect(consoleSpy).toBeCalledTimes(2);
-      expect(consoleSpy).toHaveBeenNthCalledWith(1, JSON.stringify({
-        cold_start: true,
-        function_arn: 'arn:aws:lambda:eu-west-1:123456789012:function:foo-bar-function',
-        function_memory_size: 128,
-        function_name: 'foo-bar-function',
-        function_request_id: awsRequestId,
-        level: 'INFO',
-        message: 'Lambda invocation event',
-        service: 'my-backend-service',
-        timestamp: '2016-06-20T12:08:10.000Z',
-        xray_trace_id: '1-5759e988-bd862e3fe1be46a994272793',
-        event: {
-          foo: 'bar'
-        }
-      }));
-
-    });
 
   });
 
@@ -328,6 +204,221 @@ describe('Middy middleware', () => {
         biz: 'baz'
       });
       expect(persistentAttribsAfterInvocation).toEqual(persistentAttribs);
+
+    });
+
+  });
+
+  describe('Feature: log event', () => {
+
+    test('when a logger is passed with option logEvent set to true, it logs the event', async () => {
+
+      // Prepare
+      const logger = new Logger();
+      const consoleSpy = jest.spyOn(logger['console'], 'info').mockImplementation();
+      const lambdaHandler = (): void => {
+        logger.info('This is an INFO log with some context');
+      };
+      const handler = middy(lambdaHandler).use(injectLambdaContext(logger , { logEvent: true }));
+      const event = { foo: 'bar' };
+      const getRandomInt = (): number => Math.floor(Math.random() * 1000000000);
+      const awsRequestId = getRandomInt().toString();
+      const context = {
+        callbackWaitsForEmptyEventLoop: true,
+        functionVersion: '$LATEST',
+        functionName: 'foo-bar-function',
+        memoryLimitInMB: '128',
+        logGroupName: '/aws/lambda/foo-bar-function',
+        logStreamName: '2021/03/09/[$LATEST]abcdef123456abcdef123456abcdef123456',
+        invokedFunctionArn: 'arn:aws:lambda:eu-west-1:123456789012:function:foo-bar-function',
+        awsRequestId: awsRequestId,
+        getRemainingTimeInMillis: () => 1234,
+        done: () => console.log('Done!'),
+        fail: () => console.log('Failed!'),
+        succeed: () => console.log('Succeeded!'),
+      };
+
+      // Act
+      await handler(event, context, () => console.log('Lambda invoked!'));
+
+      // Assess
+      expect(consoleSpy).toBeCalledTimes(2);
+      expect(consoleSpy).toHaveBeenNthCalledWith(1, JSON.stringify({
+        cold_start: true,
+        function_arn: 'arn:aws:lambda:eu-west-1:123456789012:function:foo-bar-function',
+        function_memory_size: 128,
+        function_name: 'foo-bar-function',
+        function_request_id: awsRequestId,
+        level: 'INFO',
+        message: 'Lambda invocation event',
+        service: 'hello-world',
+        timestamp: '2016-06-20T12:08:10.000Z',
+        xray_trace_id: '1-5759e988-bd862e3fe1be46a994272793',
+        event: {
+          foo: 'bar'
+        }
+      }));
+
+    });
+
+    test('when a logger is passed with option logEvent set to true, while also having a custom configService, it logs the event', async () => {
+
+      // Prepare
+      const configService: ConfigServiceInterface = {
+        get(name: string): string {
+          return `a-string-from-${name}`;
+        },
+        getCurrentEnvironment(): string {
+          return 'dev';
+        },
+        getLogEvent(): boolean {
+          return true;
+        },
+        getLogLevel(): string {
+          return 'INFO';
+        },
+        getSampleRateValue(): number | undefined {
+          return undefined;
+        },
+        getServiceName(): string {
+          return 'my-backend-service';
+        },
+
+      };
+
+      const logger = new Logger({
+        customConfigService: configService,
+      });
+      const consoleSpy = jest.spyOn(logger['console'], 'info').mockImplementation();
+      const lambdaHandler = (): void => {
+        logger.info('This is an INFO log with some context');
+      };
+      const handler = middy(lambdaHandler).use(injectLambdaContext(logger , { logEvent: true }));
+      const event = { foo: 'bar' };
+      const getRandomInt = (): number => Math.floor(Math.random() * 1000000000);
+      const awsRequestId = getRandomInt().toString();
+      const context = {
+        callbackWaitsForEmptyEventLoop: true,
+        functionVersion: '$LATEST',
+        functionName: 'foo-bar-function',
+        memoryLimitInMB: '128',
+        logGroupName: '/aws/lambda/foo-bar-function',
+        logStreamName: '2021/03/09/[$LATEST]abcdef123456abcdef123456abcdef123456',
+        invokedFunctionArn: 'arn:aws:lambda:eu-west-1:123456789012:function:foo-bar-function',
+        awsRequestId: awsRequestId,
+        getRemainingTimeInMillis: () => 1234,
+        done: () => console.log('Done!'),
+        fail: () => console.log('Failed!'),
+        succeed: () => console.log('Succeeded!'),
+      };
+
+      // Act
+      await handler(event, context, () => console.log('Lambda invoked!'));
+
+      // Assess
+      expect(consoleSpy).toBeCalledTimes(2);
+      expect(consoleSpy).toHaveBeenNthCalledWith(1, JSON.stringify({
+        cold_start: true,
+        function_arn: 'arn:aws:lambda:eu-west-1:123456789012:function:foo-bar-function',
+        function_memory_size: 128,
+        function_name: 'foo-bar-function',
+        function_request_id: awsRequestId,
+        level: 'INFO',
+        message: 'Lambda invocation event',
+        service: 'my-backend-service',
+        timestamp: '2016-06-20T12:08:10.000Z',
+        xray_trace_id: '1-5759e988-bd862e3fe1be46a994272793',
+        event: {
+          foo: 'bar'
+        }
+      }));
+
+    });
+
+    test('when a logger is passed without options, but POWERTOOLS_LOGGER_LOG_EVENT env var is set to true, it logs the event', async () => {
+
+      // Prepare
+      process.env.POWERTOOLS_LOGGER_LOG_EVENT = 'true';
+      const logger = new Logger();
+      const consoleSpy = jest.spyOn(logger['console'], 'info').mockImplementation();
+      const lambdaHandler = (): void => {
+        logger.info('This is an INFO log with some context');
+      };
+      const handler = middy(lambdaHandler).use(injectLambdaContext(logger));
+      const event = { foo: 'bar' };
+      const getRandomInt = (): number => Math.floor(Math.random() * 1000000000);
+      const awsRequestId = getRandomInt().toString();
+      const context = {
+        callbackWaitsForEmptyEventLoop: true,
+        functionVersion: '$LATEST',
+        functionName: 'foo-bar-function',
+        memoryLimitInMB: '128',
+        logGroupName: '/aws/lambda/foo-bar-function',
+        logStreamName: '2021/03/09/[$LATEST]abcdef123456abcdef123456abcdef123456',
+        invokedFunctionArn: 'arn:aws:lambda:eu-west-1:123456789012:function:foo-bar-function',
+        awsRequestId: awsRequestId,
+        getRemainingTimeInMillis: () => 1234,
+        done: () => console.log('Done!'),
+        fail: () => console.log('Failed!'),
+        succeed: () => console.log('Succeeded!'),
+      };
+
+      // Act
+      await handler(event, context, () => console.log('Lambda invoked!'));
+
+      // Assess
+      expect(consoleSpy).toBeCalledTimes(2);
+      expect(consoleSpy).toHaveBeenNthCalledWith(1, JSON.stringify({
+        cold_start: true,
+        function_arn: 'arn:aws:lambda:eu-west-1:123456789012:function:foo-bar-function',
+        function_memory_size: 128,
+        function_name: 'foo-bar-function',
+        function_request_id: awsRequestId,
+        level: 'INFO',
+        message: 'Lambda invocation event',
+        service: 'hello-world',
+        timestamp: '2016-06-20T12:08:10.000Z',
+        xray_trace_id: '1-5759e988-bd862e3fe1be46a994272793',
+        event: {
+          foo: 'bar'
+        }
+      }));
+
+    });
+
+    test('when a logger is passed with option logEvent set to false, but POWERTOOLS_LOGGER_LOG_EVENT env var is set to true, it does not log the event', async () => {
+
+      // Prepare
+      process.env.POWERTOOLS_LOGGER_LOG_EVENT = 'true';
+      const logger = new Logger();
+      const consoleSpy = jest.spyOn(logger['console'], 'info').mockImplementation();
+      const lambdaHandler = (): void => {
+        logger.info('This is an INFO log with some context');
+      };
+      const handler = middy(lambdaHandler).use(injectLambdaContext(logger, { logEvent: false }));
+      const event = { foo: 'bar' };
+      const getRandomInt = (): number => Math.floor(Math.random() * 1000000000);
+      const awsRequestId = getRandomInt().toString();
+      const context = {
+        callbackWaitsForEmptyEventLoop: true,
+        functionVersion: '$LATEST',
+        functionName: 'foo-bar-function',
+        memoryLimitInMB: '128',
+        logGroupName: '/aws/lambda/foo-bar-function',
+        logStreamName: '2021/03/09/[$LATEST]abcdef123456abcdef123456abcdef123456',
+        invokedFunctionArn: 'arn:aws:lambda:eu-west-1:123456789012:function:foo-bar-function',
+        awsRequestId: awsRequestId,
+        getRemainingTimeInMillis: () => 1234,
+        done: () => console.log('Done!'),
+        fail: () => console.log('Failed!'),
+        succeed: () => console.log('Succeeded!'),
+      };
+
+      // Act
+      await handler(event, context, () => console.log('Lambda invoked!'));
+
+      // Assess
+      expect(consoleSpy).toBeCalledTimes(1);
 
     });
 

--- a/packages/logger/tests/unit/middleware/middy.test.ts
+++ b/packages/logger/tests/unit/middleware/middy.test.ts
@@ -158,7 +158,7 @@ describe('Middy middleware', () => {
 
   describe('Feature: clear state', () => {
 
-    test('when enabled, the persistent log attributes added in the handler are removed after the handler\'s code is executed', async () => {
+    test('when enabled, the persistent log attributes added within the handler scope are removed after the invocation ends', async () => {
 
       // Prepare
       const logger = new Logger({
@@ -393,7 +393,7 @@ describe('Middy middleware', () => {
       const logger = new Logger();
       const consoleSpy = jest.spyOn(logger['console'], 'info').mockImplementation();
       const lambdaHandler = (): void => {
-        logger.info('This is an INFO log with some context');
+        logger.info('This is an INFO log');
       };
       const handler = middy(lambdaHandler).use(injectLambdaContext(logger, { logEvent: false }));
       const event = { foo: 'bar' };
@@ -419,7 +419,18 @@ describe('Middy middleware', () => {
 
       // Assess
       expect(consoleSpy).toBeCalledTimes(1);
-
+      expect(consoleSpy).toHaveBeenNthCalledWith(1, JSON.stringify({
+        cold_start: true,
+        function_arn: 'arn:aws:lambda:eu-west-1:123456789012:function:foo-bar-function',
+        function_memory_size: 128,
+        function_name: 'foo-bar-function',
+        function_request_id: awsRequestId,
+        level: 'INFO',
+        message: 'This is an INFO log',
+        service: 'hello-world',
+        timestamp: '2016-06-20T12:08:10.000Z',
+        xray_trace_id: '1-5759e988-bd862e3fe1be46a994272793',
+      }));
     });
 
   });


### PR DESCRIPTION
## Description of your changes

This PR aims at fixing a bug that was identified by @saragerion in the logger. In [v0.11.0](https://github.com/awslabs/aws-lambda-powertools-typescript/releases/tag/v0.11.0) we released a feature that allows to log the event parameter of a function handler. This is an opt-in feature that can be enabled by users by either passing a `logEvent` parameter equal to true in the middleware/decorator or by setting a `POWERTOOLS_LOGGER_LOG_EVENT` environment variable also equal to true. In the current iteration of the utility only the first method works.

I was able to reproduce the issue in my own tests.

There were two separate issues that contributed to this bug:

When deciding on whether to log the event or not a function named [`logEventIfEnabled`](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/packages/logger/src/Logger.ts#L318) is called. This function takes in account - and gives precedence to - the parameter passed in the middleware/decorator but also checks the value of the [`logEvent`](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/packages/logger/src/Logger.ts#L122) property that is part of the current `Logger` class. This property is set to `false` by default (as documented). That same property should be set to `true` upon class instantiation and as a part of the [`setOptions`](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/12d4c93011c279d77154338708d94e23b23cd3bf/packages/logger/src/Logger.ts#L701) lifecycle if the `POWERTOOLS_LOGGER_LOG_EVENT` env var is present & with a _truthy_ value, but this never happened.

The second issue, perhaps minor or intended (would appreciate feedback if that was the case) was that both middleware and decorator called the `logEventIfEnabled` function mentioned above only when an `options` parameter is passed to the middleware/decorator. For example:

Even fixing the logic as described previously, the code below still doesn't work because since the `injectLambdaContext` doesn't have a second parameter (`options`), the Logger class never checks if the log event feature was enabled via env var:
```ts
process.env.POWERTOOLS_LOGGER_LOG_EVENT = 'true';

export const handler = middy(lambdaHandler)
    .use(injectLambdaContext(logger));
```

To make it work, developers would have had to pass an empty object (or an object with other configs like `clearState`):
```ts
process.env.POWERTOOLS_LOGGER_LOG_EVENT = 'true';

export const handler = middy(lambdaHandler)
    .use(injectLambdaContext(logger, { }));

// OR
export const handler = middy(lambdaHandler)
    .use(injectLambdaContext(logger, { clearState: true }));
```

The same applies to the decorator usage.

Since we cannot rely on the presence of other configs (i.e. `clearState`) we shouldn't force devs to pass an empty object for the env var config to be evaluated.

### How to verify this change

See additional unit test cases that were added.

### Related issues, RFCs

N/A

### PR status

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [x] My changes generate *no new warnings*
- [x] The *code coverage* hasn't decreased
- [x] I have *added tests* that prove my change is effective and works
- [x] New and existing *unit tests pass* locally and in Github Actions
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

N/A

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
