### PR TITLE
chore(build): broke up pr workflow & measure package size

### DIFF
--- a/.github/workflows/measure-packages-size.yml
+++ b/.github/workflows/measure-packages-size.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           ref: ${{ steps.extract_PR_details.outputs.headSHA }}
       - name: Packages size report
-        uses: flochaz/pkg-size-action@v1.2.15
+        uses: flochaz/pkg-size-action@v2.0.0
         with:
           build-command: mkdir dist && npm run package -w packages/logger -w packages/tracer -w packages/metrics -w packages/commons && npm run package-bundle -w packages/logger -w packages/tracer -w packages/metrics -w packages/commons && bash -c "mv ./packages/*/dist/* dist/" && ls dist
           dist-directory: /dist

--- a/.github/workflows/measure-packages-size.yml
+++ b/.github/workflows/measure-packages-size.yml
@@ -14,12 +14,26 @@ jobs:
       NODE_ENV: dev
       PR_NUMBER: ${{ inputs.prNumber }}
     steps:
+      # Since we are manually triggering the workflow the previous checkout has the main branch. In order to checkout the branch/code of the PR
+      # we need first to use the PR number to retrieve the PR SHA number. This means we need three steps to: checkout the repo,
+      # run a custom script to get the SHA, and then finally checkout the PR branch
       - name: Checkout Repo
         uses: actions/checkout@v3
+      - name: Extract PR details
+        id: extract_PR_details
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const script = require('.github/scripts/get_pr_info.js');
+            await script({github, context, core});
+      - name: Checkout PR code
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ steps.extract_PR_details.outputs.headSHA }}
       - name: Packages size report
         uses: flochaz/pkg-size-action@v1.2.15
         with:
-          build-command: mkdir dist && npm run package -w packages/logger -w packages/tracer -w packages/metrics && npm run package-bundle -w packages/logger -w packages/tracer -w packages/metrics && bash -c "mv ./packages/*/dist/* dist/" && ls dist
+          build-command: mkdir dist && npm run package -w packages/logger -w packages/tracer -w packages/metrics -w packages/commons && npm run package-bundle -w packages/logger -w packages/tracer -w packages/metrics -w packages/commons && bash -c "mv ./packages/*/dist/* dist/" && ls dist
           dist-directory: /dist
           pr-number: ${{ inputs.prNumber }}
         env:

--- a/.github/workflows/measure-packages-size.yml
+++ b/.github/workflows/measure-packages-size.yml
@@ -1,0 +1,26 @@
+name: Measure packages size
+
+on:
+  workflow_dispatch:
+    inputs:
+      prNumber:
+        description: "PR Number"
+        required: true
+
+jobs:
+  measure-utils-sizes:
+    runs-on: ubuntu-latest
+    env:
+      NODE_ENV: dev
+      PR_NUMBER: ${{ inputs.prNumber }}
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+      - name: Packages size report
+        uses: flochaz/pkg-size-action@v1.2.15
+        with:
+          build-command: mkdir dist && npm run package -w packages/logger -w packages/tracer -w packages/metrics && npm run package-bundle -w packages/logger -w packages/tracer -w packages/metrics && bash -c "mv ./packages/*/dist/* dist/" && ls dist
+          dist-directory: /dist
+          pr-number: ${{ inputs.prNumber }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr_lint_and_test.yml
+++ b/.github/workflows/pr_lint_and_test.yml
@@ -25,13 +25,11 @@ jobs:
       - name: Cache node modules
         id: cache-node-modules
         uses: actions/cache@v3
-        env:
-          cache-name: cache-node-modules
         with:
           path: "./node_modules"
           # Use the combo between node version, name, and SHA-256 hash of the lock file as cache key so that
           # if one of them changes the cache is invalidated/discarded
-          key: ${{ matrix.version }}-build-${{ env.cache-name }}-${{ hashFiles('./package-lock.json') }}
+          key: ${{ matrix.version }}-cache-utils-node-modules-${{ hashFiles('./package-lock.json') }}
       - name: Install dependencies
         # We can skip the install if there was a cache hit
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
@@ -71,15 +69,13 @@ jobs:
       - name: Cache node modules
         id: cache-node-modules
         uses: actions/cache@v3
-        env:
-          cache-name: cache-node-modules
         with:
           path: "./examples/${{ matrix.example }}/node_modules"
           # Use the combo between example, name, and SHA-256 hash of all example lock files as cache key.
           # It's not possible to use the ${{ matrix.example }} key in the hashFiles fn so
           # if any of the lock files (wich should be fairly similar anyway) changes the cache is
           # invalidated/discarded for all.
-          key: ${{ matrix.example }}-build-${{ env.cache-name }}-${{ hashFiles('./examples/*/package-lock.json') }}
+          key: ${{ matrix.example }}-cache-examples-node-modules-${{ hashFiles('./examples/*/package-lock.json') }}
       - name: Install dependencies
         run: npm ci
       - name: Run tests

--- a/.github/workflows/pr_lint_and_test.yml
+++ b/.github/workflows/pr_lint_and_test.yml
@@ -1,9 +1,10 @@
-name: pr-lint-and-test
+name: On PR code update
+
 on:
   pull_request:
     types: [opened, synchronize]
 jobs:
-  on_push:
+  run-unit-tests-on-utils:
     runs-on: ubuntu-latest
     env:
       NODE_ENV: dev
@@ -12,63 +13,40 @@ jobs:
         version: [12, 14, 16]
       fail-fast: false
     steps:
-      - uses: actions/checkout@v3
-      - name: "Use NodeJS"
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Setup NodeJS
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.version }}
-      - name: Install npm@8.x
+      - name: Setup npm
         run: npm i -g npm@next-8
