### PR TITLE
docs(all): update & revise docstring examples

### DIFF
--- a/docs/core/tracer.md
+++ b/docs/core/tracer.md
@@ -75,7 +75,7 @@ The `Tracer` utility is instantiated outside of the Lambda handler. In doing thi
 
     // You can also pass the parameter in the constructor
     // const tracer = new Tracer({
-    //     serviceName: "serverlessAirline"
+    //     serviceName: 'serverlessAirline'
     // });
     ```
 
@@ -510,7 +510,7 @@ Tracer exposes a `getRootXrayTraceId()` method that allows you to retrieve the [
             return {
                 statusCode: 500,
                 body: `Internal Error - Please contact support and quote the following id: ${rootTraceId}`,
-                headers: { "_X_AMZN_TRACE_ID": rootTraceId },
+                headers: { '_X_AMZN_TRACE_ID': rootTraceId },
             };
         }
     };

--- a/packages/logger/src/Logger.ts
+++ b/packages/logger/src/Logger.ts
@@ -39,28 +39,12 @@ import type {
  *
  * @example
  * ```typescript
- * import { Logger } from "@aws-lambda-powertools/logger";
+ * import { Logger } from '@aws-lambda-powertools/logger';
  *
  * // Logger parameters fetched from the environment variables:
  * const logger = new Logger();
  * ```
- *
- * ### Functions usage with manual instrumentation
- *
- * If you prefer to manually instrument your Lambda handler you can use the methods in the Logger class directly.
- *
- * @example
- * ```typescript
- * import { Logger } from "@aws-lambda-powertools/logger";
- *
- * const logger = new Logger();
- *
- * export const handler = async (_event, context) => {
- *     logger.addContext(context);
- *     logger.info("This is an INFO log with some context");
- * };
- * ```
- *
+ * 
  * ### Functions usage with middleware
  *
  * If you use function-based Lambda handlers you can use the [injectLambdaContext()](#injectLambdaContext)
@@ -68,13 +52,13 @@ import type {
  *
  * @example
  * ```typescript
- * import { Logger, injectLambdaContext } from "@aws-lambda-powertools/logger";
+ * import { Logger, injectLambdaContext } from '@aws-lambda-powertools/logger';
  * import middy from '@middy/core';
  *
  * const logger = new Logger();
  *
  * const lambdaHandler = async (_event: any, _context: any) => {
- *     logger.info("This is an INFO log with some context");
+ *     logger.info('This is an INFO log with some context');
  * };
  *
  * export const handler = middy(lambdaHandler).use(injectLambdaContext(logger));
