### PR TITLE
fix: wrong scope in captureMethod

### DIFF
--- a/packages/tracer/src/Tracer.ts
+++ b/packages/tracer/src/Tracer.ts
@@ -424,7 +424,7 @@ class Tracer extends Utility implements TracerInterface {
         return this.provider.captureAsyncFunc(`### ${originalMethod.name}`, async subsegment => {          
           let result;
           try {
-            result = await originalMethod.apply(this, [...args]);
+            result = await originalMethod.apply(target, [...args]);
             this.addResponseAsMetadata(result, originalMethod.name);
           } catch (error) {
             this.addErrorAsMetadata(error as Error); 

--- a/packages/tracer/src/Tracer.ts
+++ b/packages/tracer/src/Tracer.ts
@@ -415,20 +415,20 @@ class Tracer extends Utility implements TracerInterface {
       // The descriptor.value is the method this decorator decorates, it cannot be undefined.
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const originalMethod = descriptor.value!;
-
-      descriptor.value = ((...args: unknown[]) => {
+      
+      descriptor.value = (...args: unknown[]) => {
         if (!this.isTracingEnabled()) {
           return originalMethod.apply(target, [...args]);
         }
 
-        return this.provider.captureAsyncFunc(`### ${originalMethod.name}`, async subsegment => {
-
-          let result: unknown;
+        return this.provider.captureAsyncFunc(`### ${originalMethod.name}`, async subsegment => {          
+          let result;
           try {
-            result = await originalMethod.apply(target, [...args]);
+            result = await originalMethod.apply(this, [...args]);
             this.addResponseAsMetadata(result, originalMethod.name);
           } catch (error) {
-            this.addErrorAsMetadata(error as Error);
+            this.addErrorAsMetadata(error as Error); 
+            
             throw error;
           } finally {
             subsegment?.close();
@@ -437,7 +437,7 @@ class Tracer extends Utility implements TracerInterface {
           
           return result;
         });
-      }) ;
+      };
 
       return descriptor;
     };

--- a/packages/tracer/src/Tracer.ts
+++ b/packages/tracer/src/Tracer.ts
@@ -415,20 +415,20 @@ class Tracer extends Utility implements TracerInterface {
       // The descriptor.value is the method this decorator decorates, it cannot be undefined.
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const originalMethod = descriptor.value!;
-      
-      descriptor.value = (...args: unknown[]) => {
+
+      descriptor.value = ((...args: unknown[]) => {
         if (!this.isTracingEnabled()) {
-          return originalMethod.apply(target, [...args]);
+          return originalMethod.apply(target, [ ...args ]);
         }
 
-        return this.provider.captureAsyncFunc(`### ${originalMethod.name}`, async subsegment => {          
-          let result;
+        return this.provider.captureAsyncFunc(`### ${originalMethod.name}`, async subsegment => {
+
+          let result: unknown;
           try {
-            result = await originalMethod.apply(target, [...args]);
+            result = await originalMethod.apply(target,  [ ...args ]);
             this.addResponseAsMetadata(result, originalMethod.name);
           } catch (error) {
-            this.addErrorAsMetadata(error as Error); 
-            
+            this.addErrorAsMetadata(error as Error);
             throw error;
           } finally {
             subsegment?.close();
@@ -437,7 +437,7 @@ class Tracer extends Utility implements TracerInterface {
           
           return result;
         });
-      };
+      }) ;
 
       return descriptor;
     };

--- a/packages/tracer/src/Tracer.ts
+++ b/packages/tracer/src/Tracer.ts
@@ -418,14 +418,14 @@ class Tracer extends Utility implements TracerInterface {
 
       descriptor.value = ((...args: unknown[]) => {
         if (!this.isTracingEnabled()) {
-          return originalMethod.apply(target, [ ...args ]);
+          return originalMethod.apply(target, [...args]);
         }
 
         return this.provider.captureAsyncFunc(`### ${originalMethod.name}`, async subsegment => {
 
           let result: unknown;
           try {
-            result = await originalMethod.apply(target,  [ ...args ]);
+            result = await originalMethod.apply(target, [...args]);
             this.addResponseAsMetadata(result, originalMethod.name);
           } catch (error) {
             this.addErrorAsMetadata(error as Error);

--- a/packages/tracer/tests/unit/Tracer.test.ts
+++ b/packages/tracer/tests/unit/Tracer.test.ts
@@ -984,7 +984,7 @@ describe('Class: Tracer', () => {
 
       class Lambda implements LambdaInterface {
 
-        public otherMethod(){
+        public otherMethod(): string {
           return 'otherMethod';
         }
 
@@ -999,7 +999,7 @@ describe('Class: Tracer', () => {
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
         public async handler<TEvent, TResult>(_event: TEvent, _context: Context, _callback: Callback<TResult>): void | Promise<TResult> {
-          return <TResult>(await this.dummyMethod() as unknown)
+          return <TResult>(await this.dummyMethod() as unknown);
         }
 
       }

--- a/packages/tracer/tests/unit/Tracer.test.ts
+++ b/packages/tracer/tests/unit/Tracer.test.ts
@@ -984,10 +984,6 @@ describe('Class: Tracer', () => {
 
       class Lambda implements LambdaInterface {
 
-        public otherMethod(): string {
-          return 'otherMethod';
-        }
-
         @tracer.captureMethod()
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
@@ -1000,6 +996,10 @@ describe('Class: Tracer', () => {
         // @ts-ignore
         public async handler<TEvent, TResult>(_event: TEvent, _context: Context, _callback: Callback<TResult>): void | Promise<TResult> {
           return <TResult>(await this.dummyMethod() as unknown);
+        }
+
+        public otherMethod(): string {
+          return 'otherMethod';
         }
 
       }

--- a/packages/tracer/tests/unit/Tracer.test.ts
+++ b/packages/tracer/tests/unit/Tracer.test.ts
@@ -973,6 +973,42 @@ describe('Class: Tracer', () => {
 
     });
 
+    test('when used as decorator and when calling other methods/props in the class they are called in the orginal scope', async () => {
+
+      // Prepare
+      const tracer: Tracer = new Tracer();
+      const newSubsegment: Segment | Subsegment | undefined = new Subsegment('### dummyMethod');
+      jest.spyOn(tracer.provider, 'getSegment')
+        .mockImplementation(() => newSubsegment);
+      setContextMissingStrategy(() => null);
+
+      class Lambda implements LambdaInterface {
+
+        public otherMethod(){
+          return 'otherMethod';
+        }
+
+        @tracer.captureMethod()
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        public async dummyMethod(): Promise<string> {
+          return `otherMethod:${this.otherMethod()}`;
+        }
+
+        @tracer.captureLambdaHandler()
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        public async handler<TEvent, TResult>(_event: TEvent, _context: Context, _callback: Callback<TResult>): void | Promise<TResult> {
+          return <TResult>(await this.dummyMethod() as unknown)
+        }
+
+      }
+
+      // Act / Assess
+      expect(await (new Lambda()).handler({}, context, () => console.log('Lambda invoked!'))).toEqual('otherMethod:otherMethod');
+
+    });
+
   });
 
   describe('Method: captureAWS', () => {


### PR DESCRIPTION
using the captureMethod decorator the "this" is no longer the original obj so changing to the target fixes this

<!--- 1. Make sure you follow our Contributing Guidelines: https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/CONTRIBUTING.md -->
<!--- 2. Please follow the template, and do not remove any section in the template. If something is not applicable leave it empty, but leave it in the PR. -->

## Description of your changes

change the binding of the decorated method back to the target so the below code will work:

```
export class Lambda implements LambdaInterface {
   @tracer.captureMethod()
   myMethod(){

      //other method is undefined as "this" is no longer the Lambda class
      this.otherMethod()
   }

   otherMethod(){}
}
```

<!--- Include here a summary of the change. -->

<!--- Please include also relevant motivation and context. -->

<!--- List any dependencies that are required for this change. -->

<!--- If this PR is part of a sequence of related PRs or TODOs, list the high level TODO items. -->

### How to verify this change

<!--- Add any applicable config, projects, screenshots or other resources -->
<!--- that can help us verify your changes. -->

<!--- Examples: -->
<!--- Screenshots, cloud configuration, anything helping us evaluate better. -->

### Related issues, RFCs

<!--- Add here the link to one or more Github Issues or RFCs that are related to this PR. -->
#1028 

### PR status

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [x] I have made corresponding changes to the *documentation*
- [x] I have made corresponding changes to the *examples*
- [x] My changes generate *no new warnings*
- [x] The *code coverage* hasn't decreased
- [x] I have *added tests* that prove my change is effective and works
- [ ] New and existing *unit tests pass* locally and in Github Actions
- [x] Any *dependent changes have been merged and published* in downstream module
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

- [ ] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
