### PR TITLE
Chore(tracer): unit tests to verify decorators await decorated class methods

### DIFF
--- a/packages/tracer/tests/unit/Tracer.test.ts
+++ b/packages/tracer/tests/unit/Tracer.test.ts
@@ -999,6 +999,9 @@ describe('Class: Tracer', () => {
       await handler({}, context, () => console.log('Lambda invoked!'));
 
       // Assess
+      // Here we assert that the otherDummyMethodSpy method is called before the cleanup logic (inside the finally of decorator)
+      // that should always be called after the handler has returned. If otherDummyMethodSpy is called after it means the
+      // decorator is NOT awaiting the handler which would cause the test to fail.
       expect(otherDummyMethodSpy.mock.invocationCallOrder[0]).toBeLessThan(subsegmentCloseSpy.mock.invocationCallOrder[0]);
 
     });
@@ -1326,6 +1329,9 @@ describe('Class: Tracer', () => {
       await handler({}, context, () => console.log('Lambda invoked!'));
 
       // Assess
+      // Here we assert that the subsegment.close() (inside the finally of decorator) is called before the other otherDummyMethodSpy method
+      // that should always be called after the handler has returned. If subsegment.close() is called after it means the
+      // decorator is NOT awaiting the method which would cause the test to fail.
       expect(subsegmentCloseSpy.mock.invocationCallOrder[0]).toBeLessThan(otherDummyMethodSpy.mock.invocationCallOrder[0]);
 
     });


### PR DESCRIPTION
## Description of your changes

In #1091 it was reported that the `tracer.captureMethod()` and `tracer.captureLambdaHandler()` decorators might not be awaiting correctly the decorated methods.

After a closer look it seems that they we already awaited properly, see:
- `captureMethod` here: https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/packages/tracer/src/Tracer.ts#L440
- `captureLambdaHandler` here: https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/packages/tracer/src/Tracer.ts#L367

This PR simply introduces unit tests to prove that this is the case and to guard against any future regressions.

### How to verify this change

See existing & new unit tests passing.

### Related issues, RFCs

<!--- Add here the number (i.e. #42) to the Github Issue or RFC that is related to this PR. -->
<!--- If no issue is present the PR might get blocked and not be reviewed. -->
**Issue number:** #1091

### PR status

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [ ] I have made corresponding changes to the *documentation*
- [ ] I have made corresponding changes to the *examples*
- [x] My changes generate *no new warnings*
- [x] The *code coverage* hasn't decreased
- [x] I have *added tests* that prove my change is effective and works
- [x] New and existing *unit tests pass* locally and in Github Actions
- [x] Any *dependent changes have been merged and published* in downstream module
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

N/A

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
