### PR TITLE
fix(build): remove leftover code in action that labels issues on merge

### DIFF
--- a/.github/scripts/label_related_issue.js
+++ b/.github/scripts/label_related_issue.js
@@ -39,25 +39,15 @@ module.exports = async ({github, context, core}) => {
     const { groups: {issue} } = isMatch;
 
     try {
-      core.info(`Auto-labeling related issue ${issue} for release`)
-      await github.rest.issues.addLabels({
+      core.info(`Auto-labeling related issue ${issue} for release`);
+      return await github.rest.issues.addLabels({
         issue_number: issue,
         owner: context.repo.owner,
         repo: context.repo.repo,
-        labels: [LABEL_PENDING_RELEASE]
+        labels: [LABEL_PENDING_RELEASE],
       });
     } catch (error) {
       core.setFailed(`Is this issue number (${issue}) valid? Perhaps a discussion?`);
       throw new Error(error);
     }
-
-    const { groups: {relatedIssueNumber} } = isMatch;
-
-    core.info(`Auto-labeling related issue ${relatedIssueNumber} for release`);
-    return await github.rest.issues.addLabels({
-      issue_number: relatedIssueNumber,
-      owner: context.repo.owner,
-      repo: context.repo.repo,
-      labels: [relatedIssueNumber]
-    });
 }


### PR DESCRIPTION
## Description of your changes

At the moment, the workflow that is run every time a PR is merged attempts to label the issue related to that PR with a `pending-release` tag, to inform the person opening the issue that a change will be released soon.

At the moment the script that is run during this action has a bug coming from a leftover version of the script that makes it fail.

<img width="489" alt="image" src="https://user-images.githubusercontent.com/7353869/186467168-34be3e9e-274c-42ab-a0be-6e1a397f6ad9.png">

This PR aims at fixing the issue.

### How to verify this change

Observe the result of the "On PR Merge" workflow at the next PR merged.

### Related issues, RFCs

**Issue number:** #1076

### PR status

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] My changes generate *no new warnings*
- [x] The *code coverage* hasn't decreased
- [x] New and existing *unit tests pass* locally and in Github Actions
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

N/A

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
