### PR TITLE
feat(tracer): allow disabling result capture for decorators and middleware

### DIFF
--- a/docs/core/tracer.md
+++ b/docs/core/tracer.md
@@ -256,7 +256,7 @@ You can trace other Class methods using the `captureMethod` decorator or any arb
     }
      
     const handlerClass = new Lambda();
-    export const handler = myFunction.handler.bind(handlerClass); // (1)
+    export const handler = handlerClass.handler.bind(handlerClass); // (1)
     ```
 
     1. Binding your handler method allows your handler to access `this`.
@@ -412,38 +412,48 @@ Use **`POWERTOOLS_TRACER_CAPTURE_RESPONSE=false`** environment variable to instr
     2. You might manipulate **streaming objects that can be read only once**; this prevents subsequent calls from being empty
     3. You might return **more than 64K** of data _e.g., `message too long` error_
 
-### Disabling response capture for targeted methods and handlers
-
-Use the `captureResponse: false` option in both `tracer.captureLambdaHandler()` and `tracer.captureMethod()` decorators, or use the same option in the middy `captureLambdaHander` middleware to instruct Tracer **not** to serialize function responses as metadata.
+Alternatively, use the `captureResponse: false` option in both `tracer.captureLambdaHandler()` and `tracer.captureMethod()` decorators, or use the same option in the Middy `captureLambdaHander` middleware to instruct Tracer **not** to serialize function responses as metadata.
 
 === "method.ts"
 
-    ```typescript hl_lines="5"
+    ```typescript hl_lines="6"
     import { Tracer } from '@aws-lambda-powertools/tracer';
 
     const tracer = new Tracer({ serviceName: 'serverlessAirline' });
-    class MyThing {
-        @tracer.captureMethod({ captureResponse: false })
-        myMethod(): string {
+
+    class Lambda implements LambdaInterface {
+        @tracer.captureMethod({ captureResult: false })
+        public getChargeId(): string {
             /* ... */
             return 'foo bar';
         }
+
+        public async handler(_event: any, _context: any): Promise<void> {
+            /* ... */
+        }
     }
+
+    const handlerClass = new Lambda();
+    export const handler = handlerClass.handler.bind(handlerClass);
     ```
 
 === "handler.ts"
 
-    ```typescript hl_lines="6"
+    ```typescript hl_lines="7"
     import { Tracer } from '@aws-lambda-powertools/tracer';
     import { LambdaInterface } from '@aws-lambda-powertools/commons';
 
     const tracer = new Tracer({ serviceName: 'serverlessAirline' });
-    class MyHandler implements LambdaInterface {
+
+    class Lambda implements LambdaInterface {
         @tracer.captureLambdaHandler({ captureResponse: false })
         async handler(_event: any, _context: any): Promise<void> {
             /* ... */
         }
     }
+
+    const handlerClass = new Lambda();
+    export const handler = handlerClass.handler.bind(handlerClass);
     ```
 
 === "middy.ts"

--- a/docs/core/tracer.md
+++ b/docs/core/tracer.md
@@ -414,7 +414,7 @@ Use **`POWERTOOLS_TRACER_CAPTURE_RESPONSE=false`** environment variable to instr
 
 ### Disabling response capture for targeted methods and handlers
 
-Use the `captureResponse: false` option in `tracer.captureMethod()` decorators to instruct Tracer **not** to serialize function responses as metadata.
+Use the `captureResponse: false` option in both `tracer.captureLambdaHandler()` and `tracer.captureMethod()` decorators to instruct Tracer **not** to serialize function responses as metadata.
 
 === "method.ts"
 
@@ -427,6 +427,21 @@ Use the `captureResponse: false` option in `tracer.captureMethod()` decorators t
         myMethod(): string {
             /* ... */
             return 'foo bar';
+        }
+    }
+    ```
+
+=== "handler.ts"
+
+    ```typescript hl_lines="6"
+    import { Tracer } from '@aws-lambda-powertools/tracer';
+    import { LambdaInterface } from '@aws-lambda-powertools/commons';
+
+    const tracer = new Tracer({ serviceName: 'serverlessAirline' });
+    class MyHandler implements LambdaInterface {
+        @tracer.captureLambdaHandler({ captureResponse: false })
+        async handler(_event: any, _context: any): Promise<void> {
+            /* ... */
         }
     }
     ```

--- a/docs/core/tracer.md
+++ b/docs/core/tracer.md
@@ -412,6 +412,40 @@ Use **`POWERTOOLS_TRACER_CAPTURE_RESPONSE=false`** environment variable to instr
     2. You might manipulate **streaming objects that can be read only once**; this prevents subsequent calls from being empty
     3. You might return **more than 64K** of data _e.g., `message too long` error_
 
+### Disabling response capture for targeted methods and handlers
+
+Use the `captureResponse: false` option in both `tracer.captureLambdaHandler()` and `tracer.captureMethod()` decorators to instruct Tracer **not** to serialize function responses as metadata.
+
+=== "method.ts"
+
+    ```typescript hl_lines="5"
+    import { Tracer } from '@aws-lambda-powertools/tracer';
+
+    const tracer = new Tracer({ serviceName: 'serverlessAirline' });
+    class MyThing {
+        @tracer.captureMethod({ captureResponse: false })
+        myMethod(): string {
+            /* ... */
+            return 'foo bar';
+        }
+    }
+    ```
+
+=== "handler.ts"
+
+    ```typescript hl_lines="6"
+    import { Tracer } from '@aws-lambda-powertools/tracer';
+    import { LambdaInterface } from '@aws-lambda-powertools/commons';
+
+    const tracer = new Tracer({ serviceName: 'serverlessAirline' });
+    class MyHandler implements LambdaInterface {
+        @tracer.captureLambdaHandler({ captureResponse: false })
+        async handler(_event: any, _context: any): Promise<void> {
+            /* ... */
+        }
+    }
+    ```
+
 ### Disabling exception auto-capture
 
 Use **`POWERTOOLS_TRACER_CAPTURE_ERROR=false`** environment variable to instruct Tracer **not** to serialize exceptions as metadata.
@@ -419,6 +453,40 @@ Use **`POWERTOOLS_TRACER_CAPTURE_ERROR=false`** environment variable to instruct
 !!! info "Commonly useful in one scenario"
 
     1. You might **return sensitive** information from exceptions, stack traces you might not control
+
+### Disabling exception capture for targeted methods and handlers
+
+Use the `captureError: false` option in both `tracer.captureLambdaHandler()` and `tracer.captureMethod()` decorators to instruct Tracer **not** to serialize exceptions as metadata.
+
+=== "method.ts"
+
+    ```typescript hl_lines="5"
+    import { Tracer } from '@aws-lambda-powertools/tracer';
+
+    const tracer = new Tracer({ serviceName: 'serverlessAirline' });
+    class MyThing {
+        @tracer.captureMethod({ captureError: false })
+        myMethod(): string {
+            /* ... */
+            return 'foo bar';
+        }
+    }
+    ```
+
+=== "handler.ts"
+
+    ```typescript hl_lines="6"
+    import { Tracer } from '@aws-lambda-powertools/tracer';
+    import { LambdaInterface } from '@aws-lambda-powertools/commons';
+
+    const tracer = new Tracer({ serviceName: 'serverlessAirline' });
+    class MyHandler implements LambdaInterface {
+        @tracer.captureLambdaHandler({ captureError: false })
+        async handler(_event: any, _context: any): Promise<void> {
+            /* ... */
+        }
+    }
+    ```
 
 ### Escape hatch mechanism
 

--- a/docs/core/tracer.md
+++ b/docs/core/tracer.md
@@ -414,7 +414,7 @@ Use **`POWERTOOLS_TRACER_CAPTURE_RESPONSE=false`** environment variable to instr
 
 ### Disabling response capture for targeted methods and handlers
 
-Use the `captureResponse: false` option in both `tracer.captureLambdaHandler()` and `tracer.captureMethod()` decorators to instruct Tracer **not** to serialize function responses as metadata.
+Use the `captureResponse: false` option in both `tracer.captureLambdaHandler()` and `tracer.captureMethod()` decorators, or use the same option in the middy `captureLambdaHander` middleware to instruct Tracer **not** to serialize function responses as metadata.
 
 === "method.ts"
 
@@ -444,6 +444,25 @@ Use the `captureResponse: false` option in both `tracer.captureLambdaHandler()` 
             /* ... */
         }
     }
