### PR TITLE
fix(tracer): capture method throws errors correctly

### DIFF
--- a/packages/tracer/src/Tracer.ts
+++ b/packages/tracer/src/Tracer.ts
@@ -432,7 +432,7 @@ class Tracer extends Utility implements TracerInterface {
             throw error;
           } finally {
             subsegment?.close();
-            // subsegment?.flush();
+            subsegment?.flush();
           }
           
           return result;

--- a/packages/tracer/src/Tracer.ts
+++ b/packages/tracer/src/Tracer.ts
@@ -421,17 +421,18 @@ class Tracer extends Utility implements TracerInterface {
           return originalMethod.apply(target, [...args]);
         }
 
-        return this.provider.captureAsyncFunc(`### ${originalMethod.name}`, async subsegment => {
+        return this.provider.captureAsyncFunc(`### ${originalMethod.name}`, async subsegment => {          
           let result;
           try {
             result = await originalMethod.apply(this, [...args]);
             this.addResponseAsMetadata(result, originalMethod.name);
           } catch (error) {
-            this.addErrorAsMetadata(error as Error);
-            // TODO: should this error be thrown?? If thrown we get a ERR_UNHANDLED_REJECTION. If not aren't we are basically catching a Customer error?
-            // throw error;
+            this.addErrorAsMetadata(error as Error); 
+            
+            throw error;
           } finally {
             subsegment?.close();
+            // subsegment?.flush();
           }
           
           return result;

--- a/packages/tracer/tests/unit/Tracer.test.ts
+++ b/packages/tracer/tests/unit/Tracer.test.ts
@@ -904,8 +904,7 @@ describe('Class: Tracer', () => {
       jest.spyOn(tracer.provider, 'getSegment')
         .mockImplementation(() => newSubsegment);
       setContextMissingStrategy(() => null);
-      // const captureAsyncFuncSpy = jest.spyOn(tracer.provider, 'captureAsyncFunc');
-      const captureAsyncFuncSpy = createCaptureAsyncFuncMock(tracer.provider);
+      const captureAsyncFuncSpy = jest.spyOn(tracer.provider, 'captureAsyncFunc');
       class Lambda implements LambdaInterface {
 
         @tracer.captureMethod()
@@ -948,8 +947,8 @@ describe('Class: Tracer', () => {
       jest.spyOn(tracer.provider, 'getSegment')
         .mockImplementation(() => newSubsegment);
       setContextMissingStrategy(() => null);
-      const captureAsyncFuncSpy = jest.spyOn(tracer.provider, 'captureAsyncFunc');
-      // const captureAsyncFuncSpy = createCaptureAsyncFuncMock(tracer.provider);
+      // const captureAsyncFuncSpy = jest.spyOn(tracer.provider, 'captureAsyncFunc');
+      const captureAsyncFuncSpy = createCaptureAsyncFuncMock(tracer.provider);
       const addErrorSpy = jest.spyOn(newSubsegment, 'addError');
       class Lambda implements LambdaInterface {
 

--- a/packages/tracer/tests/unit/Tracer.test.ts
+++ b/packages/tracer/tests/unit/Tracer.test.ts
@@ -17,16 +17,10 @@ interface LambdaInterface {
 type CaptureAsyncFuncMock = jest.SpyInstance<unknown, [name: string, fcn: (subsegment?: Subsegment) => unknown, parent?: Segment | Subsegment]>;
 const createCaptureAsyncFuncMock = function(provider: ProviderServiceInterface): CaptureAsyncFuncMock {
   return jest.spyOn(provider, 'captureAsyncFunc')
-    .mockImplementation((methodName, callBackFn) => {
+    .mockImplementation(async (methodName, callBackFn) => {
       const subsegment = new Subsegment(`### ${methodName}`);
       jest.spyOn(subsegment, 'flush').mockImplementation(() => null);
-      try {
-        callBackFn(subsegment);
-      } catch {
-        console.log('error was thrown');
-      } finally {
-        console.log('finally');
-      }
+      await callBackFn(subsegment);
     });
 };
 

--- a/packages/tracer/tests/unit/Tracer.test.ts
+++ b/packages/tracer/tests/unit/Tracer.test.ts
@@ -941,7 +941,6 @@ describe('Class: Tracer', () => {
       jest.spyOn(tracer.provider, 'getSegment')
         .mockImplementation(() => newSubsegment);
       setContextMissingStrategy(() => null);
-      // const captureAsyncFuncSpy = jest.spyOn(tracer.provider, 'captureAsyncFunc');
       const captureAsyncFuncSpy = createCaptureAsyncFuncMock(tracer.provider);
       const addErrorSpy = jest.spyOn(newSubsegment, 'addError');
       class Lambda implements LambdaInterface {


### PR DESCRIPTION
## Description of your changes

As reported by @saragerion, the Tracer method `captureMethod` was incorrectly catching errors thrown within the body/scope of a decorated Class method defined by users. This is not a desired behaviour as the utility should not catch customers' errors but should simply run the logic defined in the decorator function and then throw the error along for customers to handle/throw in their code.

We had this behaviour on the radar as shown by the `TODO` comment present in that part of the code (see diff) but up until now we hadn't noticed / it wasn't reported. Additionally this same change was made to the `captureLambdaHandler` at some point in the past.

This PR modifies the logic of the `captureMethod` decorator and updates the unit tests related to it so that they actually test a method that throws.

### How to verify this change

See updated unit tests.

### Related issues, RFCs

N/A

### PR status

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [x] My changes generate *no new warnings*
- [x] The *code coverage* hasn't decreased
- [x] I have *added tests* that prove my change is effective and works
- [x] New and existing *unit tests pass* locally and in Github Actions
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

N/A

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
