### PR TITLE
fix(logger): decorated class methods cannot access `this`

### DIFF
--- a/docs/core/logger.md
+++ b/docs/core/logger.md
@@ -155,7 +155,7 @@ Key | Example
 
     }
 
-    export const myFunction = new Lambda();
+    const myFunction = new Lambda();
     export const handler = myFunction.handler.bind(myFunction); // (1)
     ```
 
@@ -236,7 +236,7 @@ This is disabled by default to prevent sensitive info being logged
 
     }
 
-    export const myFunction = new Lambda();
+    const myFunction = new Lambda();
     export const handler = myFunction.handler.bind(myFunction); // (1)
     ```
 
@@ -403,7 +403,7 @@ If you want to make sure that persistent attributes added **inside the handler f
 
     }
 
-    export const myFunction = new Lambda();
+    const myFunction = new Lambda();
     export const handler = myFunction.handler.bind(myFunction); // (1)
     ```
 

--- a/docs/core/logger.md
+++ b/docs/core/logger.md
@@ -156,8 +156,11 @@ Key | Example
     }
 
     export const myFunction = new Lambda();
-    export const handler = myFunction.handler;
+    export const handler = myFunction.handler.bind(myFunction); // (1)
     ```
+
+    1. Binding your handler method allows your handler to access `this` within the class methods.
+
 === "Manual"
 
     ```typescript hl_lines="7"
@@ -234,8 +237,10 @@ This is disabled by default to prevent sensitive info being logged
     }
 
     export const myFunction = new Lambda();
-    export const handler = myFunction.handler;
+    export const handler = myFunction.handler.bind(myFunction); // (1)
     ```
+
+    1. Binding your handler method allows your handler to access `this` within the class methods.
 
 ### Appending persistent additional log keys and values
 
@@ -399,8 +404,10 @@ If you want to make sure that persistent attributes added **inside the handler f
     }
 
     export const myFunction = new Lambda();
-    export const handler = myFunction.handler;
+    export const handler = myFunction.handler.bind(myFunction); // (1)
     ```
+
+    1. Binding your handler method allows your handler to access `this` within the class methods.
 
 In each case, the printed log will look like this:
 

--- a/packages/logger/src/Logger.ts
+++ b/packages/logger/src/Logger.ts
@@ -99,8 +99,8 @@ import type {
  *     }
  * }
  *
- * export const myFunction = new Lambda();
- * export const handler = myFunction.handler;
+ * export const handlerClass = new Lambda();
+ * export const handler = handlerClass.handler.bind(handlerClass);
  * ```
  *
  * @class

--- a/packages/logger/src/Logger.ts
+++ b/packages/logger/src/Logger.ts
@@ -99,7 +99,7 @@ import type {
  *     }
  * }
  *