+    ```
+
+=== "middy.ts"
+
+    ```typescript hl_lines="14"
+    import { Tracer, captureLambdaHandler } from '@aws-lambda-powertools/tracer';
+    import middy from '@middy/core';
+
+    const tracer = new Tracer({ serviceName: 'serverlessAirline' });
+
+    const lambdaHandler = async (_event: any, _context: any): Promise<void> => {
+        /* ... */
+    };
+
+    // Wrap the handler with middy
+    export const handler = middy(lambdaHandler)
+        // Use the middleware by passing the Tracer instance as a parameter,
+        // but specify the captureResponse option as false.
+        .use(captureLambdaHandler(tracer, { captureResponse: false }));
     ```
 
 ### Disabling exception auto-capture

--- a/docs/core/tracer.md
+++ b/docs/core/tracer.md
@@ -454,40 +454,6 @@ Use **`POWERTOOLS_TRACER_CAPTURE_ERROR=false`** environment variable to instruct
 
     1. You might **return sensitive** information from exceptions, stack traces you might not control
 
-### Disabling exception capture for targeted methods and handlers
-
-Use the `captureError: false` option in both `tracer.captureLambdaHandler()` and `tracer.captureMethod()` decorators to instruct Tracer **not** to serialize exceptions as metadata.
-
-=== "method.ts"
-
-    ```typescript hl_lines="5"
-    import { Tracer } from '@aws-lambda-powertools/tracer';
-
-    const tracer = new Tracer({ serviceName: 'serverlessAirline' });
-    class MyThing {
-        @tracer.captureMethod({ captureError: false })
-        myMethod(): string {
-            /* ... */
-            return 'foo bar';
-        }
-    }
-    ```
-
-=== "handler.ts"
-
-    ```typescript hl_lines="6"
-    import { Tracer } from '@aws-lambda-powertools/tracer';
-    import { LambdaInterface } from '@aws-lambda-powertools/commons';
-
-    const tracer = new Tracer({ serviceName: 'serverlessAirline' });
-    class MyHandler implements LambdaInterface {
-        @tracer.captureLambdaHandler({ captureError: false })
-        async handler(_event: any, _context: any): Promise<void> {
-            /* ... */
-        }
-    }
-    ```
-
 ### Escape hatch mechanism
 
 You can use `tracer.provider` attribute to access all methods provided by the [AWS X-Ray SDK](https://docs.aws.amazon.com/xray-sdk-for-nodejs/latest/reference/AWSXRay.html).

--- a/docs/core/tracer.md
+++ b/docs/core/tracer.md
@@ -414,7 +414,7 @@ Use **`POWERTOOLS_TRACER_CAPTURE_RESPONSE=false`** environment variable to instr
 
 ### Disabling response capture for targeted methods and handlers
 
-Use the `captureResponse: false` option in both `tracer.captureLambdaHandler()` and `tracer.captureMethod()` decorators to instruct Tracer **not** to serialize function responses as metadata.
+Use the `captureResponse: false` option in `tracer.captureMethod()` decorators to instruct Tracer **not** to serialize function responses as metadata.
 
 === "method.ts"
 
@@ -427,21 +427,6 @@ Use the `captureResponse: false` option in both `tracer.captureLambdaHandler()` 
         myMethod(): string {
             /* ... */
             return 'foo bar';
-        }
-    }
-    ```
-
-=== "handler.ts"
-
-    ```typescript hl_lines="6"
-    import { Tracer } from '@aws-lambda-powertools/tracer';
-    import { LambdaInterface } from '@aws-lambda-powertools/commons';
-
-    const tracer = new Tracer({ serviceName: 'serverlessAirline' });
-    class MyHandler implements LambdaInterface {
-        @tracer.captureLambdaHandler({ captureResponse: false })
-        async handler(_event: any, _context: any): Promise<void> {
-            /* ... */
         }
     }
     ```

