### PR TITLE
Fix(metrics): decorated class methods cannot access `this`

### DIFF
--- a/docs/core/metrics.md
+++ b/docs/core/metrics.md
@@ -277,7 +277,7 @@ You can add default dimensions to your metrics by passing them as parameters in 
         }
     }
 
-    export const handlerClass = new Lambda();
+    const handlerClass = new Lambda();
     export const handler = handlerClass.handler.bind(handlerClass); // (1)
     ```
 
@@ -375,7 +375,7 @@ The `logMetrics` decorator of the metrics utility can be used when your Lambda h
         }
     }
 
-    export const handlerClass = new Lambda();
+    const handlerClass = new Lambda();
     export const handler = handlerClass.handler.bind(handlerClass); // (1)
     ```
 
@@ -639,7 +639,7 @@ CloudWatch EMF uses the same dimensions across all your metrics. Use `singleMetr
         }
     }
 
-    export const handlerClass = new Lambda();
+    const handlerClass = new Lambda();
     export const handler = handlerClass.handler.bind(handlerClass); // (1)
     ```
 

--- a/docs/core/metrics.md
+++ b/docs/core/metrics.md
@@ -269,14 +269,19 @@ You can add default dimensions to your metrics by passing them as parameters in 
     const metrics = new Metrics({ namespace: 'serverlessAirline', serviceName: 'orders' });
     const DEFAULT_DIMENSIONS = { 'environment': 'prod', 'foo': 'bar' };
 
