### PR TITLE
fix(build): publish workflow concurrency + leftover dependencies

### DIFF
--- a/.github/workflows/on-merge-to-main.yml
+++ b/.github/workflows/on-merge-to-main.yml
@@ -21,7 +21,7 @@ jobs:
     uses: ./.github/workflows/reusable-run-unit-tests.yml
   publish:
     needs:
-      [get_pr_details, run-unit-tests, check-examples, check-layer-publisher]
+      [get_pr_details, run-unit-tests]
     uses: ./.github/workflows/reusable-publish-docs.yml
     with:
       workflow_origin: ${{ github.event.repository.full_name }}

--- a/.github/workflows/reusable-publish-docs.yml
+++ b/.github/workflows/reusable-publish-docs.yml
@@ -17,8 +17,6 @@ on:
     secrets:
       token:
         required: true
-concurrency:
-  group: on-release-publish
 
 jobs:
   publish-docs:


### PR DESCRIPTION
## Description of your changes

While working on #1053, the PR #1052 introduced a small bug that prevented the last step of the publishing process (the one for the docs) to run as it was incorrectly set as part of the same concurrency group of the workflow that was calling it.

Additionally, there was a leftover dependency from a previous iteration that prevented another workflow to complete.

Both issues are fixed, when merged this PR will close #1053.

### How to verify this change

See workflow run on merge or on release.

### Related issues, RFCs

<!--- Add here the number (i.e. #42) to the Github Issue or RFC that is related to this PR. -->
<!--- If no issue is present the PR might get blocked and not be reviewed. -->
**Issue number:** #1053 

### PR status

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [ ] I have made corresponding changes to the *documentation*
- [ ] I have made corresponding changes to the *examples*
- [x] My changes generate *no new warnings*
- [x] The *code coverage* hasn't decreased
- [ ] I have *added tests* that prove my change is effective and works
- [x] New and existing *unit tests pass* locally and in Github Actions
- [x] Any *dependent changes have been merged and published* in downstream module
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

N/A

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
