### PR TITLE
Bug (Tracer): Tracer imports all the components via TracerInterface #1068

### DIFF
--- a/packages/tracer/src/Tracer.ts
+++ b/packages/tracer/src/Tracer.ts
@@ -1,10 +1,10 @@
-import { Handler } from 'aws-lambda';
 import { AsyncHandler, SyncHandler, Utility } from '@aws-lambda-powertools/commons';
-import { TracerInterface } from '.';
-import { ConfigServiceInterface, EnvironmentVariablesService } from './config';
-import { HandlerMethodDecorator, TracerOptions, MethodDecorator } from './types';
-import { ProviderService, ProviderServiceInterface } from './provider';
+import { Handler } from 'aws-lambda';
 import { Segment, Subsegment } from 'aws-xray-sdk-core';
+import { ConfigServiceInterface, EnvironmentVariablesService } from './config';
+import { ProviderService, ProviderServiceInterface } from './provider';
+import { TracerInterface } from './TracerInterface';
+import { HandlerMethodDecorator, MethodDecorator, TracerOptions } from './types';
 
 /**
  * ## Intro


### PR DESCRIPTION
## Description of your changes

Import `TracerInterface` only instead of all the modules from the root to avoid importing unused modules like middy

### How to verify this change

Import Tracer as `import { Tracer } from "@aws-lambda-powertools/tracer/lib/Tracer";` without middy node module and build should pass

### Related issues, RFCs

**Issue number:** https://github.com/awslabs/aws-lambda-powertools-typescript/issues/1068

### PR status

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
- [x] I have performed a *self-review* of my own code
- [ ] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [ ] I have made corresponding changes to the *documentation*
- [ ] I have made corresponding changes to the *examples*
- [ ] My changes generate *no new warnings*
- [x] The *code coverage* hasn't decreased
- [ ] I have *added tests* that prove my change is effective and works
- [ ] New and existing *unit tests pass* locally and in Github Actions
- [ ] Any *dependent changes have been merged and published* in downstream module
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

- [ ] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