--- a/packages/tracer/src/Tracer.ts
+++ b/packages/tracer/src/Tracer.ts
@@ -370,13 +370,7 @@ class Tracer extends Utility implements TracerInterface {
             }
 
           } catch (error) {
-            if (options?.captureError ?? true) {
-              tracerRef.addErrorAsMetadata(error as Error);
-            } else {
-              // Though we aren't adding the error as metadata, we should still
-              // mark the segment as having an error.
-              tracerRef.getSegment().addErrorFlag();
-            }
+            tracerRef.addErrorAsMetadata(error as Error);
             throw error;
           } finally {
             subsegment?.close();
@@ -449,14 +443,7 @@ class Tracer extends Utility implements TracerInterface {
             }
 
           } catch (error) {
-            if (options?.captureError ?? true) {
-              tracerRef.addErrorAsMetadata(error as Error);
-            } else {
-              // Though we aren't adding the error as metadata, we should still
-              // mark the segment as having an error.
-              tracerRef.getSegment().addErrorFlag();
-            }
-            
+            tracerRef.addErrorAsMetadata(error as Error);
             throw error;
           } finally {
             subsegment?.close();

--- a/packages/tracer/src/Tracer.ts
+++ b/packages/tracer/src/Tracer.ts
@@ -2,7 +2,7 @@ import { Handler } from 'aws-lambda';
 import { AsyncHandler, SyncHandler, Utility } from '@aws-lambda-powertools/commons';
 import { TracerInterface } from '.';
 import { ConfigServiceInterface, EnvironmentVariablesService } from './config';
-import { HandlerMethodDecorator, TracerOptions, TracerCaptureMethodOptions, TracerCaptureLambdaHandlerOptions, MethodDecorator } from './types';
+import { HandlerMethodDecorator, TracerOptions, TracerCaptureMethodOptions, MethodDecorator } from './types';
 import { ProviderService, ProviderServiceInterface } from './provider';
 import { Segment, Subsegment } from 'aws-xray-sdk-core';
 
@@ -339,7 +339,7 @@ class Tracer extends Utility implements TracerInterface {
    * 
    * @decorator Class
    */
-  public captureLambdaHandler(options?: TracerCaptureLambdaHandlerOptions): HandlerMethodDecorator {
+  public captureLambdaHandler(): HandlerMethodDecorator {
     return (_target, _propertyKey, descriptor) => {
       /**
        * The descriptor.value is the method this decorator decorates, it cannot be undefined.
@@ -365,10 +365,7 @@ class Tracer extends Utility implements TracerInterface {
           let result: unknown;
           try {
             result = await originalMethod.apply(handlerRef, [ event, context, callback ]);
-            if (options?.captureResponse ?? true) {
-              tracerRef.addResponseAsMetadata(result, process.env._HANDLER);
-            }
-
+            tracerRef.addResponseAsMetadata(result, process.env._HANDLER);
           } catch (error) {
             tracerRef.addErrorAsMetadata(error as Error);
             throw error;
@@ -444,6 +441,7 @@ class Tracer extends Utility implements TracerInterface {
 
           } catch (error) {
             tracerRef.addErrorAsMetadata(error as Error);
+            
             throw error;
           } finally {
             subsegment?.close();

--- a/packages/tracer/src/Tracer.ts
+++ b/packages/tracer/src/Tracer.ts
@@ -2,7 +2,7 @@ import { Handler } from 'aws-lambda';
 import { AsyncHandler, SyncHandler, Utility } from '@aws-lambda-powertools/commons';
 import { TracerInterface } from '.';
 import { ConfigServiceInterface, EnvironmentVariablesService } from './config';
-import { HandlerMethodDecorator, TracerOptions, MethodDecorator } from './types';
+import { HandlerMethodDecorator, TracerOptions, TracerCaptureMethodOptions, TracerCaptureLambdaHandlerOptions, MethodDecorator } from './types';
 import { ProviderService, ProviderServiceInterface } from './provider';
 import { Segment, Subsegment } from 'aws-xray-sdk-core';
 
@@ -339,7 +339,7 @@ class Tracer extends Utility implements TracerInterface {
    * 
    * @decorator Class
    */
-  public captureLambdaHandler(): HandlerMethodDecorator {
+  public captureLambdaHandler(options?: TracerCaptureLambdaHandlerOptions): HandlerMethodDecorator {
     return (_target, _propertyKey, descriptor) => {
       /**
        * The descriptor.value is the method this decorator decorates, it cannot be undefined.
@@ -365,9 +365,16 @@ class Tracer extends Utility implements TracerInterface {
           let result: unknown;
           try {
             result = await originalMethod.apply(handlerRef, [ event, context, callback ]);
-            tracerRef.addResponseAsMetadata(result, process.env._HANDLER);
+            if (options?.captureResponse ?? true) {
+              tracerRef.addResponseAsMetadata(result, process.env._HANDLER);
+            }
+
           } catch (error) {
-            tracerRef.addErrorAsMetadata(error as Error);
+            if (options?.captureError ?? true) {
+              tracerRef.addErrorAsMetadata(error as Error);
+            } else {
+              tracerRef.getSegment().addErrorFlag();
+            }
             throw error;
           } finally {
             subsegment?.close();
@@ -416,7 +423,7 @@ class Tracer extends Utility implements TracerInterface {
    * 
    * @decorator Class
    */
-  public captureMethod(): MethodDecorator {
+  public captureMethod(options?: TracerCaptureMethodOptions): MethodDecorator {
     return (_target, _propertyKey, descriptor) => {
       // The descriptor.value is the method this decorator decorates, it cannot be undefined.
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -435,9 +442,16 @@ class Tracer extends Utility implements TracerInterface {
           let result;
           try {
             result = await originalMethod.apply(this, [...args]);
-            tracerRef.addResponseAsMetadata(result, originalMethod.name);
+            if (options?.captureResponse ?? true) {
+              tracerRef.addResponseAsMetadata(result, originalMethod.name);
+            }
+
           } catch (error) {
-            tracerRef.addErrorAsMetadata(error as Error);
+            if (options?.captureError ?? true) {
+              tracerRef.addErrorAsMetadata(error as Error);
+            } else {
+              tracerRef.getSegment().addErrorFlag();
+            }
             
             throw error;
           } finally {

--- a/packages/tracer/src/Tracer.ts
+++ b/packages/tracer/src/Tracer.ts
@@ -373,6 +373,8 @@ class Tracer extends Utility implements TracerInterface {
             if (options?.captureError ?? true) {
               tracerRef.addErrorAsMetadata(error as Error);
             } else {
+              // Though we aren't adding the error as metadata, we should still
+              // mark the segment as having an error.
               tracerRef.getSegment().addErrorFlag();
             }
             throw error;
@@ -450,6 +452,8 @@ class Tracer extends Utility implements TracerInterface {
             if (options?.captureError ?? true) {
               tracerRef.addErrorAsMetadata(error as Error);
             } else {
+              // Though we aren't adding the error as metadata, we should still
+              // mark the segment as having an error.
               tracerRef.getSegment().addErrorFlag();
             }
             

--- a/packages/tracer/src/Tracer.ts
+++ b/packages/tracer/src/Tracer.ts
@@ -2,7 +2,7 @@ import { Handler } from 'aws-lambda';
 import { AsyncHandler, SyncHandler, Utility } from '@aws-lambda-powertools/commons';
 import { TracerInterface } from '.';
 import { ConfigServiceInterface, EnvironmentVariablesService } from './config';
-import { HandlerMethodDecorator, TracerOptions, TracerCaptureMethodOptions, TracerCaptureLambdaHandlerOptions, MethodDecorator } from './types';
+import { HandlerMethodDecorator, TracerOptions, HandlerOptions, MethodDecorator } from './types';
 import { ProviderService, ProviderServiceInterface } from './provider';
 import { Segment, Subsegment } from 'aws-xray-sdk-core';
 
@@ -339,7 +339,7 @@ class Tracer extends Utility implements TracerInterface {
    * 
    * @decorator Class
    */
-  public captureLambdaHandler(options?: TracerCaptureLambdaHandlerOptions): HandlerMethodDecorator {
+  public captureLambdaHandler(options?: HandlerOptions): HandlerMethodDecorator {
     return (_target, _propertyKey, descriptor) => {
       /**
        * The descriptor.value is the method this decorator decorates, it cannot be undefined.
@@ -419,7 +419,7 @@ class Tracer extends Utility implements TracerInterface {
    * 
    * @decorator Class
    */
-  public captureMethod(options?: TracerCaptureMethodOptions): MethodDecorator {
+  public captureMethod(options?: HandlerOptions): MethodDecorator {
     return (_target, _propertyKey, descriptor) => {
       // The descriptor.value is the method this decorator decorates, it cannot be undefined.
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -441,9 +441,9 @@ class Tracer extends Utility implements TracerInterface {
             if (options?.captureResponse ?? true) {
               tracerRef.addResponseAsMetadata(result, originalMethod.name);
             }
-
           } catch (error) {
             tracerRef.addErrorAsMetadata(error as Error);
+            
             throw error;
           } finally {
             subsegment?.close();

--- a/packages/tracer/src/Tracer.ts
+++ b/packages/tracer/src/Tracer.ts
@@ -2,7 +2,7 @@ import { Handler } from 'aws-lambda';
 import { AsyncHandler, SyncHandler, Utility } from '@aws-lambda-powertools/commons';
 import { TracerInterface } from '.';
 import { ConfigServiceInterface, EnvironmentVariablesService } from './config';
-import { HandlerMethodDecorator, TracerOptions, TracerCaptureMethodOptions, MethodDecorator } from './types';
+import { HandlerMethodDecorator, TracerOptions, TracerCaptureMethodOptions, TracerCaptureLambdaHandlerOptions, MethodDecorator } from './types';
 import { ProviderService, ProviderServiceInterface } from './provider';
 import { Segment, Subsegment } from 'aws-xray-sdk-core';
 
@@ -339,7 +339,7 @@ class Tracer extends Utility implements TracerInterface {
    * 
    * @decorator Class
    */
-  public captureLambdaHandler(): HandlerMethodDecorator {
+  public captureLambdaHandler(options?: TracerCaptureLambdaHandlerOptions): HandlerMethodDecorator {
     return (_target, _propertyKey, descriptor) => {
       /**
        * The descriptor.value is the method this decorator decorates, it cannot be undefined.
@@ -365,7 +365,10 @@ class Tracer extends Utility implements TracerInterface {
           let result: unknown;
           try {
             result = await originalMethod.apply(handlerRef, [ event, context, callback ]);
-            tracerRef.addResponseAsMetadata(result, process.env._HANDLER);
+            if (options?.captureResponse ?? true) {
+              tracerRef.addResponseAsMetadata(result, process.env._HANDLER);
+            }
+
           } catch (error) {
             tracerRef.addErrorAsMetadata(error as Error);
             throw error;
@@ -441,7 +444,6 @@ class Tracer extends Utility implements TracerInterface {
 
           } catch (error) {
             tracerRef.addErrorAsMetadata(error as Error);
-            
             throw error;
           } finally {
             subsegment?.close();

--- a/packages/tracer/src/middleware/middy.ts
+++ b/packages/tracer/src/middleware/middy.ts
@@ -2,8 +2,12 @@ import type middy from '@middy/core';
 import type { Tracer } from '../Tracer';
 import type { Segment, Subsegment } from 'aws-xray-sdk-core';
 
+export type CaptureLambdaHandlerOptions = {
+  captureResponse?: boolean
+};
+
 /**
- * A middy middleware automating capture of metadata and annotations on segments or subsegments ofr a Lambda Handler.
+ * A middy middleware automating capture of metadata and annotations on segments or subsegments for a Lambda Handler.
  * 
  * Using this middleware on your handler function will automatically:
  * * handle the subsegment lifecycle 
@@ -26,7 +30,7 @@ import type { Segment, Subsegment } from 'aws-xray-sdk-core';
  * @param target - The Tracer instance to use for tracing
  * @returns middleware object - The middy middleware object
  */
-const captureLambdaHandler = (target: Tracer): middy.MiddlewareObj => {
+const captureLambdaHandler = (target: Tracer, options?: CaptureLambdaHandlerOptions): middy.MiddlewareObj => {
   let lambdaSegment: Subsegment | Segment;
 
   const open = (): void => {
@@ -51,7 +55,9 @@ const captureLambdaHandler = (target: Tracer): middy.MiddlewareObj => {
   
   const captureLambdaHandlerAfter = async (request: middy.Request): Promise<void> => {
     if (target.isTracingEnabled()) {
-      target.addResponseAsMetadata(request.response, process.env._HANDLER);
+      if (options?.captureResponse ?? true) {
+        target.addResponseAsMetadata(request.response, process.env._HANDLER);
+      }
       close();
     }
   };

--- a/packages/tracer/src/middleware/middy.ts
+++ b/packages/tracer/src/middleware/middy.ts
@@ -1,10 +1,7 @@
 import type middy from '@middy/core';
 import type { Tracer } from '../Tracer';
 import type { Segment, Subsegment } from 'aws-xray-sdk-core';
-
-export type CaptureLambdaHandlerOptions = {
-  captureResponse?: boolean
-};
+import { HandlerOptions } from '../types';
 
 /**
  * A middy middleware automating capture of metadata and annotations on segments or subsegments for a Lambda Handler.
@@ -30,7 +27,7 @@ export type CaptureLambdaHandlerOptions = {
  * @param target - The Tracer instance to use for tracing
  * @returns middleware object - The middy middleware object
  */
-const captureLambdaHandler = (target: Tracer, options?: CaptureLambdaHandlerOptions): middy.MiddlewareObj => {
+const captureLambdaHandler = (target: Tracer, options?: HandlerOptions): middy.MiddlewareObj => {
   let lambdaSegment: Subsegment | Segment;
 
   const open = (): void => {

--- a/packages/tracer/src/middleware/middy.ts
+++ b/packages/tracer/src/middleware/middy.ts
@@ -1,7 +1,7 @@
 import type middy from '@middy/core';
 import type { Tracer } from '../Tracer';
 import type { Segment, Subsegment } from 'aws-xray-sdk-core';
-import { HandlerOptions } from '../types';
+import type { HandlerOptions } from '../types';
 
 /**
  * A middy middleware automating capture of metadata and annotations on segments or subsegments for a Lambda Handler.

--- a/packages/tracer/src/types/Tracer.ts
+++ b/packages/tracer/src/types/Tracer.ts
@@ -46,6 +46,24 @@ type TracerCaptureMethodOptions = {
   captureResponse?: boolean
 };
 
+/**
+ * Options for the captureLambdaHandler decorator to be used when decorating a method.
+ *
+ * Usage:
+ * @example
+ * ```typescript
+ * const tracer = new Tracer();
+ *
+ * class MyThing implements LambdaInterface {
+ *   @tracer.captureLambdaHandler({ captureResponse: false })
+ *   async handler(_event: any, _context: any): Promise<void> {}
+ * }
+ * ```
+ */
+type TracerCaptureLambdaHandlerOptions = {
+  captureResponse?: boolean
+};
+
 type HandlerMethodDecorator = (
   target: LambdaInterface,
   propertyKey: string | symbol,
@@ -58,6 +76,7 @@ type MethodDecorator = (target: any, propertyKey: string | symbol, descriptor: T
 
 export {
   TracerOptions,
+  TracerCaptureLambdaHandlerOptions,
   TracerCaptureMethodOptions,
   HandlerMethodDecorator,
   MethodDecorator

--- a/packages/tracer/src/types/Tracer.ts
+++ b/packages/tracer/src/types/Tracer.ts
@@ -27,40 +27,23 @@ type TracerOptions = {
 };
 
 /**
- * Options for the captureMethod decorator to be used when decorating a method.
+ * Options for handler decorators and middleware.
  *
  * Usage:
  * @example
  * ```typescript
  * const tracer = new Tracer();
  *
- * class MyThing {
- *   @tracer.captureMethod({ captureResponse: false })
- *   myMethod(): string {
- *     return 'foo bar';
- *   }
- * }
- * ```
- */
-type TracerCaptureMethodOptions = {
-  captureResponse?: boolean
-};
-
-/**
- * Options for the captureLambdaHandler decorator to be used when decorating a method.
- *
- * Usage:
- * @example
- * ```typescript
- * const tracer = new Tracer();
- *
- * class MyThing implements LambdaInterface {
+ * class Lambda implements LambdaInterface {
  *   @tracer.captureLambdaHandler({ captureResponse: false })
  *   async handler(_event: any, _context: any): Promise<void> {}
  * }
+ *
+ * const handlerClass = new Lambda();
+ * export const handler = handlerClass.handler.bind(handlerClass);
  * ```
  */
-type TracerCaptureLambdaHandlerOptions = {
+type HandlerOptions = {
   captureResponse?: boolean
 };
 
@@ -76,8 +59,7 @@ type MethodDecorator = (target: any, propertyKey: string | symbol, descriptor: T
 
 export {
   TracerOptions,
-  TracerCaptureLambdaHandlerOptions,
-  TracerCaptureMethodOptions,
+  HandlerOptions,
   HandlerMethodDecorator,
   MethodDecorator
 };

--- a/packages/tracer/src/types/Tracer.ts
+++ b/packages/tracer/src/types/Tracer.ts
@@ -36,7 +36,9 @@ type TracerOptions = {
  *
  * class MyThing {
  *   @tracer.captureMethod({ captureResponse: false, captureError: false })
- *   async myMethod() { ... }
+ *   myMethod(): string {
+ *     return 'foo bar';
+ *   }
  * }
  * ```
  */
@@ -55,7 +57,7 @@ type TracerCaptureMethodOptions = {
  *
  * class MyThing implements LambdaInterface {
  *   @tracer.captureLambdaHandler({ captureResponse: false, captureError: false })
- *   async handler() { ... }
+ *   async handler(_event: any, _context: any): Promise<void> {}
  * }
  * ```
  */

--- a/packages/tracer/src/types/Tracer.ts
+++ b/packages/tracer/src/types/Tracer.ts
@@ -26,6 +26,44 @@ type TracerOptions = {
   customConfigService?: ConfigServiceInterface
 };
 
+/**
+ * Options for the captureMethod decorator to be used when decorating a method.
+ *
+ * Usage:
+ * @example
+ * ```typescript
+ * const tracer = new Tracer();
+ *
+ * class MyThing {
+ *   @tracer.captureMethod({ captureResponse: false, captureError: false })
+ *   async myMethod() { ... }
+ * }
+ * ```
+ */
+type TracerCaptureMethodOptions = {
+  captureResponse?: boolean
+  captureError?: boolean
+};
+
+/**
+ * Options for the captureLambdaHandler decorator to be used when decorating a method.
+ *
+ * Usage:
+ * @example
+ * ```typescript
+ * const tracer = new Tracer();
+ *
+ * class MyThing implements LambdaInterface {
+ *   @tracer.captureLambdaHandler({ captureResponse: false, captureError: false })
+ *   async handler() { ... }
+ * }
+ * ```
+ */
+type TracerCaptureLambdaHandlerOptions = {
+  captureResponse?: boolean
+  captureError?: boolean
+};
+
 type HandlerMethodDecorator = (
   target: LambdaInterface,
   propertyKey: string | symbol,
@@ -38,6 +76,8 @@ type MethodDecorator = (target: any, propertyKey: string | symbol, descriptor: T
 
 export {
   TracerOptions,
+  TracerCaptureLambdaHandlerOptions,
+  TracerCaptureMethodOptions,
   HandlerMethodDecorator,
   MethodDecorator
 };

--- a/packages/tracer/src/types/Tracer.ts
+++ b/packages/tracer/src/types/Tracer.ts
@@ -35,7 +35,7 @@ type TracerOptions = {
  * const tracer = new Tracer();
  *
  * class MyThing {
- *   @tracer.captureMethod({ captureResponse: false, captureError: false })
+ *   @tracer.captureMethod({ captureResponse: false })
  *   myMethod(): string {
  *     return 'foo bar';
  *   }
@@ -44,7 +44,6 @@ type TracerOptions = {
  */
 type TracerCaptureMethodOptions = {
   captureResponse?: boolean
-  captureError?: boolean
 };
 
 /**
@@ -56,14 +55,13 @@ type TracerCaptureMethodOptions = {
  * const tracer = new Tracer();
  *
  * class MyThing implements LambdaInterface {
- *   @tracer.captureLambdaHandler({ captureResponse: false, captureError: false })
+ *   @tracer.captureLambdaHandler({ captureResponse: false })
  *   async handler(_event: any, _context: any): Promise<void> {}
  * }
  * ```
  */
 type TracerCaptureLambdaHandlerOptions = {
   captureResponse?: boolean
-  captureError?: boolean
 };
 
 type HandlerMethodDecorator = (

--- a/packages/tracer/src/types/Tracer.ts
+++ b/packages/tracer/src/types/Tracer.ts
@@ -46,24 +46,6 @@ type TracerCaptureMethodOptions = {
   captureResponse?: boolean
 };
 
-/**
- * Options for the captureLambdaHandler decorator to be used when decorating a method.
- *
- * Usage:
- * @example
- * ```typescript
- * const tracer = new Tracer();
- *
- * class MyThing implements LambdaInterface {
- *   @tracer.captureLambdaHandler({ captureResponse: false })
- *   async handler(_event: any, _context: any): Promise<void> {}
- * }
- * ```
- */
-type TracerCaptureLambdaHandlerOptions = {
-  captureResponse?: boolean
-};
-
 type HandlerMethodDecorator = (
   target: LambdaInterface,
   propertyKey: string | symbol,
@@ -76,7 +58,6 @@ type MethodDecorator = (target: any, propertyKey: string | symbol, descriptor: T
 
 export {
   TracerOptions,
-  TracerCaptureLambdaHandlerOptions,
   TracerCaptureMethodOptions,
   HandlerMethodDecorator,
   MethodDecorator

--- a/packages/tracer/tests/e2e/allFeatures.decorator.test.functionCode.ts
+++ b/packages/tracer/tests/e2e/allFeatures.decorator.test.functionCode.ts
@@ -35,14 +35,13 @@ const refreshAWSSDKImport = (): void => {
 const tracer = new Tracer({ serviceName: serviceName });
 const dynamoDBv3 = tracer.captureAWSv3Client(new DynamoDBClient({}));
 
-export class MyFunctionWithDecorator {  
+export class MyFunctionBase {
   private readonly returnValue: string;
 
   public constructor() {
     this.returnValue = customResponseValue;
   }
 
-  @tracer.captureLambdaHandler()
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
   public handler(event: CustomEvent, _context: Context, _callback: Callback<unknown>): void | Promise<unknown> {
@@ -79,7 +78,6 @@ export class MyFunctionWithDecorator {
       });
   }
 
-  @tracer.captureMethod()
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
   public myMethod(): string {
@@ -87,5 +85,40 @@ export class MyFunctionWithDecorator {
   }
 }
 
+class MyFunctionWithDecorator extends MyFunctionBase {
+  @tracer.captureLambdaHandler()
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  public handler(event: CustomEvent, _context: Context, _callback: Callback<unknown>): void | Promise<unknown> {
+    return super.handler(event, _context, _callback);
+  }
+
+  @tracer.captureMethod()
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  public myMethod(): string {
+    return super.myMethod();
+  }
+}
+
 const handlerClass = new MyFunctionWithDecorator();
 export const handler = handlerClass.handler.bind(handlerClass);
+
+class MyFunctionWithDecoratorCaptureResponseFalse extends MyFunctionBase {
+  @tracer.captureLambdaHandler({ captureResponse: false })
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  public handler(event: CustomEvent, _context: Context, _callback: Callback<unknown>): void | Promise<unknown> {
+    return super.handler(event, _context, _callback);
+  }
+
+  @tracer.captureMethod({ captureResponse: false })
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  public myMethod(): string {
+    return super.myMethod();
+  }
+}
+
+const handlerWithCaptureResponseFalseClass = new MyFunctionWithDecoratorCaptureResponseFalse();
+export const handlerWithCaptureResponseFalse = handlerClass.handler.bind(handlerWithCaptureResponseFalseClass);

--- a/packages/tracer/tests/e2e/allFeatures.middy.test.functionCode.ts
+++ b/packages/tracer/tests/e2e/allFeatures.middy.test.functionCode.ts
@@ -36,7 +36,7 @@ const refreshAWSSDKImport = (): void => {
 const tracer = new Tracer({ serviceName: serviceName });
 const dynamoDBv3 = tracer.captureAWSv3Client(new DynamoDBClient({}));
 
-export const handler = middy(async (event: CustomEvent, _context: Context): Promise<void> => {
+const testHandler = async (event: CustomEvent, _context: Context): Promise<void> => {
   tracer.putAnnotation('invocation', event.invocation);
   tracer.putAnnotation(customAnnotationKey, customAnnotationValue);
   tracer.putMetadata(customMetadataKey, customMetadataValue);
@@ -63,4 +63,8 @@ export const handler = middy(async (event: CustomEvent, _context: Context): Prom
   } catch (err) {
     throw err;
   }
-}).use(captureLambdaHandler(tracer));
+};
+
+export const handler = middy(testHandler).use(captureLambdaHandler(tracer));
+
+export const handlerWithNoCaptureResponseViaMiddlewareOption = middy(testHandler).use(captureLambdaHandler(tracer, { captureResponse: false }));

--- a/packages/tracer/tests/helpers/tracesUtils.ts
+++ b/packages/tracer/tests/helpers/tracesUtils.ts
@@ -79,6 +79,7 @@ export interface ParsedTrace {
 interface TracerTestFunctionParams { 
   stack: Stack
   functionName: string
+  handler?: string
   entry: string
   expectedServiceName: string
   environmentParams: { [key: string]: string }
@@ -237,7 +238,7 @@ const createTracerTestFunction = (params: TracerTestFunctionParams): NodejsFunct
   const func = new NodejsFunction(stack, functionName, {
     entry: entry,
     functionName: functionName,
-    handler: 'handler',
+    handler: params.handler ?? 'handler',
     tracing: Tracing.ACTIVE,
     architecture: Architecture.X86_64,
     memorySize: 256, // Default value (128) will take too long to process

--- a/packages/tracer/tests/unit/Tracer.test.ts
+++ b/packages/tracer/tests/unit/Tracer.test.ts
@@ -648,36 +648,6 @@ describe('Class: Tracer', () => {
     
     });
 
-    test('when used as decorator while captureResponse is set to false, it does not capture the response as metadata', async () => {
-
-      // Prepare
-      const tracer: Tracer = new Tracer();
-      const newSubsegment: Segment | Subsegment | undefined = new Subsegment('## index.handler');
-      jest.spyOn(tracer.provider, 'getSegment').mockImplementation(() => newSubsegment);
-      setContextMissingStrategy(() => null);
-      const captureAsyncFuncSpy = jest.spyOn(tracer.provider, 'captureAsyncFunc');
-      class Lambda implements LambdaInterface {
-
-        @tracer.captureLambdaHandler({ captureResponse: false })
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
-        public handler<TEvent, TResult>(_event: TEvent, _context: Context, _callback: Callback<TResult>): void | Promise<TResult> {
-          return new Promise((resolve, _reject) => resolve({
-            foo: 'bar'
-          } as unknown as TResult));
-        }
-
-      }
-
-      // Act
-      await new Lambda().handler(event, context, () => console.log('Lambda invoked!'));
-
-      // Assess
-      expect(captureAsyncFuncSpy).toHaveBeenCalledTimes(1);
-      expect('metadata' in newSubsegment).toBe(false);
-
-    });
-
     test('when used as decorator and with standard config, it captures the response as metadata', async () => {
       
       // Prepare

--- a/packages/tracer/tests/unit/Tracer.test.ts
+++ b/packages/tracer/tests/unit/Tracer.test.ts
@@ -648,6 +648,36 @@ describe('Class: Tracer', () => {
     
     });
 
+    test('when used as decorator while captureResponse is set to false, it does not capture the response as metadata', async () => {
+
+      // Prepare
+      const tracer: Tracer = new Tracer();
+      const newSubsegment: Segment | Subsegment | undefined = new Subsegment('## index.handler');
+      jest.spyOn(tracer.provider, 'getSegment').mockImplementation(() => newSubsegment);
+      setContextMissingStrategy(() => null);
+      const captureAsyncFuncSpy = jest.spyOn(tracer.provider, 'captureAsyncFunc');
+      class Lambda implements LambdaInterface {
+
+        @tracer.captureLambdaHandler({ captureResponse: false })
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        public handler<TEvent, TResult>(_event: TEvent, _context: Context, _callback: Callback<TResult>): void | Promise<TResult> {
+          return new Promise((resolve, _reject) => resolve({
+            foo: 'bar'
+          } as unknown as TResult));
+        }
+
+      }
+
+      // Act
+      await new Lambda().handler(event, context, () => console.log('Lambda invoked!'));
+
+      // Assess
+      expect(captureAsyncFuncSpy).toHaveBeenCalledTimes(1);
+      expect('metadata' in newSubsegment).toBe(false);
+
+    });
+
     test('when used as decorator and with standard config, it captures the response as metadata', async () => {
       
       // Prepare

--- a/packages/tracer/tests/unit/Tracer.test.ts
+++ b/packages/tracer/tests/unit/Tracer.test.ts
@@ -757,41 +757,6 @@ describe('Class: Tracer', () => {
 
     });
 
-    test('when used as decorator while captureError is set to false, it does not capture the exceptions', async () => {
-
-      // Prepare
-      const tracer: Tracer = new Tracer();
-      const newSubsegment: Segment | Subsegment | undefined = new Subsegment('## index.handler');
-      jest.spyOn(tracer.provider, 'getSegment')
-        .mockImplementation(() => newSubsegment);
-      setContextMissingStrategy(() => null);
-      const captureAsyncFuncSpy = jest.spyOn(tracer.provider, 'captureAsyncFunc');
-      const addErrorSpy = jest.spyOn(newSubsegment, 'addError');
-      const addErrorFlagSpy = jest.spyOn(newSubsegment, 'addErrorFlag');
-      class Lambda implements LambdaInterface {
-
-        @tracer.captureLambdaHandler({ captureError: false })
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
-        public handler<TEvent, TResult>(_event: TEvent, _context: Context, _callback: Callback<TResult>): void | Promise<TResult> {
-          throw new Error('Exception thrown!');
-        }
-
-      }
-
-      // Act & Assess
-      await expect(new Lambda().handler({}, context, () => console.log('Lambda invoked!'))).rejects.toThrowError(Error);
-      expect(captureAsyncFuncSpy).toHaveBeenCalledTimes(1);
-      expect(newSubsegment).toEqual(expect.objectContaining({
-        name: '## index.handler',
-      }));
-      expect('cause' in newSubsegment).toBe(false);
-      expect(addErrorFlagSpy).toHaveBeenCalledTimes(1);
-      expect(addErrorSpy).toHaveBeenCalledTimes(0);
-      expect.assertions(6);
-
-    });
-
     test('when used as decorator and with standard config, it captures the exception correctly', async () => {
       
       // Prepare
@@ -1111,47 +1076,6 @@ describe('Class: Tracer', () => {
       expect('cause' in newSubsegment).toBe(true);
       expect(addErrorSpy).toHaveBeenCalledTimes(1);
       expect(addErrorSpy).toHaveBeenCalledWith(new Error('Exception thrown!'), false);
-      expect.assertions(6);
-
-    });
-
-    test('when used as decorator and with captureError set to false, it does not capture the exception', async () => {
-
-      // Prepare
-      const tracer: Tracer = new Tracer();
-      const newSubsegment: Segment | Subsegment | undefined = new Subsegment('### dummyMethod');
-      jest.spyOn(tracer.provider, 'getSegment')
-        .mockImplementation(() => newSubsegment);
-      setContextMissingStrategy(() => null);
-      const captureAsyncFuncSpy = createCaptureAsyncFuncMock(tracer.provider);
-      const addErrorSpy = jest.spyOn(newSubsegment, 'addError');
-      const addErrorFlagSpy = jest.spyOn(newSubsegment, 'addErrorFlag');
-      class Lambda implements LambdaInterface {
-
-        @tracer.captureMethod({ captureError: false })
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
-        public async dummyMethod(_some: string): Promise<string> {
-          throw new Error('Exception thrown!');
-        }
-
-        public async handler<TEvent, TResult>(_event: TEvent, _context: Context, _callback: Callback<TResult>): Promise<TResult> {
-          const result = await this.dummyMethod('foo bar');
-
-          return new Promise((resolve, _reject) => resolve(result as unknown as TResult));
-        }
-
-      }
-
-      // Act / Assess
-      await expect(new Lambda().handler({}, context, () => console.log('Lambda invoked!'))).rejects.toThrowError(Error);
-      expect(captureAsyncFuncSpy).toHaveBeenCalledTimes(1);
-      expect(newSubsegment).toEqual(expect.objectContaining({
-        name: '### dummyMethod',
-      }));
-      expect('cause' in newSubsegment).toBe(false);
-      expect(addErrorFlagSpy).toHaveBeenCalledTimes(1);
-      expect(addErrorSpy).toHaveBeenCalledTimes(0);
       expect.assertions(6);
 
     });

--- a/packages/tracer/tests/unit/middy.test.ts
+++ b/packages/tracer/tests/unit/middy.test.ts
@@ -131,6 +131,37 @@ describe('Middy middleware', () => {
 
     });
 
+    test('when used while captureResponse set to true, it captures the response as metadata', async () => {
+      
+      // Prepare
+      const tracer: Tracer = new Tracer();
+      const newSubsegment: Segment | Subsegment | undefined = new Subsegment('## index.handler');
+      const setSegmentSpy = jest.spyOn(tracer.provider, 'setSegment').mockImplementation();
+      jest.spyOn(tracer.provider, 'getSegment').mockImplementation(() => newSubsegment);
+      setContextMissingStrategy(() => null);
+      const lambdaHandler: Handler = async (_event: unknown, _context: Context) => ({
+        foo: 'bar'
+      });
+      const handler = middy(lambdaHandler).use(captureLambdaHandler(tracer, { captureResponse: true }));
+
+      // Act
+      await handler({}, context, () => console.log('Lambda invoked!'));
+
+      // Assess
+      expect(setSegmentSpy).toHaveBeenCalledTimes(2);
+      expect(newSubsegment).toEqual(expect.objectContaining({
+        name: '## index.handler',
+        metadata: {
+          'hello-world': {
+            'index.handler response': {
+              foo: 'bar',
+            },
+          },
+        }
+      }));
+
+    });
+
     test('when used with standard config, it captures the response as metadata', async () => {
       
       // Prepare


### PR DESCRIPTION
<!--- 1. Make sure you follow our Contributing Guidelines: https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/CONTRIBUTING.md -->
<!--- 2. Please follow the template, and do not remove any section in the template. If something is not applicable leave it empty, but leave it in the PR. -->

## Description of your changes

This PR adds options to `tracer.captureMethod()`, `tracer.captureLambdaHandler()` and the `captureLambdaHandler` middleware, allowing the user to disable response capture on a per-method basis. This change helps customers control when the tracer should capture information that might be sensitive or larger than 64K, but without disabling these capture mechanisms globally via `POWERTOOLS_TRACER_CAPTURE_RESPONSE=false` environment variable.

<!--- Include here a summary of the change. -->

<!--- Please include also relevant motivation and context. -->

<!--- List any dependencies that are required for this change. -->

<!--- If this PR is part of a sequence of related PRs or TODOs, list the high level TODO items. -->

### How to verify this change

I have added multiple unit tests that simulate adding `captureResponse: false` to `tracer.captureMethod()`, `tracer.captureLambdaHandler()`, and the Middy `captureLambdaHandler` middleware. I have also added e2e tests for all three.

<!--- Add any applicable config, projects, screenshots or other resources -->
<!--- that can help us verify your changes. -->

<!--- Examples: -->
<!--- Screenshots, cloud configuration, anything helping us evaluate better. -->

### Related issues, RFCs

<!--- Add here the number (i.e. #42) to the Github Issue or RFC that is related to this PR. -->
<!--- If no issue is present the PR might get blocked and not be reviewed. -->
**Issue number:** #1064

### PR status

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [x] I have made corresponding changes to the *documentation*
- [ ] I have made corresponding changes to the *examples*
- [x] My changes generate *no new warnings*
- [x] The *code coverage* hasn't decreased
- [x] I have *added tests* that prove my change is effective and works
- [x] New and existing *unit tests pass* locally and in Github Actions
- [ ] Any *dependent changes have been merged and published* in downstream module
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

- [ ] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
