### PR TITLE
Fix(build): e2e workflow failing

### DIFF
--- a/.github/workflows/pr_lint_and_test.yml
+++ b/.github/workflows/pr_lint_and_test.yml
@@ -95,7 +95,27 @@ jobs:
         with:
           node-version: 16
           cache: "npm"
-      - name: Cache node modules
+      - name: Cache node modules for commons
+        id: cache-node-modules
+        uses: actions/cache@v3
+        with:
+          path: "./node_modules"
+          # Use the combo between node version, name, and SHA-256 hash of the lock file as cache key so that
+          # if one of them changes the cache is invalidated/discarded
+          key: 16-cache-utils-node-modules-${{ hashFiles('./package-lock.json') }}
+      - name: Install dependencies
+        # We can skip the install if there was a cache hit
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
+        # See https://github.com/npm/cli/issues/4475 to see why --foreground-scripts
+        run: npm ci --foreground-scripts
+      - name: Build packages
+        # If there's a cache hit we still need to manually build the packages
+        # this would otherwise have been done automatically as a part of the
+        # postinstall npm hook
+        if: steps.cache-node-modules.outputs.cache-hit == 'true'
+        run: |
+          npm run build -w packages/commons
+      - name: Cache node modules for layers
         id: cache-node-modules
         uses: actions/cache@v3
         with:

--- a/.github/workflows/pr_lint_and_test.yml
+++ b/.github/workflows/pr_lint_and_test.yml
@@ -95,27 +95,7 @@ jobs:
         with:
           node-version: 16
           cache: "npm"
-      - name: Cache node modules for commons
-        id: cache-node-modules
-        uses: actions/cache@v3
-        with:
-          path: "./node_modules"
-          # Use the combo between node version, name, and SHA-256 hash of the lock file as cache key so that
-          # if one of them changes the cache is invalidated/discarded
-          key: 16-cache-utils-node-modules-${{ hashFiles('./package-lock.json') }}
-      - name: Install dependencies
-        # We can skip the install if there was a cache hit
-        if: steps.cache-node-modules.outputs.cache-hit != 'true'
-        # See https://github.com/npm/cli/issues/4475 to see why --foreground-scripts
-        run: npm ci --foreground-scripts
-      - name: Build packages
-        # If there's a cache hit we still need to manually build the packages
-        # this would otherwise have been done automatically as a part of the
-        # postinstall npm hook
-        if: steps.cache-node-modules.outputs.cache-hit == 'true'
-        run: |
-          npm run build -w packages/commons
-      - name: Cache node modules for layers
+      - name: Cache node modules
         id: cache-node-modules
         uses: actions/cache@v3
         with:

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -102,7 +102,7 @@ jobs:
           path: "./node_modules"
           # Use the combo between node version, name, and SHA-256 hash of the lock file as cache key so that
           # if one of them changes the cache is invalidated/discarded
-          key: 16-cache-utils-node-modules-${{ hashFiles('./package-lock.json') }}
+          key: ${{ matrix.version }}-cache-utils-node-modules-${{ hashFiles('./package-lock.json') }}
       - name: Install dependencies
         # We can skip the install if there was a cache hit
         if: steps.cache-node-modules.outputs.cache-hit != 'true'

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -95,6 +95,26 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN_TO_ASSUME }}
           aws-region: eu-west-1
+      - name: Cache node modules for commons
+        id: cache-node-modules
+        uses: actions/cache@v3
+        with:
+          path: "./node_modules"
+          # Use the combo between node version, name, and SHA-256 hash of the lock file as cache key so that
+          # if one of them changes the cache is invalidated/discarded
+          key: 16-cache-utils-node-modules-${{ hashFiles('./package-lock.json') }}
+      - name: Install dependencies
+        # We can skip the install if there was a cache hit
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
+        # See https://github.com/npm/cli/issues/4475 to see why --foreground-scripts
+        run: npm ci --foreground-scripts
+      - name: Build packages
+        # If there's a cache hit we still need to manually build the packages
+        # this would otherwise have been done automatically as a part of the
+        # postinstall npm hook
+        if: steps.cache-node-modules.outputs.cache-hit == 'true'
+        run: |
+          npm run build -w packages/commons
       - name: "Run layer integration tests"
         run: |
           npm ci --foreground-scripts

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -81,14 +81,14 @@ jobs:
       matrix:
         version: [12, 14, 16]
     steps:
-      - name: "Checkout"
+      - name: Checkout
         uses: actions/checkout@v3
-      - name: "Use NodeJS 14"
+      - name: Use NodeJS
         uses: actions/setup-node@v3
         with:
           # Always use version 16 as we use TypeScript target es2020
           node-version: 16