- * export const handlerClass = new Lambda();
+ * const handlerClass = new Lambda();
  * export const handler = handlerClass.handler.bind(handlerClass);
  * ```
  *

--- a/packages/logger/src/Logger.ts
+++ b/packages/logger/src/Logger.ts
@@ -279,7 +279,6 @@ class Logger extends Utility implements ClassThatLogs {
       /**
        * The descriptor.value is the method this decorator decorates, it cannot be undefined.
        */
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const originalMethod = descriptor.value;
 
       // eslint-disable-next-line @typescript-eslint/no-this-alias
@@ -298,7 +297,7 @@ class Logger extends Utility implements ClassThatLogs {
         /* eslint-disable  @typescript-eslint/no-non-null-assertion */
         let result: unknown;
         try {
-          result = originalMethod!.apply(target, [ event, context, callback ]);
+          result = originalMethod!.apply(this, [ event, context, callback ]);
         } catch (error) {
           throw error;
         } finally {

--- a/packages/logger/tests/e2e/sampleRate.decorator.test.FunctionCode.ts
+++ b/packages/logger/tests/e2e/sampleRate.decorator.test.FunctionCode.ts
@@ -2,27 +2,39 @@ import { Logger } from '../../src';
 import { APIGatewayProxyEvent, Context } from 'aws-lambda';
 import { LambdaInterface } from '@aws-lambda-powertools/commons';
 
-const SAMPLE_RATE = parseFloat(process.env.SAMPLE_RATE);
-const LOG_MSG = process.env.LOG_MSG;
+const SAMPLE_RATE = parseFloat(process.env.SAMPLE_RATE || '0.1');
+const LOG_MSG = process.env.LOG_MSG || 'Hello World';
 
 const logger = new Logger({
   sampleRateValue: SAMPLE_RATE,
 });
 
 class Lambda implements LambdaInterface {
+  private readonly logMsg: string;
+
+  public constructor() {
+    this.logMsg = LOG_MSG;
+  }
+
   // Decorate your handler class method
   @logger.injectLambdaContext()
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
   public async handler(event: APIGatewayProxyEvent, context: Context): Promise<{requestId: string}> {
-    logger.debug(LOG_MSG);
-    logger.info(LOG_MSG);
-    logger.warn(LOG_MSG);
-    logger.error(LOG_MSG);
-
+    this.dummyMethod();
+    
     return {
       requestId: context.awsRequestId,
     };
   }
+
+  private dummyMethod() : void {
+    logger.debug(this.logMsg);
+    logger.info(this.logMsg);
+    logger.warn(this.logMsg);
+    logger.error(this.logMsg);
+  }
 }
 
 export const myFunction = new Lambda();
-export const handler = myFunction.handler;
+export const handler = myFunction.handler.bind(myFunction);

--- a/packages/logger/tests/e2e/sampleRate.decorator.test.FunctionCode.ts
+++ b/packages/logger/tests/e2e/sampleRate.decorator.test.FunctionCode.ts
@@ -21,14 +21,14 @@ class Lambda implements LambdaInterface {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
   public async handler(event: APIGatewayProxyEvent, context: Context): Promise<{requestId: string}> {
-    this.dummyMethod();
+    this.printLogInAllLevels();
     
     return {
       requestId: context.awsRequestId,
     };
   }
 
-  private dummyMethod() : void {
+  private printLogInAllLevels() : void {
     logger.debug(this.logMsg);
     logger.info(this.logMsg);
     logger.warn(this.logMsg);

--- a/packages/logger/tests/e2e/sampleRate.decorator.test.FunctionCode.ts
+++ b/packages/logger/tests/e2e/sampleRate.decorator.test.FunctionCode.ts
@@ -36,5 +36,5 @@ class Lambda implements LambdaInterface {
   }
 }
 
-export const myFunction = new Lambda();
+const myFunction = new Lambda();
 export const handler = myFunction.handler.bind(myFunction);


### PR DESCRIPTION
## Description of your changes

## Description of your changes

As described in #1058 the decorator implementation was affected by an issue that prevented the decorated method/class to access other class members as the value of `this` was passed incorrectly.

This PR aims at fixing the issue, creating an unit test case, making minimal changes to the function in the e2e test to verify the change, and update docstrings/docs.

A long form explanation of the issue can be found at #1055, when merged this PR will close #1058. 

### How to verify this change

See checks below the PR, also see the results of the [e2e test run](https://github.com/awslabs/aws-lambda-powertools-typescript/actions/runs/2855192482).

### Related issues, RFCs

<!--- Add here the number (i.e. #42) to the Github Issue or RFC that is related to this PR. -->
<!--- If no issue is present the PR might get blocked and not be reviewed. -->
**Issue number:** #1058  

### PR status

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [x] I have made corresponding changes to the *documentation*
- [x] I have made corresponding changes to the *examples*
- [x] My changes generate *no new warnings*
- [x] The *code coverage* hasn't decreased
- [x] I have *added tests* that prove my change is effective and works
- [x] New and existing *unit tests pass* locally and in Github Actions
- [x] Any *dependent changes have been merged and published* in downstream module
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

N/A

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
