### PR TITLE
fix(docs): docs published with incorrect version number + api docs missing after release

### DIFF
--- a/.github/workflows/on-merge-to-main.yml
+++ b/.github/workflows/on-merge-to-main.yml
@@ -18,6 +18,8 @@ jobs:
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}
   run-unit-tests:
+    needs: get_pr_details
+    if: ${{ needs.get_pr_details.outputs.prIsMerged == 'true' }}
     uses: ./.github/workflows/reusable-run-unit-tests.yml
   publish:
     needs:

--- a/.github/workflows/publish-docs-on-release.yml
+++ b/.github/workflows/publish-docs-on-release.yml
@@ -1,0 +1,17 @@
+name: Publish docs on release
+
+on:
+  # Triggered manually
+  workflow_dispatch: {}
+  # Or triggered as result of a release
+  release:
+    types: [released]
+
+jobs:
+  run-unit-tests:
+    uses: ./.github/workflows/reusable-publish-docs.yml
+    with:
+      workflow_origin: ${{ github.event.repository.full_name }}
+      isRelease: "true"
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-docs-on-release.yml
+++ b/.github/workflows/publish-docs-on-release.yml
@@ -13,7 +13,7 @@ on:
     types: [released]
 
 jobs:
-  run-unit-tests:
+  publish-docs:
     uses: ./.github/workflows/reusable-publish-docs.yml
     with:
       workflow_origin: ${{ github.event.repository.full_name }}

--- a/.github/workflows/publish-docs-on-release.yml
+++ b/.github/workflows/publish-docs-on-release.yml
@@ -2,7 +2,12 @@ name: Publish docs on release
 
 on:
   # Triggered manually
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      versionNumber:
+        required: true
+        type: string
+        description: "If running this manually please insert a version number that corresponds to the latest published in the GitHub releases (i.e. v1.1.1)"
   # Or triggered as result of a release
   release:
     types: [released]
@@ -13,5 +18,6 @@ jobs:
     with:
       workflow_origin: ${{ github.event.repository.full_name }}
       isRelease: "true"
+      versionNumber: ${{ inputs.versionNumber }}
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/reusable-publish-docs.yml
+++ b/.github/workflows/reusable-publish-docs.yml
@@ -21,7 +21,7 @@ on:
 jobs:
   publish-docs:
     # see https://github.com/awslabs/aws-lambda-powertools-python/issues/1349
