### PR TITLE
fix(tracer): use instance as `this` in capture decorators

### DIFF
--- a/docs/core/tracer.md
+++ b/docs/core/tracer.md
@@ -143,8 +143,11 @@ You can quickly start by importing the `Tracer` class, initialize it outside the
     }
      
     export const handlerClass = new Lambda();
-    export const handler = handlerClass.handler;
+    export const handler = handlerClass.handler.bind(handlerClass); // (1)
     ```
+
+    1. Binding your handler method allows your handler to access `this`.
+
 === "Manual"
 
     ```typescript hl_lines="6 8-9 12-13 19 22 26 28"
@@ -253,8 +256,11 @@ You can trace other Class methods using the `captureMethod` decorator or any arb
     }
      
     export const myFunction = new Lambda();
-    export const handler = myFunction.handler; 
+    export const handler = myFunction.handler.bind(myFunction); // (1)
     ```
+
+    1. Binding your handler method allows your handler to access `this`.
+
 === "Manual"
 
     ```typescript hl_lines="6 8-9 15 18 23 25"

--- a/packages/tracer/src/Tracer.ts
+++ b/packages/tracer/src/Tracer.ts
@@ -349,6 +349,8 @@ class Tracer extends Utility implements TracerInterface {
 
       // eslint-disable-next-line @typescript-eslint/no-this-alias
       const that = this;
+      // Use a function() {} instead of () => {} an arrow function so that we can
+      // access `myClass` as `this` in a decorated `myClass.myMethod()`.
       descriptor.value = (function (event, context, callback) {
         // We know that 'this' is a LambdaHandler because captureLambdaHandler
         // can only be applied to a LambdaHandler.
@@ -427,6 +429,8 @@ class Tracer extends Utility implements TracerInterface {
       
       // eslint-disable-next-line @typescript-eslint/no-this-alias
       const that = this;
+      // Use a function() {} instead of an () => {} arrow function so that we can
+      // access `myClass` as `this` in a decorated `myClass.myMethod()`.
       descriptor.value = function (...args: unknown[]) {
         if (!that.isTracingEnabled()) {
           return originalMethod.apply(this, [...args]);

--- a/packages/tracer/src/Tracer.ts
+++ b/packages/tracer/src/Tracer.ts
@@ -349,7 +349,7 @@ class Tracer extends Utility implements TracerInterface {
 
       // eslint-disable-next-line @typescript-eslint/no-this-alias
       const that = this;
-      // Use a function() {} instead of () => {} an arrow function so that we can
+      // Use a function() {} instead of an () => {} arrow function so that we can
       // access `myClass` as `this` in a decorated `myClass.myMethod()`.
       descriptor.value = (function (event, context, callback) {
         // We know that 'this' is a LambdaHandler because captureLambdaHandler

--- a/packages/tracer/src/Tracer.ts
+++ b/packages/tracer/src/Tracer.ts
@@ -67,7 +67,7 @@ import { Segment, Subsegment } from 'aws-xray-sdk-core';
  * }
  * 
  * export const handlerClass = new Lambda();
- * export const handler = handlerClass.handler; 
+ * export const handler = handlerClass.handler.bind(handlerClass);
  * ```
  * 
  * ### Functions usage with manual instrumentation
@@ -334,7 +334,7 @@ class Tracer extends Utility implements TracerInterface {
    * }
    * 
    * export const handlerClass = new Lambda();
-   * export const handler = handlerClass.handler; 
+   * export const handler = handlerClass.handler.bind(handlerClass);
    * ```
    * 
    * @decorator Class

--- a/packages/tracer/tests/e2e/allFeatures.decorator.test.functionCode.ts
+++ b/packages/tracer/tests/e2e/allFeatures.decorator.test.functionCode.ts
@@ -88,4 +88,4 @@ export class MyFunctionWithDecorator {
 }
 
 export const handlerClass = new MyFunctionWithDecorator();
-export const handler = handlerClass.handler;
+export const handler = handlerClass.handler.bind(handlerClass);

--- a/packages/tracer/tests/e2e/allFeatures.decorator.test.functionCode.ts
+++ b/packages/tracer/tests/e2e/allFeatures.decorator.test.functionCode.ts
@@ -36,6 +36,12 @@ const tracer = new Tracer({ serviceName: serviceName });
 const dynamoDBv3 = tracer.captureAWSv3Client(new DynamoDBClient({}));
 
 export class MyFunctionWithDecorator {  
+  private readonly returnValue: string;
+
+  public constructor() {
+    this.returnValue = customResponseValue;
+  }
+
   @tracer.captureLambdaHandler()
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
@@ -77,7 +83,7 @@ export class MyFunctionWithDecorator {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
   public myMethod(): string {
-    return customResponseValue;
+    return this.returnValue;
   }
 }
 

--- a/packages/tracer/tests/e2e/asyncHandler.decorator.test.functionCode.ts
+++ b/packages/tracer/tests/e2e/asyncHandler.decorator.test.functionCode.ts
@@ -83,4 +83,4 @@ export class MyFunctionWithDecorator {
 }
 
 export const handlerClass = new MyFunctionWithDecorator();
-export const handler = handlerClass.handler;
+export const handler = handlerClass.handler.bind(handlerClass);

--- a/packages/tracer/tests/e2e/asyncHandler.decorator.test.functionCode.ts
+++ b/packages/tracer/tests/e2e/asyncHandler.decorator.test.functionCode.ts
@@ -36,6 +36,12 @@ const tracer = new Tracer({ serviceName: serviceName });
 const dynamoDBv3 = tracer.captureAWSv3Client(new DynamoDBClient({}));
 
 export class MyFunctionWithDecorator {  
+  private readonly returnValue: string;
+
+  public constructor() {
+    this.returnValue = customResponseValue;
+  }
+
   @tracer.captureLambdaHandler()
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
@@ -72,7 +78,7 @@ export class MyFunctionWithDecorator {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
   public myMethod(): string {
-    return customResponseValue;
+    return this.returnValue;
   }
 }
 

--- a/packages/tracer/tests/unit/Tracer.test.ts
+++ b/packages/tracer/tests/unit/Tracer.test.ts
@@ -881,7 +881,8 @@ describe('Class: Tracer', () => {
 
       // Act / Assess
       const lambda = new Lambda('someValue');
-      expect(await lambda.handler({}, context, () => console.log('Lambda invoked!'))).toEqual('memberVariable:someValue');
+      const handler = lambda.handler.bind(lambda);
+      expect(await handler({}, context, () => console.log('Lambda invoked!'))).toEqual('memberVariable:someValue');
 
     });
   });

--- a/packages/tracer/tests/unit/Tracer.test.ts
+++ b/packages/tracer/tests/unit/Tracer.test.ts
@@ -854,6 +854,36 @@ describe('Class: Tracer', () => {
 
     });
 
+    test('when used as decorator and when calling the handler, it has access to member variables', async () => {
+
+      // Prepare
+      const tracer: Tracer = new Tracer();
+      const newSubsegment: Segment | Subsegment | undefined = new Subsegment('### dummyMethod');
+      jest.spyOn(tracer.provider, 'getSegment')
+        .mockImplementation(() => newSubsegment);
+      setContextMissingStrategy(() => null);
+
+      class Lambda implements LambdaInterface {
+        private readonly memberVariable: string;
+
+        public constructor(memberVariable: string) {
+          this.memberVariable = memberVariable;
+        }
+
+        @tracer.captureLambdaHandler()
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        public async handler<TEvent, TResult>(_event: TEvent, _context: Context, _callback: Callback<TResult>): void | Promise<TResult> {
+          return <TResult>(`memberVariable:${this.memberVariable}` as unknown);
+        }
+
+      }
+
+      // Act / Assess
+      const lambda = new Lambda('someValue');
+      expect(await lambda.handler({}, context, () => console.log('Lambda invoked!'))).toEqual('memberVariable:someValue');
+
+    });
   });
 
   describe('Method: captureMethod', () => {
@@ -1006,6 +1036,44 @@ describe('Class: Tracer', () => {
 
       // Act / Assess
       expect(await (new Lambda()).handler({}, context, () => console.log('Lambda invoked!'))).toEqual('otherMethod:otherMethod');
+
+    });
+
+    test('when used as decorator and when calling a method in the class, it has access to member variables', async () => {
+
+      // Prepare
+      const tracer: Tracer = new Tracer();
+      const newSubsegment: Segment | Subsegment | undefined = new Subsegment('### dummyMethod');
+      jest.spyOn(tracer.provider, 'getSegment')
+        .mockImplementation(() => newSubsegment);
+      setContextMissingStrategy(() => null);
+
+      class Lambda implements LambdaInterface {
+        private readonly memberVariable: string;
+
+        public constructor(memberVariable: string) {
+          this.memberVariable = memberVariable;
+        }
+
+        @tracer.captureMethod()
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        public async dummyMethod(): Promise<string> {
+          return `memberVariable:${this.memberVariable}`;
+        }
+
+        @tracer.captureLambdaHandler()
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        public async handler<TEvent, TResult>(_event: TEvent, _context: Context, _callback: Callback<TResult>): void | Promise<TResult> {
+          return <TResult>(await this.dummyMethod() as unknown);
+        }
+
+      }
+
+      // Act / Assess
+      const lambda = new Lambda('someValue');
+      expect(await lambda.dummyMethod()).toEqual('memberVariable:someValue');
 
     });
 


### PR DESCRIPTION
<!--- 1. Make sure you follow our Contributing Guidelines: https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/CONTRIBUTING.md -->
<!--- 2. Please follow the template, and do not remove any section in the template. If something is not applicable leave it empty, but leave it in the PR. -->

## Description of your changes

This PR fixes bugs in the `tracer.captureMethod()` and `tracer.captureLambdaHandler()` decorators. These decorators provide the class **prototype** as the `this` scope and not the **instance** of the class. While the prototype scope allows member functions to be run, it does not allow the customer to access *instance* member variables, as these instance member variables are not part of the class prototype.

Shout out to @dreamorosi for assistance in building an acceptable proof of concept in Slack.

<!--- Include here a summary of the change. -->

<!--- Please include also relevant motivation and context. -->

<!--- List any dependencies that are required for this change. -->

<!--- If this PR is part of a sequence of related PRs or TODOs, list the high level TODO items. -->

### How to verify this change

I have added two new unit tests which reproduce the bug. You may run them to verify the change.

<!--- Add any applicable config, projects, screenshots or other resources -->
<!--- that can help us verify your changes. -->

<!--- Examples: -->
<!--- Screenshots, cloud configuration, anything helping us evaluate better. -->

### Related issues, RFCs

This is related to #1028.  #1026 previously attempted to fix this and got it us part of the way to a fix.

**Issue number:** #1056

<!--- Add here the number (i.e. #42) to the Github Issue or RFC that is related to this PR. -->
<!--- If no issue is present the PR might get blocked and not be reviewed. -->

### PR status

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [ ] I have made corresponding changes to the *documentation*
- [ ] I have made corresponding changes to the *examples*
- [x] My changes generate *no new warnings*
- [x] The *code coverage* hasn't decreased
- [x] I have *added tests* that prove my change is effective and works
- [x] New and existing *unit tests pass* locally and in Github Actions
- [ ] Any *dependent changes have been merged and published* in downstream module
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

- [ ] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