-    export class MyFunction implements LambdaInterface {
+    export class Lambda implements LambdaInterface {
         // Decorate your handler class method
         @metrics.logMetrics({ defaultDimensions: DEFAULT_DIMENSIONS })
         public async handler(_event: any, _context: any): Promise<void> {
             metrics.addMetric('successfulBooking', MetricUnits.Count, 1);
         }
     }
+
+    export const handlerClass = new Lambda();
+    export const handler = handlerClass.handler.bind(handlerClass); // (1)
     ```
+
+    1. Binding your handler method allows your handler to access `this` within the class methods.
 
 If you'd like to remove them at some point, you can use the `clearDefaultDimensions` method.
 
@@ -362,14 +367,19 @@ The `logMetrics` decorator of the metrics utility can be used when your Lambda h
 
     const metrics = new Metrics({ namespace: 'serverlessAirline', serviceName: 'orders' });
 
-    export class MyFunction implements LambdaInterface {
+    class Lambda implements LambdaInterface {
 
         @metrics.logMetrics()
         public async handler(_event: any, _context: any): Promise<void> {
             metrics.addMetric('successfulBooking', MetricUnits.Count, 1);
         }
     }
+
+    export const handlerClass = new Lambda();
+    export const handler = handlerClass.handler.bind(handlerClass); // (1)
     ```
+
+    1. Binding your handler method allows your handler to access `this` within the class methods.
 
 === "Example CloudWatch Logs excerpt"
 
@@ -629,6 +639,8 @@ CloudWatch EMF uses the same dimensions across all your metrics. Use `singleMetr
         }
     }
 
-    export const myFunction = new Lambda();
-    export const handler = myFunction.handler;
+    export const handlerClass = new Lambda();
+    export const handler = handlerClass.handler.bind(handlerClass); // (1)
     ```
+
+    1. Binding your handler method allows your handler to access `this` within the class methods.

--- a/packages/metrics/src/Metrics.ts
+++ b/packages/metrics/src/Metrics.ts
@@ -1,4 +1,4 @@
-import { Callback, Context } from 'aws-lambda';
+import { Callback, Context, Handler } from 'aws-lambda';
 import { Utility } from '@aws-lambda-powertools/commons';
 import { MetricsInterface } from '.';
 import { ConfigServiceInterface, EnvironmentVariablesService } from './config';
@@ -236,24 +236,28 @@ class Metrics extends Utility implements MetricsInterface {
       this.setDefaultDimensions(defaultDimensions);
     }
 
-    return (target, _propertyKey, descriptor) => {
+    return (_target, _propertyKey, descriptor) => {
       /**
        * The descriptor.value is the method this decorator decorates, it cannot be undefined.
        */ 
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const originalMethod = descriptor.value!;
 
-      descriptor.value = ( async (event: unknown, context: Context, callback: Callback): Promise<unknown> => {
-        this.functionName = context.functionName;
-        if (captureColdStartMetric) this.captureColdStartMetric();
+      // eslint-disable-next-line @typescript-eslint/no-this-alias
+      const metricsRef = this;
+      // Use a function() {} instead of an () => {} arrow function so that we can
+      // access `myClass` as `this` in a decorated `myClass.myMethod()`.
+      descriptor.value = ( async function(this: Handler, event: unknown, context: Context, callback: Callback): Promise<unknown> {
+        metricsRef.functionName = context.functionName;
+        if (captureColdStartMetric) metricsRef.captureColdStartMetric();
           
         let result: unknown;
         try {
-          result = await originalMethod.apply(target, [ event, context, callback ]);
+          result = await originalMethod.apply(this, [ event, context, callback ]);
         } catch (error) {
           throw error;
         } finally {
-          this.publishStoredMetrics();
+          metricsRef.publishStoredMetrics();
         }
           
         return result;

--- a/packages/metrics/src/Metrics.ts
+++ b/packages/metrics/src/Metrics.ts
@@ -58,7 +58,7 @@ const DEFAULT_NAMESPACE = 'default_namespace';
  *   }
  * }
  *
- * export const handlerClass = new MyFunctionWithDecorator();
+ * const handlerClass = new MyFunctionWithDecorator();
  * export const handler = handlerClass.handler.bind(handlerClass);
  * ```
  *
@@ -221,7 +221,7 @@ class Metrics extends Utility implements MetricsInterface {
    *   }
    * }
    *
-   * export const handlerClass = new MyFunctionWithDecorator();
+   * const handlerClass = new MyFunctionWithDecorator();
    * export const handler = handlerClass.handler.bind(handlerClass);
    * ```
    *

--- a/packages/metrics/src/Metrics.ts
+++ b/packages/metrics/src/Metrics.ts
@@ -59,7 +59,7 @@ const DEFAULT_NAMESPACE = 'default_namespace';
  * }
  *
  * export const handlerClass = new MyFunctionWithDecorator();
- * export const handler = handlerClass.handler;
+ * export const handler = handlerClass.handler.bind(handlerClass);
  * ```
  *
  * ### Standard function
@@ -222,7 +222,7 @@ class Metrics extends Utility implements MetricsInterface {
    * }
    *
    * export const handlerClass = new MyFunctionWithDecorator();
-   * export const handler = handlerClass.handler;
+   * export const handler = handlerClass.handler.bind(handlerClass);
    * ```
    *
    * @decorator Class

--- a/packages/metrics/tests/e2e/basicFeatures.decorator.test.functionCode.ts
+++ b/packages/metrics/tests/e2e/basicFeatures.decorator.test.functionCode.ts
@@ -1,6 +1,6 @@
 import { Metrics, MetricUnits } from '../../src';
 import { Context } from 'aws-lambda';
-import { LambdaInterface } from '../../examples/utils/lambda/LambdaInterface';
+import { LambdaInterface } from '@aws-lambda-powertools/commons';
 
 const namespace = process.env.EXPECTED_NAMESPACE ?? 'CdkExample';
 const serviceName = process.env.EXPECTED_SERVICE_NAME ?? 'MyFunctionWithStandardHandler';
@@ -19,21 +19,28 @@ const metrics = new Metrics({ namespace: namespace, serviceName: serviceName });
 class Lambda implements LambdaInterface {
 
   @metrics.logMetrics({ captureColdStartMetric: true, defaultDimensions: JSON.parse(defaultDimensions), throwOnEmptyMetrics: true })
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
   public async handler(_event: unknown, _context: Context): Promise<void> {
     metrics.addMetric(metricName, metricUnit, parseInt(metricValue));
     metrics.addDimension(
       Object.entries(JSON.parse(extraDimension))[0][0],
       Object.entries(JSON.parse(extraDimension))[0][1] as string,
     );
-  
+
+    this.dummyMethod();
+  }
+
+  private dummyMethod(): void {
     const metricWithItsOwnDimensions = metrics.singleMetric();
     metricWithItsOwnDimensions.addDimension(
       Object.entries(JSON.parse(singleMetricDimension))[0][0],
       Object.entries(JSON.parse(singleMetricDimension))[0][1] as string,
     );
+
     metricWithItsOwnDimensions.addMetric(singleMetricName, singleMetricUnit, parseInt(singleMetricValue));
   }
 }
 
 export const handlerClass = new Lambda();
-export const handler = handlerClass.handler;
+export const handler = handlerClass.handler.bind(handlerClass);

--- a/packages/metrics/tests/e2e/basicFeatures.decorator.test.functionCode.ts
+++ b/packages/metrics/tests/e2e/basicFeatures.decorator.test.functionCode.ts
@@ -42,5 +42,5 @@ class Lambda implements LambdaInterface {
   }
 }
 
-export const handlerClass = new Lambda();
+const handlerClass = new Lambda();
 export const handler = handlerClass.handler.bind(handlerClass);

--- a/packages/metrics/tests/unit/Metrics.test.ts
+++ b/packages/metrics/tests/unit/Metrics.test.ts
@@ -642,9 +642,13 @@ describe('Class: Metrics', () => {
         }
       }
       await new LambdaFunction().handler(dummyEvent, dummyContext.helloworldContext, () => console.log('Lambda invoked!'));
+      const loggedData = JSON.parse(consoleSpy.mock.calls[0][0]);
 
       // Assess
       expect(console.log).toBeCalledTimes(1);
+      expect(loggedData._aws.CloudWatchMetrics[0].Metrics.length).toEqual(1);
+      expect(loggedData._aws.CloudWatchMetrics[0].Metrics[0].Name).toEqual('test_name');
+      expect(loggedData._aws.CloudWatchMetrics[0].Metrics[0].Unit).toEqual('Seconds');
     });
   });
 

