### PR TITLE
feat(metrics):  increase maximum dimensions to 29

### DIFF
--- a/docs/core/metrics.md
+++ b/docs/core/metrics.md
@@ -301,7 +301,7 @@ If you do not use the middleware or decorator, you have to flush your metrics ma
 !!! warning "Metric validation"
     If metrics are provided, and any of the following criteria are not met, a **`RangeError`** exception will be thrown:
 
-    * Maximum of 9 dimensions
+    * Maximum of 29 dimensions
     * Namespace is set only once (or none)
     * Metric units must be [supported by CloudWatch](https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_MetricDatum.html)
 

--- a/packages/metrics/src/Metrics.ts
+++ b/packages/metrics/src/Metrics.ts
@@ -14,7 +14,7 @@ import {
 } from './types';
 
 const MAX_METRICS_SIZE = 100;
-const MAX_DIMENSION_COUNT = 9;
+const MAX_DIMENSION_COUNT = 29;
 const DEFAULT_NAMESPACE = 'default_namespace';
 
 /**

--- a/packages/metrics/tests/unit/Metrics.test.ts
+++ b/packages/metrics/tests/unit/Metrics.test.ts
@@ -13,7 +13,7 @@ import { Metrics, MetricUnits } from '../../src/';
 import { populateEnvironmentVariables } from '../helpers';
 
 const MAX_METRICS_SIZE = 100;
-const MAX_DIMENSION_COUNT = 9;
+const MAX_DIMENSION_COUNT = 29;
 const DEFAULT_NAMESPACE = 'default_namespace';
 
 const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
@@ -371,7 +371,7 @@ describe('Class: Metrics', () => {
       }
     });
 
-    test('Error should be thrown on empty metrics when throwOnEmptyMetrics() is callse', async () => {
+    test('Error should be thrown on empty metrics when throwOnEmptyMetrics() is called', async () => {
       expect.assertions(1);
 
       const metrics = new Metrics({ namespace: 'test' });
@@ -459,6 +459,7 @@ describe('Class: Metrics', () => {
     });
 
     test('Should throw an error if the same metric name is added again with a different unit', ()=> {
+      expect.assertions(1);
       const metrics = new Metrics();
       
       metrics.addMetric('test_name', MetricUnits.Count, 2);


### PR DESCRIPTION
<!--- 1. Make sure you follow our Contributing Guidelines: https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/CONTRIBUTING.md -->
<!--- 2. Please follow the template, and do not remove any section in the template. If something is not applicable leave it empty, but leave it in the PR. -->

## Description of your changes

Amazon added support to up 30 dimensions per metric. In this PR we increase this limit
<!--- Include here a summary of the change. -->

<!--- Please include also relevant motivation and context. -->

<!--- List any dependencies that are required for this change. -->

<!--- If this PR is part of a sequence of related PRs or TODOs, list the high level TODO items. -->

### How to verify this change

Review the code changes and the results of the automated builds.

<!--- Add any applicable config, projects, screenshots or other resources -->
<!--- that can help us verify your changes. -->

<!--- Examples: -->
<!--- Screenshots, cloud configuration, anything helping us evaluate better. -->

### Related issues, RFCs

<!--- Add here the number (i.e. #42) to the Github Issue or RFC that is related to this PR. -->
<!--- If no issue is present the PR might get blocked and not be reviewed. -->
**Issue number:**  #1044 

### PR status

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have made corresponding changes to the *documentation*
- [ ] I have made corresponding changes to the *examples*
- [x] My changes generate *no new warnings*
- [x] The *code coverage* hasn't decreased
- [ ] I have *added tests* that prove my change is effective and works
- [x] New and existing *unit tests pass* locally and in Github Actions
- [ ] Any *dependent changes have been merged and published* in downstream module
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

N/A

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
