### PR TITLE
docs(layers): fix format issues

### DIFF
--- a/docs/core/logger.md
+++ b/docs/core/logger.md
@@ -201,7 +201,7 @@ In each case, the printed log will look like this:
 When debugging in non-production environments, you can instruct Logger to log the incoming event with the middleware/decorator parameter `logEvent` or via `POWERTOOLS_LOGGER_LOG_EVENT` env var set to `true`.
 
 ???+ warning
-This is disabled by default to prevent sensitive info being logged
+	This is disabled by default to prevent sensitive info being logged
 
 === "Middy Middleware"
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -76,10 +76,10 @@ You can include Lambda Powertools Lambda Layer using [AWS Lambda Console](https:
 
     ```yaml hl_lines="5"
     MyLambdaFunction:
-        Type: AWS::Serverless::Function
+      Type: AWS::Serverless::Function
         Properties:
-            Layers:
-                - !Sub arn:aws:lambda:${AWS::Region}:094274105915:layer:AWSLambdaPowertoolsTypeScript:3
+          Layers:
+            - !Sub arn:aws:lambda:${AWS::Region}:094274105915:layer:AWSLambdaPowertoolsTypeScript:3
     ```
 
 === "Serverless framework"
@@ -89,56 +89,52 @@ You can include Lambda Powertools Lambda Layer using [AWS Lambda Console](https:
 		hello:
 		  handler: lambda_function.lambda_handler
 		  layers:
-			- arn:aws:lambda:${aws:region}:094274105915:layer:AWSLambdaPowertoolsTypeScript:3
+			  - arn:aws:lambda:${aws::region}:094274105915:layer:AWSLambdaPowertoolsTypeScript:3
     ```
 
 === "CDK"
 
-    ```typescript hl_lines="11 16"
+    ```typescript hl_lines="13 19"
     import * as cdk from 'aws-cdk-lib';
     import { Construct } from 'constructs';
     import * as lambda from 'aws-cdk-lib/aws-lambda';
+    
     export class SampleFunctionWithLayer extends Construct {
-        constructor(scope: Construct, id: string) {
-            super(scope, id);
-            // Create a Layer with AWS Lambda Powertools for TypeScript
-            const powertoolsLayer = lambda.LayerVersion.fromLayerVersionArn(
-            this,
-            'PowertoolsLayer',
-            `arn:aws:lambda:${cdk.Stack.of(this).region}:094274105915:layer:AWSLambdaPowertoolsTypeScript:3`
-            );
-            new lambda.Function(this, 'Function', {
-            runtime: lambda.Runtime.NODEJS_16_X,
-            // Add the Layer to a Lambda function
-            layers: [powertoolsLayer],
-            code: lambda.Code.fromInline(`
-            const { Logger } = require('@aws-lambda-powertools/logger');
-            const { Metrics } = require('@aws-lambda-powertools/metrics');
-            const { Tracer } = require('@aws-lambda-powertools/tracer');
-            const logger = new Logger({logLevel: 'DEBUG'});
-            const metrics = new Metrics();
-            const tracer = new Tracer();
-            exports.handler = function(event, ctx) {
-                logger.debug("Hello World!"); 
-            }`),
-            handler: 'index.handler',
-            });
-        }
+      constructor(scope: Construct, id: string) {
+        super(scope, id);
+      
+        // Create a Layer with AWS Lambda Powertools for TypeScript
+        const powertoolsLayer = lambda.LayerVersion.fromLayerVersionArn(
+          this,
+          'PowertoolsLayer',
+          `arn:aws:lambda:${cdk.Stack.of(this).region}:094274105915:layer:AWSLambdaPowertoolsTypeScript:3`
+        );
+        
+        new lambda.Function(this, 'Function', {
+          runtime: lambda.Runtime.NODEJS_16_X,
+          // Add the Layer to a Lambda function
+          layers: [powertoolsLayer],
+          code: lambda.Code.fromInline(`...`),
+          handler: 'index.handler',
+        });
+      }
     }
     ```
 
 === "Terraform"
 
-    ```terraform hl_lines="9 38"
+    ```terraform hl_lines="9 36"
     terraform {
       required_version = "~> 1.0.5"
       required_providers {
         aws = "~> 3.50.0"
       }
     }
+
     provider "aws" {
-      region  = "{region}"
+      region  = "{aws::region}"
     }
+
     resource "aws_iam_role" "iam_for_lambda" {
       name = "iam_for_lambda"
       assume_role_policy = <<EOF
@@ -154,15 +150,16 @@ You can include Lambda Powertools Lambda Layer using [AWS Lambda Console](https:
             }
           ]
         }
-        EOF
-	}
+      EOF
+	  }
+    
     resource "aws_lambda_function" "test_lambda" {
       filename      = "lambda_function_payload.zip"
       function_name = "lambda_function_name"
       role          = aws_iam_role.iam_for_lambda.arn
-      handler       = "index.test"
+      handler       = "index.handler"
       runtime 		= "nodejs16.x"
-      layers 		= ["arn:aws:lambda:{region}:094274105915:layer:AWSLambdaPowertoolsTypeScript:3"]
+      layers 		= ["arn:aws:lambda:{aws::region}:094274105915:layer:AWSLambdaPowertoolsTypeScript:3"]
       source_code_hash = filebase64sha256("lambda_function_payload.zip")
     }
     ```
@@ -178,7 +175,7 @@ You can include Lambda Powertools Lambda Layer using [AWS Lambda Console](https:
     ? Do you want to configure advanced settings? Yes
     ...
     ? Do you want to enable Lambda layers for this function? Yes
-    ? Enter up to 5 existing Lambda layer ARNs (comma-separated): arn:aws:lambda:eu-central-1:094274105915:layer:AWSLambdaPowertoolsTypeScript:3
+    ? Enter up to 5 existing Lambda layer ARNs (comma-separated): arn:aws:lambda:{aws::region}:094274105915:layer:AWSLambdaPowertoolsTypeScript:3
     ❯ amplify push -y
     # Updating an existing function and add the layer
     ❯ amplify update function
@@ -187,15 +184,13 @@ You can include Lambda Powertools Lambda Layer using [AWS Lambda Console](https:
     - Name: <NAME-OF-FUNCTION>
     ? Which setting do you want to update? Lambda layers configuration
     ? Do you want to enable Lambda layers for this function? Yes
-    ? Enter up to 5 existing Lambda layer ARNs (comma-separated): arn:aws:lambda:eu-central-1:094274105915:layer:AWSLambdaPowertoolsTypeScript:3
+    ? Enter up to 5 existing Lambda layer ARNs (comma-separated): arn:aws:lambda:{aws::region}:094274105915:layer:AWSLambdaPowertoolsTypeScript:3
     ? Do you want to edit the local lambda function now? No
     ```
 
 === "Get the Layer .zip contents"
