### PR TITLE
docs: added Node.js 12 deprecation banner to docs

### DIFF
--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -6,3 +6,12 @@ You're not viewing the latest version.
   <strong>Click here to go to latest.</strong>
 </a>
 {% endblock %}
+
+{% block announce %}
+Version 1.5.0 will be the last version to support Node.js 12. <br /> Node.js 12 has reached end-of-life and the
+corresponding
+AWS Lambda runtime will be deprecated at the end of March 2023. Please upgrade to Node.js 14 or later.<br />
+<a href="https://github.com/awslabs/aws-lambda-powertools-typescript/issues/1061#issuecomment-1349031362"
+  target="_blank">Click here to read the full announcement</a>, or <a href="https://discord.gg/B8zZKbbyET"
+  target="_blank">join our Discord server</a> to chime in the discussion.
+{% endblock %}


### PR DESCRIPTION
<!--- 1. Make sure you follow our Contributing Guidelines: https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/CONTRIBUTING.md -->
<!--- 2. Please follow the template, and do not remove any section in the template. If something is not applicable leave it empty, but leave it in the PR. -->

## Description of your changes

This PR introduces a banner at the top of the documentation website to inform customers that `v1.5.0` will be the last version that supports Nodejs 12 and the `nodejs12.x` AWS Lambda runtime. While we don't have a date scheduled for the next release, I don't expect there to be any release before Jan 2023 (over 2weeks away).

In addition to the banner, I have left a longer comment in the linked issue and made an announcement on the Discord server, as well as Twitter.

### How to verify this change

See docs local preview or published docs after merge.

### Related issues, RFCs

<!--- Add here the number (i.e. #42) to the Github Issue or RFC that is related to this PR. -->
<!--- If no issue is present the PR might get blocked and not be reviewed. -->
**Issue number:** #1061

### PR status

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-typescript/#tenets)
- [x] I have performed a *self-review* of my own code
- [ ] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [x] I have made corresponding changes to the *documentation*
- [ ] I have made corresponding changes to the *examples*
- [ ] My changes generate *no new warnings*
- [ ] The *code coverage* hasn't decreased
- [ ] I have *added tests* that prove my change is effective and works
- [ ] New and existing *unit tests pass* locally and in Github Actions
- [ ] Any *dependent changes have been merged and published*
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

- [ ] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