-    if: inputs.workflow_origin == 'awslabs/aws-lambda-powertools-typescript'
+    if: ${{ inputs.workflow_origin == 'awslabs/aws-lambda-powertools-typescript' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -56,14 +56,15 @@ jobs:
           python-version: "3.8"
       # We run this step only when the workflow has been triggered by a release
       # in this case we publish the docs to `/latest`
-      - name: Set RELEASE_VERSION env var to `latest`
+      - name: (Conditional) Set RELEASE_VERSION env var to `latest`
         if: ${{ inputs.isRelease == 'true' }}
         run: |
-          RELEASE_VERSION=$(cat packages/commons/package.json | jq '.version' -r)
+          RELEASE_VERSION=$(echo ${{ github.ref_name }} | sed 's/v//')
+          echo "RELEASE_VERSION=${RELEASE_VERSION}"
           echo "RELEASE_VERSION=${RELEASE_VERSION}" >> $GITHUB_ENV
       # We run this step only when the workflow has been triggered by a PR merge
       # in this case we publish the docs to `/dev`
-      - name: Set RELEASE_VERSION env var to `dev`
+      - name: (Conditional) Set RELEASE_VERSION env var to `dev`
         if: ${{ inputs.prIsMerged == 'true' }}
         run: |
           echo "RELEASE_VERSION=dev" >> $GITHUB_ENV
@@ -72,7 +73,7 @@ jobs:
         uses: actions/github-script@v3
         with:
           script: |
-              core.setFailed('RELEASE_VERSION env var is empty.')
+            core.setFailed('RELEASE_VERSION env var is empty.')
       - name: Install doc generation dependencies
         run: |
           pip install --upgrade pip 

--- a/.github/workflows/reusable-publish-docs.yml
+++ b/.github/workflows/reusable-publish-docs.yml
@@ -100,3 +100,11 @@ jobs:
           publish_dir: ./api
           keep_files: true
           destination_dir: ${{ env.RELEASE_VERSION }}/api
+      - name: Release API docs to latest
+        if: ${{ env.RELEASE_VERSION != 'dev' }}
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./api
+          keep_files: true
+          destination_dir: latest/api

--- a/.github/workflows/reusable-publish-docs.yml
+++ b/.github/workflows/reusable-publish-docs.yml
@@ -1,4 +1,4 @@
-name: Publish docs
+name: Reusable Publish docs
 
 on:
   workflow_call:
@@ -13,6 +13,10 @@ on:
       isRelease:
         required: false
         default: "false"
+        type: string
+      versionNumber:
+        required: false
+        default: ""
         type: string
     secrets:
       token:
@@ -60,8 +64,14 @@ jobs:
         if: ${{ inputs.isRelease == 'true' }}
         run: |
           RELEASE_VERSION=$(echo ${{ github.ref_name }} | sed 's/v//')
-          echo "RELEASE_VERSION=${RELEASE_VERSION}"
-          echo "RELEASE_VERSION=${RELEASE_VERSION}" >> $GITHUB_ENV
+          EXPLICIT_RELEASE_VERSION=$(echo ${{ inputs.versionNumber }} | sed 's/v//')
+          if [ $EXPLICIT_RELEASE_VERSION != "" ]; then
+            echo "RELEASE_VERSION=${EXPLICIT_RELEASE_VERSION}"
+            echo "RELEASE_VERSION=${EXPLICIT_RELEASE_VERSION}" >> $GITHUB_ENV
+          else
+            echo "RELEASE_VERSION=${RELEASE_VERSION}"
+            echo "RELEASE_VERSION=${RELEASE_VERSION}" >> $GITHUB_ENV
+          fi
       # We run this step only when the workflow has been triggered by a PR merge
       # in this case we publish the docs to `/dev`
       - name: (Conditional) Set RELEASE_VERSION env var to `dev`

--- a/.github/workflows/reusable-publish-docs.yml
+++ b/.github/workflows/reusable-publish-docs.yml
@@ -67,6 +67,12 @@ jobs:
         if: ${{ inputs.prIsMerged == 'true' }}
         run: |
           echo "RELEASE_VERSION=dev" >> $GITHUB_ENV
+      - name: Check RELEASE_VERSION env var
+        if: ${{ env.RELEASE_VERSION == '' }}
+        uses: actions/github-script@v3
+        with:
+          script: |
+              core.setFailed('RELEASE_VERSION env var is empty.')
       - name: Install doc generation dependencies
         run: |
           pip install --upgrade pip 
@@ -75,7 +81,7 @@ jobs:
         run: |
           git config --global user.name Docs deploy
           git config --global user.email docs@dummy.bot.com
-      - name: Publish docs to latest
+      - name: Publish docs to latest if isRelease
         if: ${{ env.RELEASE_VERSION != 'dev' }}
         run: |
           rm -rf site
@@ -100,7 +106,7 @@ jobs:
           publish_dir: ./api
           keep_files: true
           destination_dir: ${{ env.RELEASE_VERSION }}/api
-      - name: Release API docs to latest
+      - name: Release API docs to latest if isRelease
         if: ${{ env.RELEASE_VERSION != 'dev' }}
         uses: peaceiris/actions-gh-pages@v3
         with:


### PR DESCRIPTION
## Description of your changes

As described in #1063 there were two issues related to the docs publishing after a release. Both issues were due to oversights on my part.

### Issue 1 - API docs are missing

The first one was that I removed a step from the `reusable-publish-docs` ([link](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/workflows/reusable-publish-docs.yml)) and this step was the one that published the API docs under the correct version number in the docs. You can verify this by checking the `/latest` version of the docs, which works (while the `v1.1.0` doesn't). Adding back the step fixes the docs missing issue.

### Issue 2 - Incorrect version number

The second one was instead due to a behavior of GitHub Actions that I misunderstood.

For context: we have 2 workflows: `make-release` ([link](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/workflows/make-release.yml)) and `reusable-publish-docs` ([link](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/workflows/reusable-publish-docs.yml)). 

The first one is triggered manually, the second is called by the former as the last step (we also use it elsewhere, hence it’s `reusable-` prefix).

During the `make-release` workflow we perform some actions, [one of these](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/workflows/make-release.yml#L48) is to increment the version of our packages, commit, & push a tag.

**When `make-release` calls `reusable-publish-docs` I was expecting the latter to checkout the code that contains the latest changes & tag, so that it can build the docs using the correct version number**.

What happens instead is that when checking out the actions/checkout action detects the latest tag (L517 of “Checkout code step” [here](https://github.com/awslabs/aws-lambda-powertools-typescript/runs/7900433814?check_suite_focus=true#step:2:522)) but then the code in the repo & the tag used are the previous & same as the one in the make-release context.

Below a diagram that visually represents what described so far:
![IMG_0009](https://user-images.githubusercontent.com/7353869/185599301-fa99b083-345b-4ebf-a7d5-c5dc6fd8d54a.jpg)

Reading the [docs on reusing workflow](https://docs.github.com/en/actions/using-workflows/reusing-workflows) though, there are some info that I was missing. Below two key excerpts:
> A workflow that uses another workflow is referred to as a "caller" workflow. The reusable workflow is a "called" workflow. One caller workflow can use multiple called workflows.

and

> For example, if the called workflow uses actions/checkout, the action checks out the contents of the repository that hosts the caller workflow, not the called workflow.

This means that even though the called workflow (`reusable-publish-docs`) was correctly detecting the presence of a new tag, the context used and the the version of the repo checked out, were the same as the `make-release` one, which was in a point in time before the release & consequent version bump.

There are two solutions that come to mind here:
1. Have the caller workflow export the commit SHA of the post-version state of the repo, pass it to the called workflow, and have the called workflow to use said SHA to checkout the correct version of the workflow. This approach would be laborious and would make the two workflow tightly coupled, reducing the _reusability_ of the called workflow.
2. Change the trigger of the called workflow and execute it in response to an [actual release event](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release). This is an event that that is triggered **after a maintainer publishes a release**, which means that the docs will be synced to the GitHub release instead of the the NPM publish. This is the approach that I am proposing in this PR which also removes both issues described above since it'll get always the latest tag in the event.

Finally, I'm also adding a way to **manually trigger the publish docs workflow** as a break-glass solution that will allow us to manually trigger a docs publish if any of the other triggers fails.

### How to verify this change

Review the code & see these workflow runs in a fork:
- I run `make-release` - [result here](https://github.com/dreamorosi/aws-lambda-powertools-typescript/actions/runs/2889145596) - (only difference here is that I'm not publishing to NPM, otherwise the workflow is the same)
- I then [make a release](https://github.com/dreamorosi/aws-lambda-powertools-typescript/releases/tag/v1.2.17) on the GH repo (manually) - (This is a release in the release section, not a workflow execution)
- This triggers the `reusable-publish-docs` workflow - result [here](https://github.com/dreamorosi/aws-lambda-powertools-typescript/actions/runs/2889171377)
- Check that the docs correspond to the released version - [link](https://dreamorosi.github.io/aws-lambda-powertools-typescript/latest/) (I'll delete this after the PR is merged to avoid confusion)

Additionally, I have also run the publish docs workflow manually, [here's the result](https://github.com/dreamorosi/aws-lambda-powertools-typescript/actions/runs/2889878925).

### Related issues, RFCs

<!--- Add here the number (i.e. #42) to the Github Issue or RFC that is related to this PR. -->
<!--- If no issue is present the PR might get blocked and not be reviewed. -->
**Issue number:** #1063 

### PR status

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [x] My changes generate *no new warnings*
- [x] The *code coverage* hasn't decreased
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

N/A

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