-	Change `{region}` to your AWS region, e.g. `eu-west-1`
-
     ```bash title="AWS CLI"
-	aws lambda get-layer-version-by-arn --arn arn:aws:lambda:{region}:094274105915:layer:AWSLambdaPowertoolsTypeScript:3 --region {region}
+	  aws lambda get-layer-version-by-arn --arn arn:aws:lambda:{aws::region}:094274105915:layer:AWSLambdaPowertoolsTypeScript:3 --region {region}
     ```
 
     The pre-signed URL to download this Lambda Layer will be within `Location` key.
@@ -206,23 +201,23 @@ You can include Lambda Powertools Lambda Layer using [AWS Lambda Console](https:
 
 If you use `esbuild` to bundle your code, make sure to exclude `@aws-lambda-powertools`   from being bundled since the packages will be brought by the Layer:
 
-=== "SAM" (check the [doc](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-using-build-typescript.html) for more details)
+=== "SAM (check the [doc](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-using-build-typescript.html) for more details)"
 
     ```yaml hl_lines="5"
     MyLambdaFunction:
-        Type: AWS::Serverless::Function
-        Properties:
-            ...
-            Metadata: 
-              # Manage esbuild properties
-              BuildMethod: esbuild
-              BuildProperties:
-                Minify: true
-                External:
-                - '@aws-lambda-powertools/commons'
-                - '@aws-lambda-powertools/logger'
-                - '@aws-lambda-powertools/metrics'
-                - '@aws-lambda-powertools/tracer'
+      Type: AWS::Serverless::Function
+      Properties:
+        ...
+        Metadata: 
+          # Manage esbuild properties
+          BuildMethod: esbuild
+          BuildProperties:
+          Minify: true
+          External:
+            - '@aws-lambda-powertools/commons'
+            - '@aws-lambda-powertools/logger'
+            - '@aws-lambda-powertools/metrics'
+            - '@aws-lambda-powertools/tracer'
     ```
 
 === "Serverless framework (check the [doc](https://floydspace.github.io/serverless-esbuild/) for more details)"
@@ -240,17 +235,17 @@ If you use `esbuild` to bundle your code, make sure to exclude `@aws-lambda-powe
 === "CDK (check the [doc](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_lambda_nodejs.BundlingOptions.html#externalmodules) for more details)"
 
     ```typescript hl_lines="11 16"
-            new awsLambdaNodejs.NodejsFunction(this, 'Function', {
-              ...
-              bundling: {
-                externalModules: [
-                  '@aws-lambda-powertools/commons',
-                  '@aws-lambda-powertools/logger',
-                  '@aws-lambda-powertools/metrics',
-                  '@aws-lambda-powertools/tracer',
-                ],
-              }
-            });
+    new awsLambdaNodejs.NodejsFunction(this, 'Function', {
+      ...
+      bundling: {
+        externalModules: [
+          '@aws-lambda-powertools/commons',
+          '@aws-lambda-powertools/logger',
+          '@aws-lambda-powertools/metrics',
+          '@aws-lambda-powertools/tracer',
+        ],
+      }
+    });
     ```
 
 ### NPM Modules


### PR DESCRIPTION
## Description of your changes

This PR fixes some formatting/displaying issues around the layer section of the docs before the announcement.

It also fixes #1121.

### How to verify this change

Fix layers section:

![image](https://user-images.githubusercontent.com/7353869/196225624-adcd44b3-1da7-484a-b825-5ab41d58efa9.png)


Fix of #1121

![image](https://user-images.githubusercontent.com/7353869/196225545-7ea3e4c4-283d-4df6-b7c9-2ffb1793cf14.png)


### Related issues, RFCs

<!--- Add here the number (i.e. #42) to the Github Issue or RFC that is related to this PR. -->
<!--- If no issue is present the PR might get blocked and not be reviewed. -->
**Issue number:** #1121

### PR status

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
- [x] I have performed a *self-review* of my own code
- [ ] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [x] I have made corresponding changes to the *documentation*
- [ ] I have made corresponding changes to the *examples*
- [ ] My changes generate *no new warnings*
- [ ] The *code coverage* hasn't decreased
- [ ] I have *added tests* that prove my change is effective and works
- [ ] New and existing *unit tests pass* locally and in Github Actions
- [ ] Any *dependent changes have been merged and published* in downstream module
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

N/A

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
