### PR TITLE
chore(layer): fix bundling and e2e tests by manually setting hash of asset

### DIFF
--- a/layer-publisher/package-lock.json
+++ b/layer-publisher/package-lock.json
@@ -11,7 +11,8 @@
         "aws-cdk-lib": "2.25.0",
         "constructs": "^10.0.0",
         "if-node-version": "^1.1.1",
-        "source-map-support": "^0.5.16"
+        "source-map-support": "^0.5.16",
+        "ts-md5": "^1.3.1"
       },
       "bin": {
         "layer-publisher": "bin/layer-publisher.js"
@@ -6345,6 +6346,14 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
     },
+    "node_modules/ts-md5": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/ts-md5/-/ts-md5-1.3.1.tgz",
+      "integrity": "sha512-DiwiXfwvcTeZ5wCE0z+2A9EseZsztaiZtGrtSaY5JOD7ekPnR/GoIVD5gXZAlK9Na9Kvpo9Waz5rW64WKAWApg==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ts-node": {
       "version": "10.9.1",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
@@ -11783,6 +11792,11 @@
           "dev": true
         }
       }
+    },
+    "ts-md5": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/ts-md5/-/ts-md5-1.3.1.tgz",
+      "integrity": "sha512-DiwiXfwvcTeZ5wCE0z+2A9EseZsztaiZtGrtSaY5JOD7ekPnR/GoIVD5gXZAlK9Na9Kvpo9Waz5rW64WKAWApg=="
     },
     "ts-node": {
       "version": "10.9.1",

--- a/layer-publisher/package.json
+++ b/layer-publisher/package.json
@@ -30,6 +30,7 @@
     "aws-cdk-lib": "2.25.0",
     "constructs": "^10.0.0",
     "if-node-version": "^1.1.1",
-    "source-map-support": "^0.5.16"
+    "source-map-support": "^0.5.16",
+    "ts-md5": "^1.3.1"
   }
 }

--- a/layer-publisher/tests/e2e/happy-case.test.lambda.ts
+++ b/layer-publisher/tests/e2e/happy-case.test.lambda.ts
@@ -31,7 +31,7 @@ exports.handler = function (_event: never, _ctx: unknown): void {
 
     if (packageJSON.version != process.env.POWERTOOLS_PACKAGE_VERSION) {
       throw new Error(
-        `Package version mismatch: \${packageJSON.version} != \${process.env.POWERTOOLS_PACKAGE_VERSION}`
+        `Package version mismatch: ${packageJSON.version} != ${process.env.POWERTOOLS_PACKAGE_VERSION}`
       );
     }
   } catch (error) {

--- a/layer-publisher/tests/unit/__snapshots__/layer-publisher.test.ts.snap
+++ b/layer-publisher/tests/unit/__snapshots__/layer-publisher.test.ts.snap
@@ -32,8 +32,9 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "dfbb723532549b2040a663602bbe51ab6b3f16dfd063eafc5bbd7e64b13f997d.zip",
+          "S3Key": "c2f621503b147cecccf2e6cc6df420a8f11ee29ae042d2c1f523cf5db3f47ca2.zip",
         },
+        "Description": "Lambda Powertools for TypeScript version 1.0.1",
         "LayerName": "AWSLambdaPowertoolsTypeScript",
       },
       "Type": "AWS::Lambda::LayerVersion",


### PR DESCRIPTION
## Description of your changes

For some reason bundled layer was not updated properly when version change. 
After some investigation it looks like to be related to a bug in lambda.Code.fromAsset which does not take into account a change in bundling local command. Forcing the calculation of the hash based on bundling local command (which include version as well), layer is updated properly.

### How to verify this change

Check https://github.com/awslabs/aws-lambda-powertools-typescript/actions/runs/3232406370 or run e2e from your computer

### Related issues, RFCs

Issue Number: #1114 

### PR status

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [x] I have made corresponding changes to the *documentation*
- [x] I have made corresponding changes to the *examples*
- [x] My changes generate *no new warnings*
- [x] The *code coverage* hasn't decreased
- [x] I have *added tests* that prove my change is effective and works
- [x] New and existing *unit tests pass* locally and in Github Actions
- [x] Any *dependent changes have been merged and published* in downstream module
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
