### PR TITLE
fix(all): update version command to use lint-fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "lerna-prepare": "lerna exec -- npm run build",
     "lerna-prepublishOnly": "lerna exec -- npm test && lerna exec -- npm run lint",
     "lerna-preversion": "lerna exec -- npm run lint",
-    "lerna-version": "lerna exec -- npm run format && git add -A src",
+    "lerna-version": "lerna exec -- npm run lint-fix && git add -A src",
     "postversion": "git push && git push --tags",
     "docs-website-build-run": "npm run docs-buildDockerImage && npm run docs-runLocalDocker",
     "docs-buildDockerImage": "docker build -t powertool-typescript/docs ./docs/",

--- a/packages/commons/package.json
+++ b/packages/commons/package.json
@@ -23,7 +23,7 @@
     "prepare": "npm run build",
     "prepublishOnly": "npm test && npm run lint",
     "preversion": "npm run lint",
-    "version": "npm run format && git add -A src",
+    "version": "npm run lint-fix && git add -A src",
     "postversion": "git push && git push --tags"
   },
   "homepage": "https://github.com/awslabs/aws-lambda-powertools-typescript/tree/master/packages/metrics#readme",

--- a/packages/idempotency/package.json
+++ b/packages/idempotency/package.json
@@ -26,7 +26,7 @@
     "prepare": "npm run build",
     "prepublishOnly": "npm test && npm run lint",
     "preversion": "npm run lint",
-    "version": "npm run format && git add -A src",
+    "version": "npm run lint-fix && git add -A src",
     "postversion": "git push && git push --tags"
   },
   "homepage": "https://github.com/awslabs/aws-lambda-powertools-typescript/tree/master/packages/idempotency#readme",

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -26,7 +26,7 @@
     "prepare": "npm run build",
     "prepublishOnly": "npm test && npm run lint",
     "preversion": "npm run lint",
-    "version": "npm run format && git add -A src",
+    "version": "npm run lint-fix && git add -A src",
     "postversion": "git push && git push --tags"
   },
   "homepage": "https://github.com/awslabs/aws-lambda-powertools-typescript/tree/master/packages/logging#readme",

--- a/packages/metrics/package.json
+++ b/packages/metrics/package.json
@@ -26,7 +26,7 @@
     "prepare": "npm run build",
     "prepublishOnly": "npm test && npm run lint",
     "preversion": "npm run lint",
-    "version": "npm run format && git add -A src",
+    "version": "npm run lint-fix && git add -A src",
     "postversion": "git push && git push --tags"
   },
   "homepage": "https://github.com/awslabs/aws-lambda-powertools-typescript/tree/master/packages/metrics#readme",

--- a/packages/tracer/package.json
+++ b/packages/tracer/package.json
@@ -24,7 +24,7 @@
     "prepare": "npm run build",
     "prepublishOnly": "npm test && npm run lint",
     "preversion": "npm run lint",
-    "version": "npm run format && git add -A src",
+    "version": "npm run lint-fix && git add -A src",
     "postversion": "git push && git push --tags",
     "package": "mkdir -p dist/ && npm pack && mv *.tgz dist/",
     "package-bundle": "../../package-bundler.sh tracer-bundle ./dist"


### PR DESCRIPTION
## Description of your changes

As reported in #1118 the `version` command present in the `package.json` files of all utilities is referencing another command (`format`) that has been renamed to `lint-fix` in a previous PR (#1105). This causes the release pipeline to fail.

This PR updates the content of the command from `npm run format && git add -A src` to `npm run lint-fix && git add -A src` (`format` becomes `lint-fix`).

### How to verify this change

See diff, then check next run of the `Make Release` workflow.

### Related issues, RFCs

<!--- Add here the number (i.e. #42) to the Github Issue or RFC that is related to this PR. -->
<!--- If no issue is present the PR might get blocked and not be reviewed. -->
**Issue number:** #1118 

### PR status

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
- [x] I have performed a *self-review* of my own code
- [ ] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [ ] I have made corresponding changes to the *documentation*
- [ ] I have made corresponding changes to the *examples*
- [x] My changes generate *no new warnings*
- [x] The *code coverage* hasn't decreased
- [ ] I have *added tests* that prove my change is effective and works
- [x] New and existing *unit tests pass* locally and in Github Actions
- [ ] Any *dependent changes have been merged and published* in downstream module
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

N/A

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
