### PR TITLE
improv(build): allow to specify PR number when running e2e tests

### DIFF
--- a/.github/scripts/get_pr_info.js
+++ b/.github/scripts/get_pr_info.js
@@ -1,0 +1,27 @@
+module.exports = async ({ github, context, core }) => {
+  const prNumber = process.env.PR_NUMBER;
+
+  if (prNumber === "") {
+    core.setFailed(`No PR number was passed. Aborting`);
+  }
+
+  try {
+    const {
+      data: { head, base },
+    } = await github.rest.pulls.get({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      pull_number: prNumber,
+    });
+
+    core.setOutput("headRef", head.ref);
+    core.setOutput("headSHA", head.sha);
+    core.setOutput("baseRef", base.ref);
+    core.setOutput("baseSHA", base.sha);
+  } catch (error) {
+    core.setFailed(
+      `Unable to retrieve info from PR number ${prNumber}.\n\n Error details: ${error}`
+    );
+    throw error;
+  }
+};

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -1,47 +1,19 @@
-name: run-e2e-tests
+name: Run e2e Tests
+
 on:
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      prNumber:
+        description: "(Optional) PR Number. If you specify a value the value of the branch field will be ignored."
+        required: false
+        default: ""
+
 jobs:
-  example-and-package-check:
+  run-e2e-tests-on-utils:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - name: "Checkout"
-        uses: actions/checkout@v3
-      - name: "Use NodeJS 16"
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16
-      - name: "Install npm@8.x"
-        run: npm i -g npm@next-8
-      - name: "Install monorepo packages"
-        # This installs all the dependencies of ./packages/*
-        # See https://github.com/npm/cli/issues/4475 to see why --foreground-scripts
-        run: npm ci --foreground-scripts
-      - name: Install CDK example packages
-        # Since we are not managing the CDK examples with npm workspaces we install
-        # the dependencies in a separate step
-        working-directory: ./examples/cdk
-        run: npm ci
-      - name: "Setup SAM"
-        # We use an ad-hoc action so we can specify the SAM CLI version
-        uses: aws-actions/setup-sam@v2
-        with:
-          version: 1.49.0
-      - name: Install SAM example packages
-        # Since we are not managing the SAM examples with npm workspaces we install
-        # the dependencies in a separate step
-        working-directory: ./examples/sam
-        run: npm ci
-      - name: "Test packaging"
-        run: |
-          npm run lerna-package
-          cd examples/cdk
-          npm install ../../packages/**/dist/aws-lambda-powertools-*
-          npm run test
-  package-e2e-tests:
-    runs-on: ubuntu-latest
+    env:
+      NODE_ENV: dev
+      PR_NUMBER: ${{ inputs.prNumber }}
     permissions:
       id-token: write # needed to interact with GitHub's OIDC Token endpoint.
       contents: read
@@ -51,28 +23,47 @@ jobs:
         version: [12, 14, 16]
       fail-fast: false
     steps:
-      - name: "Checkout"
+      - name: Checkout Repo
         uses: actions/checkout@v3
-      - name: "Use NodeJS"
+      # If we pass a PR Number when triggering the workflow we will retrieve the PR info and get its headSHA
+      - name: Extract PR details
+        id: extract_PR_details
+        if: ${{ inputs.prNumber != '' }}
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const script = require('.github/scripts/get_pr_info.js');
+            await script({github, context, core});
+      # Only if a PR Number was passed and the headSHA of the PR extracted,
+      # we checkout the PR at that point in time
+      - name: Checkout PR code
+        if: ${{ inputs.prNumber != '' }}
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ steps.extract_PR_details.outputs.headSHA }}
+      - name: Setup NodeJS
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.version }}
-      - name: "Install npm@8.x"
+      - name: Setup npm
         run: npm i -g npm@next-8
-      - name: "Install monorepo packages"
+      - name: Install dependencies
         # This installs all the dependencies of ./packages/*
         # See https://github.com/npm/cli/issues/4475 to see why --foreground-scripts
         run: npm ci --foreground-scripts
-      - name: "Configure AWS credentials"
+      - name: Setup AWS credentials
         uses: aws-actions/configure-aws-credentials@v1.6.1
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN_TO_ASSUME }}
           aws-region: eu-west-1
