### PR TITLE
fix(tracer): captureMethod detects proper method name when used with external decorators

### DIFF
--- a/packages/tracer/src/Tracer.ts
+++ b/packages/tracer/src/Tracer.ts
@@ -420,7 +420,7 @@ class Tracer extends Utility implements TracerInterface {
    * @decorator Class
    */
   public captureMethod(options?: HandlerOptions): MethodDecorator {
-    return (_target, _propertyKey, descriptor) => {
+    return (_target, propertyKey, descriptor) => {
       // The descriptor.value is the method this decorator decorates, it cannot be undefined.
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const originalMethod = descriptor.value!;
@@ -434,12 +434,14 @@ class Tracer extends Utility implements TracerInterface {
           return originalMethod.apply(this, [...args]);
         }
 
-        return tracerRef.provider.captureAsyncFunc(`### ${originalMethod.name}`, async subsegment => {
+        const methodName = String(propertyKey);
+
+        return tracerRef.provider.captureAsyncFunc(`### ${methodName}`, async subsegment => {
           let result;
           try {
             result = await originalMethod.apply(this, [...args]);
             if (options?.captureResponse ?? true) {
-              tracerRef.addResponseAsMetadata(result, originalMethod.name);
+              tracerRef.addResponseAsMetadata(result, methodName);
             }
           } catch (error) {
             tracerRef.addErrorAsMetadata(error as Error);


### PR DESCRIPTION
## Description of your changes

In #1093 it has been reported that the `tracer.captureMethod` decorator was not properly detecting the name of the decorated class method, causing the name of the segment and the corresponding metadata entry to have an empty name.

I.e.

```ts
const tracer = new Tracer();

function passThrough() {
  // A decorator that calls the original method.
  return (_target: unknown, _propertyKey: string, descriptor: PropertyDescriptor) => {
    const originalMethod = descriptor.value!;
    descriptor.value = function (...args: unknown[]) {
      return originalMethod.apply(this, [...args]);
    };
  };
}

class MyClass {
  @tracer.captureMethod()
  @passThrough()
  async doSomething(): Promise<string> {
    return 'foo';
  }
}

const myClass = new MyClass();
await myClass.doSomething();

// Segment name will be "### "
/**
 * Metadata entry on the segment would be
 * {
 *   "default": {
 *     " response": "foo" <- key should have been `doSomething response`
 *   }
 * }
 *
 */
```

@misterjoshua, who opened the initial issue, also suggested a potential fix which was used in this PR.

This PR also adds an unit test case to demonstrate the fix.

### How to verify this change

See new unit test case that was added in this PR.

### Related issues, RFCs

<!--- Add here the number (i.e. #42) to the Github Issue or RFC that is related to this PR. -->
<!--- If no issue is present the PR might get blocked and not be reviewed. -->
**Issue number:** #1093 

### PR status

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [ ] I have made corresponding changes to the *documentation*
- [ ] I have made corresponding changes to the *examples*
- [x] My changes generate *no new warnings*
- [x] The *code coverage* hasn't decreased
- [x] I have *added tests* that prove my change is effective and works
- [x] New and existing *unit tests pass* locally and in Github Actions
- [ ] Any *dependent changes have been merged and published* in downstream module
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

N/A

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