-      - name: "Setup npm"
-        run: |
-          npm set "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}"
-      - name: Install monorepo packages
-        # This installs all the dependencies of ./packages/*
+      - name: Install dependencies
         # See https://github.com/npm/cli/issues/4475 to see why --foreground-scripts
         run: npm ci --foreground-scripts
-      - name: Install CDK example packages
-        # Since we are not managing the CDK examples with npm workspaces we install
-        # the dependencies in a separate step
-        working-directory: ./examples/cdk
-        run: npm ci
-      - name: "Setup SAM"
-        # We use an ad-hoc action so we can specify the SAM CLI version
-        uses: aws-actions/setup-sam@v2
+      - name: Lint
+        run: npm run lint -ws
+      - name: Run unit tests
+        run: npm t -ws
+  check-examples:
+    runs-on: ubuntu-latest
+    env:
+      NODE_ENV: dev
+    strategy:
+      matrix:
+        example: ["sam", "cdk"]
+      fail-fast: false
+    defaults:
+      run:
+        working-directory: examples/${{ matrix.example }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Setup NodeJS
+        uses: actions/setup-node@v3
         with:
-          version: 1.49.0
-      - name: Install SAM example packages
-        # Since we are not managing the SAM examples with npm workspaces we install
-        # the dependencies in a separate step
-        working-directory: ./examples/sam
+          node-version: 16
+      - name: Install dependencies
         run: npm ci
-      - name: Run lint
-        run: npm run lerna-lint
       - name: Run tests
-        run: npm run lerna-test
-      - name: Collate Coverage Reports
-        if: ${{ github.actor != 'dependabot[bot]' }}
-        run: |
-          for d in ./packages/*/ ; do
-              mkdir -p coverage
-              if [[ ! -f coverage/lcov.info ]]
-              then
-                  continue
-              fi
-              filename="$d""coverage/lcov.info"
-              targetSource="SF:""$d""src"
-              sed "s|SF:src|$targetSource|g" $filename >> coverage/lcov.info
-          done
-      - name: Report Coverage
-        #Dependabot user will only have read-only perms, so don't try to report coverage
-        if: ${{ github.actor != 'dependabot[bot]' }}
-        uses: romeovs/lcov-reporter-action@v0.3.1
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          lcov-file: ./coverage/lcov.info
-      - name: Packages size report
-        uses: flochaz/pkg-size-action@v1.2.12
-        with:
-          build-command: mkdir dist && npm run lerna-package && npm run lerna-package-bundle && bash -c "mv ./packages/*/dist/* dist/" && ls dist
-          dist-directory: /dist
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: npm t

--- a/.github/workflows/pr_lint_and_test.yml
+++ b/.github/workflows/pr_lint_and_test.yml
@@ -25,9 +25,9 @@ jobs:
         # See https://github.com/npm/cli/issues/4475 to see why --foreground-scripts
         run: npm ci --foreground-scripts
       - name: Lint
-        run: npm run lint -ws
+        run: npm run lint -w packages/logger -w packages/tracer -w packages/metrics
       - name: Run unit tests
-        run: npm t -ws
+        run: npm t -w packages/logger -w packages/tracer -w packages/metrics
   check-examples:
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/pr_lint_and_test.yml
+++ b/.github/workflows/pr_lint_and_test.yml
@@ -19,11 +19,32 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.version }}
+          cache: "npm"
       - name: Setup npm
         run: npm i -g npm@next-8
+      - name: Cache node modules
+        id: cache-node-modules
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: "./node_modules"
+          # Use the combo between node version, name, and SHA-256 hash of the lock file as cache key so that
+          # if one of them changes the cache is invalidated/discarded
+          key: ${{ matrix.version }}-build-${{ env.cache-name }}-${{ hashFiles('./package-lock.json') }}
       - name: Install dependencies
+        # We can skip the install if there was a cache hit
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
         # See https://github.com/npm/cli/issues/4475 to see why --foreground-scripts
         run: npm ci --foreground-scripts
+      - name: Build packages
+        # If there's a cache hit we still need to manually build the packages
+        # this would otherwise have been done automatically as a part of the
+        # postinstall npm hook
+        if: steps.cache-node-modules.outputs.cache-hit == 'true'
+        run: |
+          npm run build -w packages/commons
+          npm run build -w packages/logger & npm run build -w packages/tracer & npm run build -w packages/metrics
       - name: Lint
         run: npm run lint -w packages/logger -w packages/tracer -w packages/metrics
       - name: Run unit tests
@@ -46,6 +67,19 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 16
+          cache: "npm"
+      - name: Cache node modules
+        id: cache-node-modules
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: "./examples/${{ matrix.example }}/node_modules"
+          # Use the combo between example, name, and SHA-256 hash of all example lock files as cache key.
+          # It's not possible to use the ${{ matrix.example }} key in the hashFiles fn so
+          # if any of the lock files (wich should be fairly similar anyway) changes the cache is
+          # invalidated/discarded for all.
+          key: ${{ matrix.example }}-build-${{ env.cache-name }}-${{ hashFiles('./examples/*/package-lock.json') }}
       - name: Install dependencies
         run: npm ci
       - name: Run tests

--- a/examples/sam/package-lock.json
+++ b/examples/sam/package-lock.json
@@ -16,6 +16,7 @@
       },
       "devDependencies": {
         "@types/aws-lambda": "^8.10.86",
+        "@types/jest": "^27.5.2",
         "@types/node": "18.0.0",
         "esbuild": "^0.14.23",
         "eslint": "^8.4.0",
@@ -1185,6 +1186,16 @@
       "dev": true,
       "dependencies": {
         "@types/istanbul-lib-report": "*"
+      }
+    },
+    "node_modules/@types/jest": {
+      "version": "27.5.2",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-27.5.2.tgz",
+      "integrity": "sha512-mpT8LJJ4CMeeahobofYWIjFo0xonRS/HfxnVEPMPFSQdGUt1uHCnoPT7Zhb+sjDU2wz0oKV0OLUR0WzrHNgfeA==",
+      "dev": true,
+      "dependencies": {
+        "jest-matcher-utils": "^27.0.0",
+        "pretty-format": "^27.0.0"
       }
     },
     "node_modules/@types/node": {
@@ -6336,6 +6347,16 @@
       "dev": true,
       "requires": {
         "@types/istanbul-lib-report": "*"
+      }
+    },
+    "@types/jest": {
+      "version": "27.5.2",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-27.5.2.tgz",
+      "integrity": "sha512-mpT8LJJ4CMeeahobofYWIjFo0xonRS/HfxnVEPMPFSQdGUt1uHCnoPT7Zhb+sjDU2wz0oKV0OLUR0WzrHNgfeA==",
+      "dev": true,
+      "requires": {
+        "jest-matcher-utils": "^27.0.0",
+        "pretty-format": "^27.0.0"
       }
     },
     "@types/node": {

--- a/examples/sam/package.json
+++ b/examples/sam/package.json
@@ -18,6 +18,7 @@
   },
   "devDependencies": {
     "@types/aws-lambda": "^8.10.86",
+    "@types/jest": "^27.5.2",
     "@types/node": "18.0.0",
     "esbuild": "^0.14.23",
     "eslint": "^8.4.0",

--- a/packages/commons/package.json
+++ b/packages/commons/package.json
@@ -19,7 +19,7 @@
     "lint": "eslint --ext .ts --fix --no-error-on-unmatched-pattern src tests",
     "format": "eslint --fix --ext .ts --fix --no-error-on-unmatched-pattern src tests",
     "package": "mkdir -p dist/ && npm pack && mv *.tgz dist/",
-    "package-bundle": "../../package-bundler.sh ${LERNA_PACKAGE_NAME}-bundle ./dist/",
+    "package-bundle": "../../package-bundler.sh commons-bundle ./dist",
     "prepare": "npm run build",
     "prepublishOnly": "npm test && npm run lint",
     "preversion": "npm run lint",

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -22,7 +22,7 @@
     "lint": "eslint --ext .ts --fix --no-error-on-unmatched-pattern src tests",
     "format": "eslint --fix --ext .ts --fix --no-error-on-unmatched-pattern src tests",
     "package": "mkdir -p dist/ && npm pack && mv *.tgz dist/",
-    "package-bundle": "../../package-bundler.sh ${LERNA_PACKAGE_NAME}-bundle ./dist/",
+    "package-bundle": "../../package-bundler.sh logger-bundle ./dist",
     "prepare": "npm run build",
     "prepublishOnly": "npm test && npm run lint",
     "preversion": "npm run lint",

--- a/packages/metrics/package.json
+++ b/packages/metrics/package.json
@@ -22,7 +22,7 @@
     "lint": "eslint --ext .ts --fix --no-error-on-unmatched-pattern src tests",
     "format": "eslint --fix --ext .ts --fix --no-error-on-unmatched-pattern src tests",
     "package": "mkdir -p dist/ && npm pack && mv *.tgz dist/",
-    "package-bundle": "../../package-bundler.sh ${LERNA_PACKAGE_NAME}-bundle ./dist/",
+    "package-bundle": "../../package-bundler.sh metrics-bundle ./dist",
     "prepare": "npm run build",
     "prepublishOnly": "npm test && npm run lint",
     "preversion": "npm run lint",

--- a/packages/tracer/package.json
+++ b/packages/tracer/package.json
@@ -27,7 +27,7 @@
     "version": "npm run format && git add -A src",
     "postversion": "git push && git push --tags",
     "package": "mkdir -p dist/ && npm pack && mv *.tgz dist/",
-    "package-bundle": "../../package-bundler.sh ${LERNA_PACKAGE_NAME}-bundle ./dist/"
+    "package-bundle": "../../package-bundler.sh tracer-bundle ./dist"
   },
   "homepage": "https://github.com/awslabs/aws-lambda-powertools-typescript/tree/master/packages/tracer#readme",
   "license": "MIT-0",


