### PR TITLE
fix(metrics): captureColdStartMetric and throwOnEmptyMetrics when set to false was interpreted as true

### DIFF
--- a/packages/metrics/src/middleware/middy.ts
+++ b/packages/metrics/src/middleware/middy.ts
@@ -9,13 +9,13 @@ const logMetrics = (target: Metrics | Metrics[], options: ExtraOptions = {}): mi
     metricsInstances.forEach((metrics: Metrics) => {
       metrics.setFunctionName(request.context.functionName);
       const { throwOnEmptyMetrics, defaultDimensions, captureColdStartMetric } = options;
-      if (throwOnEmptyMetrics !== undefined) {
+      if (throwOnEmptyMetrics) {
         metrics.throwOnEmptyMetrics();
       }
       if (defaultDimensions !== undefined) {
         metrics.setDefaultDimensions(defaultDimensions);
       }
-      if (captureColdStartMetric !== undefined) {
+      if (captureColdStartMetric) {
         metrics.captureColdStartMetric();
       }
     });


### PR DESCRIPTION
## Description of your changes

Metrics' Middy implementation was checking for `undefined` to evaluate `throwOnEmptyMetrics` and `captureColdStartMetrics`.

### How to verify this change

1. Get only the unit tests from this PR, see them fail
2. Get the update on `middy.ts`
3. rerun the unit tests and see them passed

### Related issues, RFCs

Issue number: #1088 

### PR status

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [x] I have made corresponding changes to the *documentation*
- [x] I have made corresponding changes to the *examples*
- [x] My changes generate *no new warnings*
- [x] The *code coverage* hasn't decreased
- [x] I have *added tests* that prove my change is effective and works
- [x] New and existing *unit tests pass* locally and in Github Actions
- [x] Any *dependent changes have been merged and published* in downstream module
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