-      - name: "Run packages integration tests"
+      - name: Run integration tests on utils
         run: |
           RUNTIME=nodejs${{ matrix.version }}x npm run test:e2e -w packages/${{ matrix.package }}
   layer-e2e-tests:
     runs-on: ubuntu-latest
+    env:
+      NODE_ENV: dev
+      PR_NUMBER: ${{ inputs.prNumber }}
     permissions:
       id-token: write # needed to interact with GitHub's OIDC Token endpoint.
       contents: read
@@ -81,14 +72,30 @@ jobs:
       matrix:
         version: [12, 14, 16]
     steps:
-      - name: Checkout
+      - name: Checkout Repo
         uses: actions/checkout@v3
-      - name: Use NodeJS
+      # If we pass a PR Number when triggering the workflow we will retrieve the PR info and get its headSHA
+      - name: Extract PR details
+        id: extract_PR_details
+        if: ${{ inputs.prNumber != '' }}
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const script = require('.github/scripts/get_pr_info.js');
+            await script({github, context, core});
+      # Only if a PR Number was passed and the headSHA of the PR extracted,
+      # we checkout the PR at that point in time
+      - name: Checkout PR code
+        if: ${{ inputs.prNumber != '' }}
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ steps.extract_PR_details.outputs.headSHA }}
+      - name: Setup NodeJS
         uses: actions/setup-node@v3
         with:
           # Always use version 16 as we use TypeScript target es2020
           node-version: 16
-      - name: Install npm@8.x
+      - name: Setup npm
         run: npm i -g npm@next-8
       - name: "Configure AWS credentials"
         uses: aws-actions/configure-aws-credentials@v1.6.1
@@ -115,9 +122,8 @@ jobs:
         if: steps.cache-node-modules.outputs.cache-hit == 'true'
         run: |
           npm run build -w packages/commons
-      - name: "Run layer integration tests"
+      - name: Run integration test on layers
         run: |
           npm ci --foreground-scripts
           RUNTIME=nodejs${{ matrix.version }}.x npm run test:e2e
         working-directory: layer-publisher
-


### PR DESCRIPTION
## Description of your changes

As described in issue #1077, at the moment it's not possible to run e2e tests on branches that reside on a fork of the repo. This PR, with the changes that are described below, aims at supporting this mechanism so that maintainers can trigger an integration test on PRs coming from the community. 

> **Warning**
> **This GitHub Action can be started only by maintainers of this repository. Maintainers should continue to thoroughly review external contributions to make sure the changes are appropriate prior to running the workflow on a given PR**.

This PR adds an optional input field to the workflow that runs integration tests, **now renamed "Run e2e tests** for consistency:
<img width="335" alt="image" src="https://user-images.githubusercontent.com/7353869/186486863-a2f6909f-7804-4044-b147-367e7dd13529.png">

The field is an integer that represents a PR number from this repository. When a value is provided, **this value takes precedence over the branch name selected in the dropdown**.

If a value is not supplied, the workflow will run the integration tests on the selected branch.

Below a diagram that shows the new flow:
```mermaid
graph TD
    A[Manual Trigger] --> B[Checkout branch]
    B --> C{Is there a PR Number?}
    C -->|Yes| D[Retrieve PR info]
    D --> E[Checkout branch from PR]
    E --> F
    C -->|No - keep selected branch| F[Run e2e tests]
  
```

Finally, I have removed from the workflow the step that runs unit tests since this will always be run either on `main` (where unit tests are run before and after merging), or on a PR which should be merged only when unit tests are successful.

### How to verify this change

Run the e2e tests on a PR coming from a fork once the workflow is merged.

### Related issues, RFCs

<!--- Add here the number (i.e. #42) to the Github Issue or RFC that is related to this PR. -->
<!--- If no issue is present the PR might get blocked and not be reviewed. -->
**Issue number:** #1077

### PR status

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [x] My changes generate *no new warnings*
- [x] The *code coverage* hasn't decreased
- [x] New and existing *unit tests pass* locally and in Github Actions
- [ ] Any *dependent changes have been merged and published* in downstream module
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

N/A

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
