### PR TITLE
chore: add install step in docs workflow

### DIFF
--- a/.github/workflows/reusable-publish-docs.yml
+++ b/.github/workflows/reusable-publish-docs.yml
@@ -48,9 +48,16 @@ jobs:
         with:
           path: "./node_modules"
           key: 16-cache-utils-node-modules-${{ hashFiles('./package-lock.json') }}
-      # Here we assume that there will always be a cache hit because this workflow can be triggered
-      # only after tests have already happened on this same code
+      - name: Install dependencies
+        # We can skip the installation if there was a cache hit
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
+        # See https://github.com/npm/cli/issues/4475 to see why --foreground-scripts
+        run: npm ci --foreground-scripts
       - name: Build packages
+        # If there's a cache hit we still need to manually build the packages
+        # this would otherwise have been done automatically as a part of the
+        # post-install npm hook
+        if: steps.cache-node-modules.outputs.cache-hit == 'true'
         run: |
           npm run build -w packages/commons
           npm run build -w packages/logger & npm run build -w packages/tracer & npm run build -w packages/metrics

--- a/packages/idempotency/package.json
+++ b/packages/idempotency/package.json
@@ -30,7 +30,7 @@
   "license": "MIT",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
-  "typedocMain": "src/index.ts",
+  "typedocMain": "src/file_that_does_not_exist_so_its_ignored_from_api_docs.ts",
   "files": [
     "lib"
   ],

--- a/packages/parameters/package.json
+++ b/packages/parameters/package.json
@@ -30,6 +30,7 @@
   "license": "MIT-0",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
+  "typedocMain": "src/file_that_does_not_exist_so_its_ignored_from_api_docs.ts",
   "files": [
     "lib"
   ],


### PR DESCRIPTION
<!--- 1. Make sure you follow our Contributing Guidelines: https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/CONTRIBUTING.md -->
<!--- 2. Please follow the template, and do not remove any section in the template. If something is not applicable leave it empty, but leave it in the PR. -->

## Description of your changes

This PR reintroduces an install step in the workflow that publishes the docs, which [is currently failing](https://github.com/awslabs/aws-lambda-powertools-typescript/actions/runs/3541373134).

### How to verify this change

Check the workflow outputs after merging.

### Related issues, RFCs

<!--- Add here the number (i.e. #42) to the Github Issue or RFC that is related to this PR. -->
<!--- If no issue is present the PR might get blocked and not be reviewed. -->
**Issue number:** #1182

### PR status

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-typescript/#tenets)
- [x] I have performed a *self-review* of my own code
- [ ] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [ ] I have made corresponding changes to the *documentation*
- [ ] I have made corresponding changes to the *examples*
- [ ] My changes generate *no new warnings*
- [ ] The *code coverage* hasn't decreased
- [ ] I have *added tests* that prove my change is effective and works
- [ ] New and existing *unit tests pass* locally and in Github Actions
- [ ] Any *dependent changes have been merged and published*
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

- [ ] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