-      - name: "Install npm@8.x"
+      - name: Install npm@8.x
         run: npm i -g npm@next-8
       - name: "Configure AWS credentials"
         uses: aws-actions/configure-aws-credentials@v1.6.1

--- a/layer-publisher/tests/e2e/happy-case.test.lambda.ts
+++ b/layer-publisher/tests/e2e/happy-case.test.lambda.ts
@@ -1,7 +1,6 @@
 import { Logger } from '@aws-lambda-powertools/logger';
 import { Metrics } from '@aws-lambda-powertools/metrics';
 import { Tracer } from '@aws-lambda-powertools/tracer';
-import { Context } from 'aws-lambda';
 import fs from 'fs';
 
 const SERVICE_NAME = 'e2e-tests-layer-consumer';
@@ -9,7 +8,7 @@ const logger = new Logger({ serviceName: SERVICE_NAME, logLevel: 'DEBUG' });
 const metrics = new Metrics({ serviceName: SERVICE_NAME });
 const tracer = new Tracer({ serviceName: SERVICE_NAME });
 
-exports.handler = function (_event: never, _ctx: Context): void {
+exports.handler = function (_event: never, _ctx: unknown): void {
   // check logger lib access
   logger.injectLambdaContext();
   logger.debug('Hello World!');

--- a/layer-publisher/tests/e2e/happy-case.test.ts
+++ b/layer-publisher/tests/e2e/happy-case.test.ts
@@ -26,7 +26,7 @@ const layerStack = new LayerPublisher.LayerPublisherStack(
   {
     layerName: `e2e-tests-layer-${runtime.name.split('.')[0]}`,
     powerToolsPackageVersion: powerToolsPackageVersion,
-    ssmParameterLayerArn: '/e2e-tests-layertools-layer-arn',
+    ssmParameterLayerArn: `/e2e-tests-layertools-layer-arn-${runtime.name.split('.')[0]}`,
   }
 );
 

--- a/layer-publisher/tests/e2e/happy-case.test.ts
+++ b/layer-publisher/tests/e2e/happy-case.test.ts
@@ -70,6 +70,14 @@ const createSampleLambda = (runtime: cdk.aws_lambda.Runtime): { consumerStack: c
     handler: 'handler',
     functionName,
     runtime: runtime,
+    bundling: {
+      externalModules: [
+        '@aws-lambda-powertools/commons',
+        '@aws-lambda-powertools/logger',
+        '@aws-lambda-powertools/metrics',
+        '@aws-lambda-powertools/tracer'
+      ]
+    },
     environment: {
       POWERTOOLS_PACKAGE_VERSION: powerToolsPackageVersion,
     },


### PR DESCRIPTION
## Description of your changes

As described in #1046 there is a small bug in the newly introduced layer job that is now part (#826) of the e2e tests.

The issue was caused by the fact that the e2e tests for this part of the codebase required code in the `packages/commons` folder. The dependencies for that packages were not being installed causing the run to fail.

After fixing the issue I then found out two more issues:
- The workflow uses the matrix strategy to run the e2e tests on multiple NodeJS versions. There was a resource in the tested stack (an SSM Param) for which the name was not unique making 2/3 versions of the matrix fail automatically. I have added a suffix with the NodeJS version being tested to make the name unique.
- The workflow deploys a Lambda function that is used to test the correctness of the Lambda Layer being tested. That function imports the Powertools utilities. Since the utils are expected to be in the layer, they are not installed (`npm i`) as part of the setup process. This was however causing the `esbuild` process to fail because they were not marked as [external](https://docs.aws.amazon.com/cdk/api/v1/docs/aws-lambda-nodejs-readme.html#externals). Marking a dependency as external tells CDK & esbuild to not bundle said dependency since it's expected to be present in the Lambda environment.

This PR aims at fixing all three issues mentioned above.

### How to verify this change

See this cool badge for the e2e test results for this branch:
[![run-e2e-tests](https://github.com/awslabs/aws-lambda-powertools-typescript/actions/workflows/run-e2e-tests.yml/badge.svg?branch=fix%2Fbuild%2Fe2e_workflow)](https://github.com/awslabs/aws-lambda-powertools-typescript/actions/workflows/run-e2e-tests.yml)

### Related issues, RFCs

<!--- Add here the number to the Github Issue or RFC that is related to this PR. -->
**Issue number:** #1046 

### PR status

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [x] My changes generate *no new warnings*
- [x] The *code coverage* hasn't decreased
- [x] I have *added tests* that prove my change is effective and works
- [x] New and existing *unit tests pass* locally and in Github Actions
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

N/A

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
