### PR TITLE
chore(build): update make-release.yml to remove redundant publish step

### DIFF
--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -47,11 +47,3 @@ jobs:
           git remote set-url origin https://x-access-token:${GH_TOKEN}@github.com/$GITHUB_REPOSITORY
           npx lerna version --conventional-commits --force-publish --yes
           npx lerna publish from-git --no-verify-access --yes
-  publish:
-    needs: publish-npm
-    uses: ./.github/workflows/reusable-publish-docs.yml
-    with:
-      workflow_origin: ${{ github.event.repository.full_name }}
-      isRelease: "true"
-    secrets:
-      token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description of your changes

In #1066 we decoupled the release to NPM & docs publishing processes. With that change the release of a new Powertools for TypeScript version works as follows:
- Manually trigger the "Make release" workflow - this will run unit tests, increase the version of the packages in the repo, create a new git tag, & publish the packages to NPM with increased version
- Manually make a release via GitHub releases UI - this will be using the tag created earlier, and once published it will trigger the other workflow that publishes the docs using the correct version number

With this PR I'm removing a leftover step from the "Make Release" workflow that was also publishing the docs.

### How to verify this change

Run the "Make release" workflow.

### Related issues, RFCs

**Issue number:** #1063

### PR status

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] My changes generate *no new warnings*
- [x] The *code coverage* hasn't decreased
- [x] New and existing *unit tests pass* locally and in Github Actions
- [x] Any *dependent changes have been merged and published* in downstream module
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

- [ ] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
