### PR TITLE
chore(layer): reduce size by 3 by removing @types packages

### DIFF
--- a/layer-publisher/src/powertools-typescript-layer.ts
+++ b/layer-publisher/src/powertools-typescript-layer.ts
@@ -30,6 +30,7 @@ export class PowerToolsTypeScriptLayer extends lambda.LayerVersion {
         @aws-lambda-powertools/logger@${version} \
         @aws-lambda-powertools/metrics@${version} \
         @aws-lambda-powertools/tracer@${version}`,
+      'rm -rf node_modules/@types',
       'rm package.json package-lock.json',
     ];
     const commandJoined = commands.join(' && ');


### PR DESCRIPTION
Current bundling of lambda layer is including all dependencies from downstream dependencies including `@types/node` brought in especially by `aws-x-ray-sdk-core` -> `cjs-hooked`.

<img width="969" alt="https://npmgraph.js.org/?q=%40aws-lambda-powertools%2Ftracer" src="https://user-images.githubusercontent.com/1225809/203499171-e54c28a0-1526-43d3-b79d-c9b56aa74d75.png">

## Description of your changes

Simply manually removing `@types` from folder before zipping.

### How to verify this change

It is not breaking layer capabilities: https://github.com/awslabs/aws-lambda-powertools-typescript/actions/runs/3530267827

You can manually verify the improvment by deploying the layer to your own account (`cd layer-publisher && cdk deploy`) and check either the `cdk.out/assets` or download the published layer from AWS Console.

### Related issues, RFCs

**Issue number:**  #1171

### PR status

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-typescript/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [x] I have made corresponding changes to the *documentation*
- [x] I have made corresponding changes to the *examples*
- [x] My changes generate *no new warnings*
- [x] The *code coverage* hasn't decreased
- [x] I have *added tests* that prove my change is effective and works
- [x] New and existing *unit tests pass* locally and in Github Actions
- [x] Any *dependent changes have been merged and published*
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

- [x] I have documented the migration process
- [x] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