@@ -86,21 +70,40 @@ import type {
  *
  * @example
  * ```typescript
- * import { Logger } from "@aws-lambda-powertools/logger";
+ * import { Logger } from '@aws-lambda-powertools/logger';
  * import { LambdaInterface } from '@aws-lambda-powertools/commons';
  *
  * const logger = new Logger();
  *
  * class Lambda implements LambdaInterface {
+ * 
+ *   // FYI: Decorator might not render properly in VSCode mouse over due to https://github.com/microsoft/TypeScript/issues/47679 and might show as *@logger* instead of `@logger.injectLambdaContext`
+ * 
  *     // Decorate your handler class method
  *     @logger.injectLambdaContext()
  *     public async handler(_event: any, _context: any): Promise<void> {
- *         logger.info("This is an INFO log with some context");
+ *         logger.info('This is an INFO log with some context');
  *     }
  * }
  *
  * const handlerClass = new Lambda();
  * export const handler = handlerClass.handler.bind(handlerClass);
+ * ```
+ * 
+ * ### Functions usage with manual instrumentation
+ *
+ * If you prefer to manually instrument your Lambda handler you can use the methods in the Logger class directly.
+ *
+ * @example
+ * ```typescript
+ * import { Logger } from '@aws-lambda-powertools/logger';
+ *
+ * const logger = new Logger();
+ *
+ * export const handler = async (_event, context) => {
+ *     logger.addContext(context);
+ *     logger.info('This is an INFO log with some context');
+ * };
  * ```
  *
  * @class
@@ -269,9 +272,32 @@ class Logger extends Utility implements ClassThatLogs {
   /**
    * Method decorator that adds the current Lambda function context as extra
    * information in all log items.
+   * 
    * The decorator can be used only when attached to a Lambda function handler which
    * is written as method of a class, and should be declared just before the handler declaration.
    *
+   * Note: Currently TypeScript only supports decorators on classes and methods. If you are using the
+   * function syntax, you should use the middleware instead.
+   * 
+   * @example
+   * ```typescript
+   * import { Logger } from '@aws-lambda-powertools/logger';
+   * import { LambdaInterface } from '@aws-lambda-powertools/commons';
+   *
+   * const logger = new Logger();
+   *
+   * class Lambda implements LambdaInterface {
+   *     // Decorate your handler class method
+   *     @logger.injectLambdaContext()
+   *     public async handler(_event: any, _context: any): Promise<void> {
+   *         logger.info('This is an INFO log with some context');
+   *     }
+   * }
+   *
+   * const handlerClass = new Lambda();
+   * export const handler = handlerClass.handler.bind(handlerClass);
+   * ```
+   * 
    * @see https://www.typescriptlang.org/docs/handbook/decorators.html#method-decorators
    * @returns {HandlerMethodDecorator}
    */

--- a/packages/logger/src/middleware/middy.ts
+++ b/packages/logger/src/middleware/middy.ts
@@ -3,7 +3,7 @@ import type middy from '@middy/core';
 import { HandlerOptions, LogAttributes } from '../types';
 
 /**
- * A middy middleware that adds the current Lambda invocation's context inside all log items.
+ * A middy middleware that helps emitting CloudWatch EMF metrics in your logs.
  *
  * Using this middleware on your handler function will automatically add context information to logs, as well as optionally log the event and clear attributes set during the invocation.
  * 

--- a/packages/logger/src/middleware/middy.ts
+++ b/packages/logger/src/middleware/middy.ts
@@ -5,27 +5,26 @@ import { HandlerOptions, LogAttributes } from '../types';
 /**
  * A middy middleware that adds the current Lambda invocation's context inside all log items.
  *
- * ## Usage
- *
+ * Using this middleware on your handler function will automatically add context information to logs, as well as optionally log the event and clear attributes set during the invocation.
+ * 
  * @example
  * ```typescript
- * import { Logger, injectLambdaContext } from "@aws-lambda-powertools/logger";
- *
+ * import { Logger, injectLambdaContext } from '@aws-lambda-powertools/logger';
  * import middy from '@middy/core';
  *
  *
  * const logger = new Logger();
  *
  * const lambdaHandler = async (_event: any, _context: any) => {
- *     logger.info("This is an INFO log with some context");
+ *     logger.info('This is an INFO log with some context');
  * };
- *
  *
  * export const handler = middy(lambdaHandler).use(injectLambdaContext(logger));
  * ```
  *
- * @param {Logger|Logger[]} target - The Tracer instance to use for tracing
- * @returns {middy.MiddlewareObj} - The middy middleware object
+ * @param target - The Logger instance(s) to use for logging
+ * @param options - (_optional_) Options for the middleware
+ * @returns - The middy middleware object
  */
 const injectLambdaContext = (target: Logger | Logger[], options?: HandlerOptions): middy.MiddlewareObj => {
 

--- a/packages/metrics/src/middleware/middy.ts
+++ b/packages/metrics/src/middleware/middy.ts
@@ -2,6 +2,33 @@ import type { Metrics } from '../Metrics';
 import type middy from '@middy/core';
 import type { ExtraOptions } from '../types';
 
+/**
+ * A middy middleware automating capture of metadata and annotations on segments or subsegments for a Lambda Handler.
+ * 
+ * Using this middleware on your handler function will automatically flush metrics after the function returns or throws an error.
+ * Additionally, you can configure the middleware to easily:
+ * * ensure that at least one metric is emitted before you flush them
+ * * capture a `ColdStart` a metric
+ * * set default dimensions for all your metrics
+ * 
+ * @example
+ * ```typescript
+ * import { Metrics, logMetrics } from '@aws-lambda-powertools/metrics';
+ * import middy from '@middy/core';
+ * 
+ * const metrics = new Metrics({ namespace: 'serverlessAirline', serviceName: 'orders' });
+ * 
+ * const lambdaHandler = async (_event: any, _context: any) => {
+ *   ...
+ * };
+ * 
+ * export const handler = middy(lambdaHandler).use(logMetrics(metrics));
+ * ```
+ * 
+ * @param target - The Metrics instance to use for emitting metrics
+ * @param options - (_optional_) Options for the middleware
+ * @returns middleware - The middy middleware object
+ */
 const logMetrics = (target: Metrics | Metrics[], options: ExtraOptions = {}): middy.MiddlewareObj => {
   const metricsInstances = target instanceof Array ? target : [target];
 

--- a/packages/tracer/src/Tracer.ts
+++ b/packages/tracer/src/Tracer.ts
@@ -38,9 +38,11 @@ import { Segment, Subsegment } from 'aws-xray-sdk-core';
  * 
  * const tracer = new Tracer({ serviceName: 'serverlessAirline' });
  * 
- * export const handler = middy(async (_event: any, _context: any) => {
+* const lambdaHandler = async (_event: any, _context: any) => {
  *   ...
- * }).use(captureLambdaHandler(tracer));
+ * };
+ * 
+ * export const handler = middy(lambdaHandler).use(captureLambdaHandler(tracer));
  * ```
  * 
  * ### Object oriented usage with decorators
@@ -54,12 +56,13 @@ import { Segment, Subsegment } from 'aws-xray-sdk-core';
  * @example
  * ```typescript
  * import { Tracer } from '@aws-lambda-powertools/tracer';
+ * import { LambdaInterface } from '@aws-lambda-powertools/commons';
  * 
  * const tracer = new Tracer({ serviceName: 'serverlessAirline' });
  * 
- * // FYI: Decorator might not render properly in VSCode mouse over due to https://github.com/microsoft/TypeScript/issues/39371 and might show as *@tracer* instead of `@tracer.captureLambdaHandler`
+ * // FYI: Decorator might not render properly in VSCode mouse over due to https://github.com/microsoft/TypeScript/issues/47679 and might show as *@tracer* instead of `@tracer.captureLambdaHandler`
  * 
- * class Lambda {
+ * class Lambda implements LambdaInterface {
  *   @tracer.captureLambdaHandler()
  *   public handler(event: any, context: any) {
  *     ...
@@ -77,7 +80,6 @@ import { Segment, Subsegment } from 'aws-xray-sdk-core';
  * @example
  * ```typescript
  * import { Tracer } from '@aws-lambda-powertools/tracer';
- * import { Segment } from 'aws-xray-sdk-core';
  * 
  * const tracer = new Tracer({ serviceName: 'serverlessAirline' });
  * 
@@ -93,7 +95,7 @@ import { Segment, Subsegment } from 'aws-xray-sdk-core';
  *
  *   let res;
  *   try {
- *       res = ...
+ *       // ... your own logic goes here
  *       // Add the response as metadata 
  *       tracer.addResponseAsMetadata(res, process.env._HANDLER);
  *   } catch (err) {
@@ -245,11 +247,11 @@ class Tracer extends Utility implements TracerInterface {
    * 
    * @example
    * ```typescript
-   * import { S3 } from "aws-sdk";
+   * import { S3 } from 'aws-sdk';
    * import { Tracer } from '@aws-lambda-powertools/tracer';
    * 
    * const tracer = new Tracer({ serviceName: 'serverlessAirline' });
-   * const s3 = tracer.captureAWSClient(new S3({ apiVersion: "2006-03-01" }));
+   * const s3 = tracer.captureAWSClient(new S3({ apiVersion: '2006-03-01' }));
    * 
    * export const handler = async (_event: any, _context: any) => {
    *   ...
@@ -287,7 +289,7 @@ class Tracer extends Utility implements TracerInterface {
    * 
    * @example
    * ```typescript
-   * import { S3Client } from "@aws-sdk/client-s3";
+   * import { S3Client } from '@aws-sdk/client-s3';
    * import { Tracer } from '@aws-lambda-powertools/tracer';
    * 
    * const tracer = new Tracer({ serviceName: 'serverlessAirline' });
@@ -323,10 +325,11 @@ class Tracer extends Utility implements TracerInterface {
    * @example
    * ```typescript
    * import { Tracer } from '@aws-lambda-powertools/tracer';
+   * import { LambdaInterface } from '@aws-lambda-powertools/commons';
    * 
    * const tracer = new Tracer({ serviceName: 'serverlessAirline' });
    * 
-   * class Lambda {
+   * class Lambda implements LambdaInterface {
    *   @tracer.captureLambdaHandler()
    *   public handler(event: any, context: any) {
    *     ...
@@ -400,10 +403,11 @@ class Tracer extends Utility implements TracerInterface {
    * @example
    * ```typescript
    * import { Tracer } from '@aws-lambda-powertools/tracer';
+   * import { LambdaInterface } from '@aws-lambda-powertools/commons';
    * 
    * const tracer = new Tracer({ serviceName: 'serverlessAirline' });
    * 
-   * class Lambda {
+   * class Lambda implements LambdaInterface {
    *   @tracer.captureMethod()
    *   public myMethod(param: any) {
    *     ...
@@ -477,7 +481,6 @@ class Tracer extends Utility implements TracerInterface {
    * const tracer = new Tracer({ serviceName: 'serverlessAirline' });
    * 
    * export const handler = async () => {
-   * 
    *   try {
    *     ...
    *   } catch (err) {
@@ -489,7 +492,7 @@ class Tracer extends Utility implements TracerInterface {
    *       // Include the rootTraceId in the response so we can show a "contact support" button that
    *       // takes the customer to a customer service form with the trace as additional context.
    *       body: `Internal Error - Please contact support and quote the following id: ${rootTraceId}`,
-   *       headers: { "_X_AMZN_TRACE_ID": rootTraceId },
+   *       headers: { '_X_AMZN_TRACE_ID': rootTraceId },
    *     };
    *   }
    * }
@@ -623,7 +626,7 @@ class Tracer extends Utility implements TracerInterface {
    * @example
    * ```typescript
    * import { Tracer } from '@aws-lambda-powertools/tracer';
-   * import { Segment } from 'aws-xray-sdk-core';
+   * import { Subsegment } from 'aws-xray-sdk-core';
    * 
    * const tracer = new Tracer({ serviceName: 'serverlessAirline' });
    * 

--- a/packages/tracer/src/middleware/middy.ts
+++ b/packages/tracer/src/middleware/middy.ts
@@ -19,14 +19,16 @@ import type { CaptureLambdaHandlerOptions } from '../types';
  * 
  * const tracer = new Tracer({ serviceName: 'serverlessAirline' });
  * 
- * export const handler = middy(async (_event: any, _context: any) => {
+ * const lambdaHandler = async (_event: any, _context: any) => {
  *   ...
- * }).use(captureLambdaHandler(tracer));
+ * };
+ * 
+ * export const handler = middy(lambdaHandler).use(captureLambdaHandler(tracer));
  * ```
  * 
  * @param target - The Tracer instance to use for tracing
  * @param options - (_optional_) Options for the middleware
- * @returns middleware object - The middy middleware object
+ * @returns middleware - The middy middleware object
  */
 const captureLambdaHandler = (target: Tracer, options?: CaptureLambdaHandlerOptions): middy.MiddlewareObj => {
   let lambdaSegment: Subsegment | Segment;


### PR DESCRIPTION
## Description of your changes

Following the report in #1142 a community member highlighted the fact that some examples in the docstrings of the packages (mainly Tracer) were inconsistent with the ones in the published documentation.

In response to the issue I went through the examples and checked that they were appropriate and consistent, this PR contains the changes related to this review.

Changes:
- Added middleware example to Metrics
- Standardized order of usages in main docstring: middleware, decorator, manual
- Cleaned up imports
- Standardized usage of single quotes 

### How to verify this change

Check diff.

### Related issues, RFCs

<!--- Add here the number (i.e. #42) to the Github Issue or RFC that is related to this PR. -->
<!--- If no issue is present the PR might get blocked and not be reviewed. -->
**Issue number:** #1142 

### PR status

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [x] I have made corresponding changes to the *documentation*
- [ ] I have made corresponding changes to the *examples*
- [x] My changes generate *no new warnings*
- [x] The *code coverage* hasn't decreased
- [ ] I have *added tests* that prove my change is effective and works
- [x] New and existing *unit tests pass* locally and in Github Actions
- [ ] Any *dependent changes have been merged and published* in downstream module
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

N/A

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