--- a/packages/metrics/tests/unit/Metrics.test.ts
+++ b/packages/metrics/tests/unit/Metrics.test.ts
@@ -619,6 +619,33 @@ describe('Class: Metrics', () => {
 
       expect(console.log).toBeCalledTimes(1);
     });
+
+    test('Using decorator should preserve `this` in decorated class', async () => {
+      // Prepare
+      const metrics = new Metrics({ namespace: 'test' });
+
+      // Act
+      class LambdaFunction implements LambdaInterface {
+        @metrics.logMetrics()
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        public handler<TEvent, TResult>(
+          _event: TEvent,
+          _context: Context,
+          _callback: Callback<TResult>,
+        ): void | Promise<TResult> {
+          this.dummyMethod();
+        }
+
+        private dummyMethod(): void {
+          metrics.addMetric('test_name', MetricUnits.Seconds, 1);
+        }
+      }
+      await new LambdaFunction().handler(dummyEvent, dummyContext.helloworldContext, () => console.log('Lambda invoked!'));
+
+      // Assess
+      expect(console.log).toBeCalledTimes(1);
+    });
   });
 
   describe('Feature: Custom Config Service', () => {


### PR DESCRIPTION
## Description of your changes

As described in #1057 the decorator implementation was affected by an issue that prevented the decorated method/class to access other class members as the value of `this` was passed incorrectly.

This PR aims at fixing the issue, creating an unit test case, making minimal changes to the function in the e2e test to verify the change, and update docstrings/docs.

A long form explanation of the issue can be found at #1055, when merged this PR will close #1057. 

### How to verify this change

See checks below the PR, also see the results of the [e2e test run](https://github.com/awslabs/aws-lambda-powertools-typescript/actions/runs/2855116627).

### Related issues, RFCs

<!--- Add here the number (i.e. #42) to the Github Issue or RFC that is related to this PR. -->
<!--- If no issue is present the PR might get blocked and not be reviewed. -->
**Issue number:** #1057 

### PR status

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [x] I have made corresponding changes to the *documentation*
- [x] I have made corresponding changes to the *examples*
- [x] My changes generate *no new warnings*
- [x] The *code coverage* hasn't decreased
- [x] I have *added tests* that prove my change is effective and works
- [x] New and existing *unit tests pass* locally and in Github Actions
- [x] Any *dependent changes have been merged and published* in downstream module
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

N/A

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
