### PR TITLE
chore(tracer): remove redundant export in docs & examples

### DIFF
--- a/docs/core/tracer.md
+++ b/docs/core/tracer.md
@@ -142,7 +142,7 @@ You can quickly start by importing the `Tracer` class, initialize it outside the
         }
     }
      
-    export const handlerClass = new Lambda();
+    const handlerClass = new Lambda();
     export const handler = handlerClass.handler.bind(handlerClass); // (1)
     ```
 
@@ -255,8 +255,8 @@ You can trace other Class methods using the `captureMethod` decorator or any arb
         }
     }
      
-    export const myFunction = new Lambda();
-    export const handler = myFunction.handler.bind(myFunction); // (1)
+    const handlerClass = new Lambda();
+    export const handler = myFunction.handler.bind(handlerClass); // (1)
     ```
 
     1. Binding your handler method allows your handler to access `this`.

--- a/packages/tracer/src/Tracer.ts
+++ b/packages/tracer/src/Tracer.ts
@@ -66,7 +66,7 @@ import { Segment, Subsegment } from 'aws-xray-sdk-core';
  *   }
  * }
  * 
- * export const handlerClass = new Lambda();
+ * const handlerClass = new Lambda();
  * export const handler = handlerClass.handler.bind(handlerClass);
  * ```
  * 
@@ -333,7 +333,7 @@ class Tracer extends Utility implements TracerInterface {
    *   }
    * }
    * 
-   * export const handlerClass = new Lambda();
+   * const handlerClass = new Lambda();
    * export const handler = handlerClass.handler.bind(handlerClass);
    * ```
    * 
@@ -410,9 +410,8 @@ class Tracer extends Utility implements TracerInterface {
    *   }
    * }
    * 
-   * export const handlerClass = new Lambda();
-   * export const myMethod = handlerClass.myMethod; 
-   * export const handler = handlerClass.handler; 
+   * const handlerClass = new Lambda();
+   * export const handler = handlerClass.handler.bind(handlerClass);; 
    * ```
    * 
    * @decorator Class

--- a/packages/tracer/tests/e2e/allFeatures.decorator.test.functionCode.ts
+++ b/packages/tracer/tests/e2e/allFeatures.decorator.test.functionCode.ts
@@ -87,5 +87,5 @@ export class MyFunctionWithDecorator {
   }
 }
 
-export const handlerClass = new MyFunctionWithDecorator();
+const handlerClass = new MyFunctionWithDecorator();
 export const handler = handlerClass.handler.bind(handlerClass);

--- a/packages/tracer/tests/e2e/asyncHandler.decorator.test.functionCode.ts
+++ b/packages/tracer/tests/e2e/asyncHandler.decorator.test.functionCode.ts
@@ -82,5 +82,5 @@ export class MyFunctionWithDecorator {
   }
 }
 
-export const handlerClass = new MyFunctionWithDecorator();
+const handlerClass = new MyFunctionWithDecorator();
 export const handler = handlerClass.handler.bind(handlerClass);


### PR DESCRIPTION
## Description of your changes

As evidenced [in this review comment](https://github.com/awslabs/aws-lambda-powertools-typescript/pull/1059#discussion_r947884023), the examples, the docstrings, and the documentation had a redundant export when it comes to showing how use a Lambda handler as a class:

**Before**
```ts
class Lambda implements LambdaInterface {}

export const handlerClass = new Lambda();
export const handler = handlerClass.handler.bind(handlerClass);
```

**After**
```ts
class Lambda implements LambdaInterface {}

const handlerClass = new Lambda(); // <- Removes export
export const handler = handlerClass.handler.bind(handlerClass);
```

This PR addresses the change given that the related PR has already been merged. Similar changes have been applied to the other two PRs still open.

### How to verify this change

See updated docs/examples/docstrings.

### Related issues, RFCs

**Issue number:**#1056

### PR status

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have made corresponding changes to the *documentation*
- [x] I have made corresponding changes to the *examples*
- [x] My changes generate *no new warnings*
- [x] The *code coverage* hasn't decreased
- [x] New and existing *unit tests pass* locally and in Github Actions
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

N/A

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
