### PR TITLE
fix(metrics): store service name in defaultDimensions to avoid clearing it

### DIFF
--- a/packages/metrics/src/Metrics.ts
+++ b/packages/metrics/src/Metrics.ts
@@ -177,8 +177,8 @@ class Metrics extends Utility implements MetricsInterface {
     if (!this.isColdStart()) return;
     const singleMetric = this.singleMetric();
 
-    if (this.dimensions.service) {
-      singleMetric.addDimension('service', this.dimensions.service);
+    if (this.defaultDimensions.service) {
+      singleMetric.setDefaultDimensions({ service: this.defaultDimensions.service });
     }
     if (this.functionName != null) {
       singleMetric.addDimension('function_name', this.functionName);

--- a/packages/metrics/src/Metrics.ts
+++ b/packages/metrics/src/Metrics.ts
@@ -455,7 +455,7 @@ class Metrics extends Utility implements MetricsInterface {
       this.getCustomConfigService()?.getServiceName() ||
       this.getEnvVarsService().getServiceName()) as string;
     if (targetService.length > 0) {
-      this.addDimension('service', targetService);
+      this.setDefaultDimensions({ service: targetService });
     }
   }
 

--- a/packages/metrics/tests/unit/middleware/middy.test.ts
+++ b/packages/metrics/tests/unit/middleware/middy.test.ts
@@ -247,14 +247,14 @@ describe('Middy middleware', () => {
             CloudWatchMetrics: [
               {
                 Namespace: 'serverlessAirline',
-                Dimensions: [[ 'environment', 'aws_region', 'service', 'function_name' ]],
+                Dimensions: [[ 'service', 'environment', 'aws_region', 'function_name' ]],
                 Metrics: [{ Name: 'ColdStart', Unit: 'Count' }],
               },
             ],
           },
+          service: 'orders',
           environment: 'prod',
           aws_region: 'eu-west-1',
-          service: 'orders',
           function_name: 'foo-bar-function',
           ColdStart: 1,
         })
@@ -267,14 +267,14 @@ describe('Middy middleware', () => {
             CloudWatchMetrics: [
               {
                 Namespace: 'serverlessAirline',
-                Dimensions: [[ 'environment', 'aws_region', 'service' ]],
+                Dimensions: [[ 'service', 'environment', 'aws_region' ]],
                 Metrics: [{ Name: 'successfulBooking', Unit: 'Count' }],
               },
             ],
           },
+          service: 'orders',
           environment: 'prod',
           aws_region: 'eu-west-1',
-          service: 'orders',
           successfulBooking: 1,
         })
       );


### PR DESCRIPTION
## Description of your changes

As described in #1145, `v1.4.0` highlighted a bug that causes the service name to be cleared from metrics after flushing. 

The issue contains examples of the behavior and proposes a fix which has been implemented in this PR.

### How to verify this change

See checks in PR.

### Related issues, RFCs

<!--- Add here the number (i.e. #42) to the Github Issue or RFC that is related to this PR. -->
<!--- If no issue is present the PR might get blocked and not be reviewed. -->
**Issue number:** #1145 

### PR status

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [ ] I have made corresponding changes to the *documentation*
- [ ] I have made corresponding changes to the *examples*
- [x] My changes generate *no new warnings*
- [x] The *code coverage* hasn't decreased
- [ ] I have *added tests* that prove my change is effective and works
- [x] New and existing *unit tests pass* locally and in Github Actions
- [ ] Any *dependent changes have been merged and published* in downstream module
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

N/A

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