### PR DESCRIPTION
## Description of your changes

This PR proposes changes to the workflow that is run every time a new PR is created & synchronised (aka new commit is pushed). It also spins off in a separate file the workflow that measures the size of the packages as well as changing is trigger from even based to on-demand.

### On PR code update

The workflow that runs every time new code is added to a PR was running completely in sequential mode before this PR, aside from the matrix feature that was used to select the runtime. I have applied the same pattern also to the examples and break up the two sections in two different jobs that can now run in parallel:
![image](https://user-images.githubusercontent.com/7353869/181814522-2e6ae9ed-95dd-4314-875b-3ba785871f2a.png)

I also have removed completely all the `lerna`-related commands in favor of the `npm workspaces` related ones. This allows us to select the packages we want to run the commands in. 

Initially I used a more terse version:
```sh
npm run lint -ws
```
but then I moved to a slightly longer, but more explicit one, that will allow us to exclude packages that are work in progress until they are ready, while still being part of the workspace:
```sh
npm run lint -w packages/logger -w packages/tracer -w packages/metrics
```

Each job is also now caching the content of the `node_modules` folders (both main and ones in `examples/*`) between different executions. The cache uses a combination of environment variables, node version, and hash of the `package-lock.json` as key so that if environment, version, or dependencies change the cache is rebuilt.

Here's an [example of cache hit](https://github.com/dreamorosi/aws-lambda-powertools-typescript/actions/runs/2770252600).

#### The current time for all the checks to run is now ~2.5 minutes when all caches are hit 💨 🥵 ⚡  (around ~3min when no cache)

### Measure packages size

This action was previously running after the one described in the section above. This meant each new commit was causing the action to run and leave a comment. After several weeks some of us (me included) have felt like this was generating a bit too much noise in the comments section.

This PR moves the action in its own workflow and allows maintainers to run it on demand by specifying a PR number. The action will use the PR number to get the info related to `head` and `base` and then, after having computed the changes and sizes, it will leave a comment only when manually triggered.

This PR is dependant on [this other PR](https://github.com/flochaz/pkg-size-action/pull/1) made in the action's repo.

Like in the previous workflow, I have also removed the `lerna` related commands and used the `npm workspaces` ones. This has the added benefit of avoiding running unnecessary commands in the `examples/*` folders.

![Screenshot 2022-07-29 at 17 06 33](https://user-images.githubusercontent.com/7353869/181814655-547ba242-5e45-4d3a-9ffd-1fb01773ea50.png)

Finally, this new version of the action and workflow, once merged **will allow to safely run the checks also for PRs that come from external contributors**.

### Additionally, both workflows are now `lerna`-free and use `npm workspaces`  🤟

### How to verify this change

See example of the `On PR code update` workflow run in a fork here:
https://github.com/dreamorosi/aws-lambda-powertools-typescript/actions/runs/2724186137

Also see an example of the comment left on a PR opened by an external user on a fork (of a fork):
https://github.com/dreamorosi/aws-lambda-powertools-typescript/pull/3

### Related issues, RFCs

**Issue number:** #991 

### PR status

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [x] My changes generate *no new warnings*
- [x] New and existing *unit tests pass* locally and in Github Actions
- [x] Any *dependent changes have been merged and published* in downstream module
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

N/A

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
