### PR TITLE
chore(ci): housekeeping scripts & workflows related to PRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,3 @@
-# These owners will be the default owners for everything in
-# the repo.
-# TODO: revisit this list
-* @saragerion, @alan-churley, @heitorlessa
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+* @awslabs/aws-lambda-powertools-typescript

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,9 +21,9 @@
 
 ### Related issues, RFCs
 
-<!--- Add here the link to one or more Github Issues or RFCs that are related to this PR. -->
-[#XXXXX](https://github.com/awslabs/aws-lambda-powertools-typescript/issues/XXXXX)  
-[#ZZZZZ](https://github.com/awslabs/aws-lambda-powertools-typescript/issues/ZZZZZ)
+<!--- Add here the number to the Github Issue or RFC that is related to this PR. -->
+<!-- **Issue number:** #123 -->
+**Issue number:** 
 
 ### PR status
 

--- a/.github/scripts/constants.js
+++ b/.github/scripts/constants.js
@@ -1,0 +1,42 @@
+module.exports = Object.freeze({
+  /** @type {string} */
+  // Values: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request
+  "PR_ACTION": process.env.PR_ACTION?.replace(/"/g, '') || "",
+
+  /** @type {string} */
+  "PR_AUTHOR": process.env.PR_AUTHOR?.replace(/"/g, '') || "",
+
+  /** @type {string} */
+  "PR_BODY": process.env.PR_BODY || "",
+
+  /** @type {string} */
+  "PR_TITLE": process.env.PR_TITLE || "",
+
+  /** @type {number} */
+  "PR_NUMBER": process.env.PR_NUMBER || 0,
+
+  /** @type {string} */
+  "PR_IS_MERGED": process.env.PR_IS_MERGED || "false",
+
+  /** @type {string} */
+  "LABEL_BLOCK": "do-not-merge",
+
+  /** @type {string} */
+  "LABEL_BLOCK_REASON": "need-issue",
+
+  /** @type {string} */
+  "LABEL_PENDING_RELEASE": "pending-release",
+
+  /** @type {string} */
+  "HANDLE_MAINTAINERS_TEAM": "@awslabs/aws-lambda-powertools-typescript",
+
+  /** @type {string[]} */
+  "IGNORE_AUTHORS": ["dependabot[bot]"],
+
+  /** @type {string[]} */
+  "AREAS": [
+      "tracer",
+      "metrics",
+      "logger",
+  ],
+});

--- a/.github/scripts/download_pr_artifact.js
+++ b/.github/scripts/download_pr_artifact.js
@@ -1,0 +1,26 @@
+module.exports = async ({github, context, core}) => {
+  const fs = require('fs');
+
+  const workflowRunId = process.env.WORKFLOW_ID;
+  core.info(`Listing artifacts for workflow run ${workflowRunId}`);
+
+  const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    run_id: workflowRunId,
+  });
+
+  const matchArtifact = artifacts.data.artifacts.filter(artifact => artifact.name == "pr")[0];
+
+  core.info(`Downloading artifacts for workflow run ${workflowRunId}`);
+  const artifact = await github.rest.actions.downloadArtifact({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    artifact_id: matchArtifact.id,
+    archive_format: 'zip',
+  });
+
+  core.info("Saving artifact found", artifact);
+
+  fs.writeFileSync('pr.zip', Buffer.from(artifact.data));
+}

--- a/.github/scripts/label_missing_related_issue.js
+++ b/.github/scripts/label_missing_related_issue.js
@@ -1,0 +1,40 @@
+const {
+  PR_ACTION,
+  PR_AUTHOR,
+  PR_BODY,
+  PR_NUMBER,
+  IGNORE_AUTHORS,
+  LABEL_BLOCK,
+  LABEL_BLOCK_REASON
+} = require("./constants");
+
+module.exports = async ({github, context, core}) => {
+    if (IGNORE_AUTHORS.includes(PR_AUTHOR)) {
+      return core.notice("Author in IGNORE_AUTHORS list; skipping...");
+    }
+
+    if (PR_ACTION != "opened") {
+      return core.notice("Only newly open PRs are labelled to avoid spam; skipping");
+    }
+
+    const RELATED_ISSUE_REGEX = /Issue number:[^\d\r\n]+(?<issue>\d+)/;
+    const isMatch = RELATED_ISSUE_REGEX.exec(PR_BODY);
+    if (isMatch == null) {
+        core.info(`No related issue found, maybe the author didn't use the template but there is one.`);
+
+        let msg = "No related issues found. Please ensure there is an open issue related to this change to avoid significant delays or closure.";
+        await github.rest.issues.createComment({
+          owner: context.repo.owner,
+          repo: context.repo.repo,
+          body: msg,
+          issue_number: PR_NUMBER,
+        });
+
+        return await github.rest.issues.addLabels({
+          issue_number: PR_NUMBER,
+          owner: context.repo.owner,
+          repo: context.repo.repo,
+          labels: [LABEL_BLOCK, LABEL_BLOCK_REASON]
+        });
+    }
+}

--- a/.github/scripts/label_pr_based_on_title.js
+++ b/.github/scripts/label_pr_based_on_title.js
@@ -1,0 +1,60 @@
+const { PR_NUMBER, PR_TITLE, AREAS } = require("./constants");
+
+module.exports = async ({github, context, core}) => {
+    const FEAT_REGEX = /feat(\((.+)\))?(:.+)/
+    const BUG_REGEX = /(fix|bug)(\((.+)\))?(:.+)/
+    const DOCS_REGEX = /(docs|doc)(\((.+)\))?(:.+)/
+    const CHORE_REGEX = /(chore)(\((.+)\))?(:.+)/
+    const DEPRECATED_REGEX = /(deprecated)(\((.+)\))?(:.+)/
+    const REFACTOR_REGEX = /(refactor)(\((.+)\))?(:.+)/
+
+    const labels = {
+        "feature": FEAT_REGEX,
+        "bug": BUG_REGEX,
+        "documentation": DOCS_REGEX,
+        "internal": CHORE_REGEX,
+        "enhancement": REFACTOR_REGEX,
+        "deprecated": DEPRECATED_REGEX,
+    };
+
+    // Maintenance: We should keep track of modified PRs in case their titles change
+    let miss = 0;
+    try {
+        for (const label in labels) {
+            const matcher = new RegExp(labels[label]);
+            const matches = matcher.exec(PR_TITLE);
+            if (matches != null) {
+                core.info(`Auto-labeling PR ${PR_NUMBER} with ${label}`);
+
+                await github.rest.issues.addLabels({
+                    issue_number: PR_NUMBER,
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    labels: [label]
+                });
+
+                const area = matches[2]; // second capture group contains the area
+                if (AREAS.indexOf(area) > -1) {
+                    core.info(`Auto-labeling PR ${PR_NUMBER} with area ${area}`);
+                    await github.rest.issues.addLabels({
+                        issue_number: PR_NUMBER,
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        labels: [`area/${area}`],
+                    });
+                } else {
+                    core.debug(`'${PR_TITLE}' didn't match any known area.`);
+                }
+
+                return;
+            } else {
+                core.debug(`'${PR_TITLE}' didn't match '${label}' semantic.`);
+                miss += 1;
+            }
+        }
+    } finally {
+        if (miss == Object.keys(labels).length) {
+            core.notice(`PR ${PR_NUMBER} title '${PR_TITLE}' doesn't follow semantic titles; skipping...`);
+        }
+    }
+}

--- a/.github/scripts/label_related_issue.js
+++ b/.github/scripts/label_related_issue.js
@@ -1,0 +1,63 @@
+const {
+  PR_AUTHOR,
+  PR_BODY,
+  PR_NUMBER,
+  IGNORE_AUTHORS,
+  LABEL_PENDING_RELEASE,
+  HANDLE_MAINTAINERS_TEAM,
+  PR_IS_MERGED,
+} = require("./constants")
+
+module.exports = async ({github, context, core}) => {
+    if (IGNORE_AUTHORS.includes(PR_AUTHOR)) {
+      return core.notice("Author in IGNORE_AUTHORS list; skipping...");
+    }
+
+    if (PR_IS_MERGED == "false") {
+      return core.notice("Only merged PRs to avoid spam; skipping");
+    }
+
+    const RELATED_ISSUE_REGEX = /Issue number:[^\d\r\n]+(?<issue>\d+)/;
+
+    const isMatch = RELATED_ISSUE_REGEX.exec(PR_BODY);
+
+    try {
+      if (!isMatch) {
+        core.setFailed(`Unable to find related issue for PR number ${PR_NUMBER}.\n\n Body details: ${PR_BODY}`);
+        return await github.rest.issues.createComment({
+          owner: context.repo.owner,
+          repo: context.repo.repo,
+          body: `${HANDLE_MAINTAINERS_TEAM} No related issues found. Please ensure '${LABEL_PENDING_RELEASE}' label is applied before releasing.`,
+          issue_number: PR_NUMBER,
+        });
+      }
+    } catch (error) {
+      core.setFailed(`Unable to create comment on PR number ${PR_NUMBER}.\n\n Error details: ${error}`);
+      throw new Error(error);
+    }
+
+    const { groups: {issue} } = isMatch;
+
+    try {
+      core.info(`Auto-labeling related issue ${issue} for release`)
+      await github.rest.issues.addLabels({
+        issue_number: issue,
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        labels: [LABEL_PENDING_RELEASE]
+      });
+    } catch (error) {
+      core.setFailed(`Is this issue number (${issue}) valid? Perhaps a discussion?`);
+      throw new Error(error);
+    }
+
+    const { groups: {relatedIssueNumber} } = isMatch;
+
+    core.info(`Auto-labeling related issue ${relatedIssueNumber} for release`);
+    return await github.rest.issues.addLabels({
+      issue_number: relatedIssueNumber,
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      labels: [relatedIssueNumber]
+    });
+}

--- a/.github/scripts/save_pr_details.js
+++ b/.github/scripts/save_pr_details.js
@@ -1,0 +1,13 @@
+module.exports = async ({context, core}) => {
+  const fs = require('fs');
+  const filename = "pr.txt";
+
+  try {
+      fs.writeFileSync(`./${filename}`, JSON.stringify(context.payload));
+
+      return `PR successfully saved ${filename}`;
+  } catch (err) {
+      core.setFailed("Failed to save PR details");
+      console.error(err);
+  }
+}

--- a/.github/workflows/on-merge-to-main.yml
+++ b/.github/workflows/on-merge-to-main.yml
@@ -1,10 +1,38 @@
-name: on-merge-to-main
+name: On PR merge
+
 on:
-  push:
-    branches:
-      - main
-  workflow_dispatch: {}
+  workflow_run:
+    workflows: ["Record PR details"]
+    types:
+      - completed
+
 jobs:
+  get_pr_details:
+    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
+    uses: ./.github/workflows/reusable_export_pr_details.yml
+    with:
+      record_pr_workflow_id: ${{ github.event.workflow_run.id }}
+      workflow_origin: ${{ github.event.repository.full_name }}
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}
+  release_label_on_merge:
+    needs: get_pr_details
+    runs-on: ubuntu-latest
+    if: needs.get_pr_details.outputs.prIsMerged == 'true'
+    steps:
+      - uses: actions/checkout@v3
+      - name: "Label PR related issue for release"
+        uses: actions/github-script@v6
+        env:
+          PR_NUMBER: ${{ needs.get_pr_details.outputs.prNumber }}
+          PR_BODY: ${{ needs.get_pr_details.outputs.prBody }}
+          PR_IS_MERGED: ${{ needs.get_pr_details.outputs.prIsMerged }}
+          PR_AUTHOR: ${{ needs.get_pr_details.outputs.prAuthor }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const script = require('.github/scripts/label_related_issue.js')
+            await script({github, context, core})
   publish:
     #########################
     # Force Github action to run only a single job at a time (based on the group name)

--- a/.github/workflows/on_opened_pr.yml
+++ b/.github/workflows/on_opened_pr.yml
@@ -1,4 +1,4 @@
-name: Label PR based on title
+name: On new PR
 
 on:
   workflow_run:
@@ -8,8 +8,6 @@ on:
 
 jobs:
   get_pr_details:
-    # Guardrails to only ever run if PR recording workflow was indeed
-    # run in a PR event and ran successfully
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     uses: ./.github/workflows/reusable_export_pr_details.yml
     with:
@@ -17,22 +15,22 @@ jobs:
       workflow_origin: ${{ github.event.repository.full_name }}
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}
-  label_pr:
+  check_related_issue:
     needs: get_pr_details
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-      - name: "Label PR based on title"
+      - uses: actions/checkout@v3
+      - name: "Debug workflow_run event"
+        run: echo "${{ github }}"
+      - name: "Ensure related issue is present"
         uses: actions/github-script@v6
         env:
+          PR_BODY: ${{ needs.get_pr_details.outputs.prBody }}
           PR_NUMBER: ${{ needs.get_pr_details.outputs.prNumber }}
-          PR_TITLE: ${{ needs.get_pr_details.outputs.prTitle }}
+          PR_ACTION: ${{ needs.get_pr_details.outputs.prAction }}
+          PR_AUTHOR: ${{ needs.get_pr_details.outputs.prAuthor }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          # This safely runs in our base repo, not on fork
-          # thus allowing us to provide a write access token to label based on PR title
-          # and label PR based on semantic title accordingly
           script: |
-            const script = require('.github/scripts/label_pr_based_on_title.js')
+            const script = require('.github/scripts/label_missing_related_issue.js')
             await script({github, context, core})

--- a/.github/workflows/record_pr.yml
+++ b/.github/workflows/record_pr.yml
@@ -1,21 +1,22 @@
-name: Record PR number
+name: Record PR details
 
 on:
   pull_request:
-    types: [opened, edited]
+    types: [opened, edited, closed]
 
 jobs:
-  record:
+  record_pr:
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v3
-      - name: Save PR number
-        run: |
-          mkdir -p ./pr
-          echo ${{ github.event.number }} > ./pr/number
-          echo "${{ github.event.pull_request.title }}" > ./pr/title
+      - name: "Extract PR details"
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const script = require('.github/scripts/save_pr_details.js')
+            await script({github, context, core})
       - uses: actions/upload-artifact@v3
         with:
           name: pr
-          path: pr/
+          path: pr.txt

--- a/.github/workflows/reusable_export_pr_details.yml
+++ b/.github/workflows/reusable_export_pr_details.yml
@@ -36,7 +36,7 @@ on:
 jobs:
   export_pr_details:
     # see https://github.com/awslabs/aws-lambda-powertools-python/issues/1349
-    if: inputs.workflow_origin == 'awslabs/aws-lambda-powertools-python'
+    if: inputs.workflow_origin == 'awslabs/aws-lambda-powertools-typescript'
     runs-on: ubuntu-latest
     env:
       FILENAME: pr.txt

--- a/.github/workflows/reusable_export_pr_details.yml
+++ b/.github/workflows/reusable_export_pr_details.yml
@@ -1,0 +1,86 @@
+name: Export previously recorded PR
+
+on:
+  workflow_call:
+    inputs:
+      record_pr_workflow_id:
+        required: true
+        type: number
+      workflow_origin: # see https://github.com/awslabs/aws-lambda-powertools-python/issues/1349
+        required: true
+        type: string
+    secrets:
+      token:
+        required: true
+    # Map the workflow outputs to job outputs
+    outputs:
+      prNumber:
+        description: "PR Number"
+        value: ${{ jobs.export_pr_details.outputs.prNumber }}
+      prTitle:
+        description: "PR Title"
+        value: ${{ jobs.export_pr_details.outputs.prTitle }}
+      prBody:
+        description: "PR Body as string"
+        value: ${{ jobs.export_pr_details.outputs.prBody }}
+      prAuthor:
+        description: "PR author username"
+        value: ${{ jobs.export_pr_details.outputs.prAuthor }}
+      prAction:
+        description: "PR event action"
+        value: ${{ jobs.export_pr_details.outputs.prAction }}
+      prIsMerged:
+        description: "Whether PR is merged"
+        value: ${{ jobs.export_pr_details.outputs.prIsMerged }}
+
+jobs:
+  export_pr_details:
+    # see https://github.com/awslabs/aws-lambda-powertools-python/issues/1349
+    if: inputs.workflow_origin == 'awslabs/aws-lambda-powertools-python'
+    runs-on: ubuntu-latest
+    env:
+      FILENAME: pr.txt
+    # Map the job outputs to step outputs
+    outputs:
+      prNumber: ${{ steps.prNumber.outputs.prNumber }}
+      prTitle: ${{ steps.prTitle.outputs.prTitle }}
+      prBody: ${{ steps.prBody.outputs.prBody }}
+      prAuthor: ${{ steps.prAuthor.outputs.prAuthor }}
+      prAction: ${{ steps.prAction.outputs.prAction }}
+      prIsMerged: ${{ steps.prIsMerged.outputs.prIsMerged }}
+    steps:
+      - name: Checkout repository # in case caller workflow doesn't checkout thus failing with file not found
+        uses: actions/checkout@v3
+      - name: "Download previously saved PR"
+        uses: actions/github-script@v6
+        env:
+          WORKFLOW_ID: ${{ inputs.record_pr_workflow_id }}
+        # For security, we only download artifacts tied to the successful PR recording workflow
+        with:
+          github-token: ${{ secrets.token }}
+          script: |
+            const script = require('.github/scripts/download_pr_artifact.js')
+            await script({github, context, core})
+      # NodeJS standard library doesn't provide ZIP capabilities; use system `unzip` command instead
+      - name: "Unzip PR artifact"
+        run: unzip pr.zip
+      # NOTE: We need separate steps for each mapped output and respective IDs
+      # otherwise the parent caller won't see them regardless on how outputs are set.
+      - name: "Export Pull Request Number"
+        id: prNumber
+        run: echo ::set-output name=prNumber::$(jq -c '.number' ${FILENAME})
+      - name: "Export Pull Request Title"
+        id: prTitle
+        run: echo ::set-output name=prTitle::$(jq -c '.pull_request.title' ${FILENAME})
+      - name: "Export Pull Request Body"
+        id: prBody
+        run: echo ::set-output name=prBody::$(jq -c '.pull_request.body' ${FILENAME})
+      - name: "Export Pull Request Author"
+        id: prAuthor
+        run: echo ::set-output name=prAuthor::$(jq -c '.pull_request.user.login' ${FILENAME})
+      - name: "Export Pull Request Action"
+        id: prAction
+        run: echo ::set-output name=prAction::$(jq -c '.action' ${FILENAME})
+      - name: "Export Pull Request Merged status"
+        id: prIsMerged
+        run: echo ::set-output name=prIsMerged::$(jq -c '.pull_request.merged' ${FILENAME})

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,8 @@
 {
   "packages": [
-    "packages/*",
+    "packages/tracer",
+    "packages/logger",
+    "packages/metrics",
     "examples/cdk",
     "examples/sam"
   ],

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,6 @@
 {
   "packages": [
+    "packages/commons",
     "packages/tracer",
     "packages/logger",
     "packages/metrics",


### PR DESCRIPTION
## Description of your changes

### Scripts

This PR introduces a series of JS scripts under `.github/scripts/*`. These scripts have been lifted from the Powertools for Python repo.

### Workflows

This PR introduces also a few workflows and updates others related to PRs, namely:
- One single workflow called `record_pr.yml` is now run as a result of an opened, modified (description/title only - not code), closed PR. This workflow runs and generates an artefact containing the PR details (i.e. title, number, etc.). This artefact is then used by the subsequent workflows.
- A second workflow called `label_pr_on_title.yml` is run as result of the successful execution of the `record_pr.yml`. It uses the generated artefact to obtain the details of the PR (via `reusable_export_pr_details.yml`) and it labels the PR based on the title. Given that this workflow must have somewhat privileged permissions to label the PR, the new _invocation_ mechanism makes it so that the workflow runs only when called on the original repo ([see details here](https://github.com/awslabs/aws-lambda-powertools-python/pull/1350))
- A third workflow called `on_opened_pr.yml` is run as result of the successful execution of the `record_pr.yml`. It uses the generated artefact to obtain the details of the PR (via `reusable_export_pr_details.yml`) and it tries to find an Issue number in the PR description. PRs that don't have a related issue are then labeled as blocked. This is to avoid having PRs that come without a previous discussion - like detailed in the `CONTRIBUTING` guidelines.
- The fourth workflow, called `on-merge-to-main.yml` already existed and it has now been edited to incorporate a mechanism that labels an issue related to a PR as `pending-release`.

See diagram below for visual representation of the workflows:

```mermaid
flowchart TB
    A[PR Opened / edited / closed - record_pr.yml runs] -->|Extract PR details - scripts/save_pr_details.js| B[Artifact pr.txt is generated]
    B -->|Label PR| C[label_pr_on_title.yml]
    C -->|Get PR details/artifact - reusable_export_pr_details.yml| D[Adds label to PR if any relevant - label_pr_based_on_title.js]
    B -->|Find related Issue| E[on_opened_pr.yml]
    E -->|Get PR details/artifact - reusable_export_pr_details.yml| F[Adds label only to new PRs if no linked issue is present in PR body - label_missing_related_issue.js]
    B -->|Label related Issue| G[on-merge-to-main.yml]
    G -->|Get PR details/artifact - reusable_export_pr_details.yml| H[Adds label to linked issue when PR is merged - label_related_issue.js]
```

### Codeowners

The file now points to the team `@awslabs/aws-lambda-powertools-typescript` that also governs access to the repo.

For additional context, the version of the file present on `main` had an invalid/outdated format as well as a `#todo` item with a reminder to change it.

### Lerna

The repo has a file called `lerna.json`, this file is used to specify which packages/folders should be managed by `lerna`. Previous to this PR all folders under `packages/*` were included, this PR makes it explicit which folders should be included.

This will come in handy once we start merging PRs that include unreleased utilities or utilities that are not ready to be included as a part of the CI.

### PR Template

The section titled `Related issues, RFCs` has been updated to now point to a single issue with the following format:

```md
<!--- Add here the number to the Github Issue or RFC that is related to this PR. -->
<!-- **Issue number:** #123 -->
**Issue number:** 
```

This change is aimed at helping the workflow defined above to find the related issue.

### How to verify this change

See newly introduced workflows run on PR created/updated/closed

### Related issues, RFCs

https://github.com/awslabs/aws-lambda-powertools-python/pull/1350
https://github.com/awslabs/aws-lambda-powertools-python/pull/1352

### PR status

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [x] My changes generate *no new warnings*
- [x] The *code coverage* hasn't decreased
- [x] New and existing *unit tests pass* locally and in Github Actions
- [x] Any *dependent changes have been merged and published* in downstream module
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

N/A

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
