### PR TITLE
chore: end of support for nodejs12x runtime

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # See here for image contents: https://github.com/microsoft/vscode-dev-containers/blob/v0.212.0/containers/javascript-node/.devcontainer/base.Dockerfile
-# [Choice] Node.js version (use -bullseye variants on local arm64/Apple Silicon): 16, 14, 12, 16-bullseye, 14-bullseye, 12-bullseye, 16-buster, 14-buster, 12-buster
+# [Choice] Node.js version (use -bullseye variants on local arm64/Apple Silicon): 16, 14, 16-bullseye, 14-bullseye, 16-buster, 14-buster
 ARG VARIANT="16-bullseye"
 FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:0-${VARIANT}
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
   "name": "Node.js",
   "build": {
     "dockerfile": "Dockerfile",
-    // Update 'VARIANT' to pick a Node version: 16, 14, 12.
+    // Update 'VARIANT' to pick a Node version: 16, 14.
     // Append -bullseye or -buster to pin to an OS version.
     // Use -bullseye variants on local arm64/Apple Silicon.
     "args": {

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -58,7 +58,6 @@ body:
     attributes:
       label: AWS Lambda function runtime
       options:
-        - 12.x
         - 14.x
         - 16.x
     validations:

--- a/.github/workflows/reusable-run-linting-check-and-unit-tests.yml
+++ b/.github/workflows/reusable-run-linting-check-and-unit-tests.yml
@@ -10,7 +10,7 @@ jobs:
       NODE_ENV: dev
     strategy:
       matrix:
-        version: [12, 14, 16]
+        version: [14, 16]
       fail-fast: false
     steps:
       - name: Checkout code

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         package: [logger, metrics, tracer]
-        version: [12, 14, 16]
+        version: [14, 16]
       fail-fast: false
     steps:
       - name: Checkout Repo
@@ -70,7 +70,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [12, 14, 16]
+        version: [14, 16]
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3

--- a/layer-publisher/src/powertools-typescript-layer.ts
+++ b/layer-publisher/src/powertools-typescript-layer.ts
@@ -38,11 +38,11 @@ export class PowerToolsTypeScriptLayer extends lambda.LayerVersion {
     super(scope, id, {
       layerVersionName: props?.layerVersionName,
       description: `Lambda Powertools for TypeScript version ${props?.version}`,
-      compatibleRuntimes: [ lambda.Runtime.NODEJS_12_X, lambda.Runtime.NODEJS_14_X, lambda.Runtime.NODEJS_16_X ],
+      compatibleRuntimes: [ lambda.Runtime.NODEJS_14_X, lambda.Runtime.NODEJS_16_X ],
       code: lambda.Code.fromAsset(path.join(__dirname, '.'), {
         assetHash: Md5.hashStr(commandJoined),
         bundling: {
-          image: lambda.Runtime.NODEJS_12_X.bundlingImage,
+          image: lambda.Runtime.NODEJS_14_X.bundlingImage,
           local: {
             tryBundle(outputDir: string) {
               try {

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "lib/**/*"
   ],
   "engines": {
-    "node": ">=12"
+    "node": ">=14"
   },
   "dependencies": {
     "hosted-git-info": "^5.0.0"

--- a/packages/commons/tests/utils/e2eUtils.ts
+++ b/packages/commons/tests/utils/e2eUtils.ts
@@ -14,10 +14,9 @@ import { InvocationLogs } from './InvocationLogs';
 
 const lambdaClient = new AWS.Lambda();
 
-const testRuntimeKeys = [ 'nodejs12x', 'nodejs14x', 'nodejs16x' ];
+const testRuntimeKeys = [ 'nodejs14x', 'nodejs16x' ];
 export type TestRuntimesKey = typeof testRuntimeKeys[number];
 export const TEST_RUNTIMES: Record<TestRuntimesKey, Runtime> = {
-  nodejs12x: Runtime.NODEJS_12_X,
   nodejs14x: Runtime.NODEJS_14_X,
   nodejs16x: Runtime.NODEJS_16_X,
 };

--- a/packages/commons/tsconfig-dev.json
+++ b/packages/commons/tsconfig-dev.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "experimentalDecorators": true,
         "noImplicitAny": true,
-        "target": "ES2019",
+        "target": "ES2020",
         "module": "commonjs",
         "declaration": true,
         "declarationMap": true,
@@ -23,7 +23,7 @@
         "watchDirectory": "useFsEvents",
         "fallbackPolling": "dynamicPriority"
     },
-    "lib": [ "es2019" ],
+    "lib": [ "es2020" ],
     "types": [
         "jest",
         "node"

--- a/packages/commons/tsconfig.json
+++ b/packages/commons/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "experimentalDecorators": true,
         "noImplicitAny": true,
-        "target": "ES2019",
+        "target": "ES2020",
         "module": "commonjs",
         "declaration": true,
         "declarationMap": true,
@@ -23,7 +23,7 @@
         "watchDirectory": "useFsEvents",
         "fallbackPolling": "dynamicPriority"
     },
-    "lib": [ "es2019" ],
+    "lib": [ "es2020" ],
     "types": [
         "jest",
         "node"

--- a/packages/idempotency/package.json
+++ b/packages/idempotency/package.json
@@ -13,7 +13,6 @@
     "commit": "commit",
     "test": "npm run test:unit",
     "test:unit": "jest --group=unit --detectOpenHandles --coverage --verbose",
-    "test:e2e:nodejs12x": "echo \"Not implemented\"",
     "test:e2e:nodejs14x": "echo \"Not implemented\"",
     "test:e2e:nodejs16x": "echo \"Not implemented\"",
     "test:e2e": "echo \"Not implemented\"",

--- a/packages/idempotency/tsconfig.json
+++ b/packages/idempotency/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "experimentalDecorators": true,
         "noImplicitAny": true,
-        "target": "ES2019",
+        "target": "ES2020",
         "module": "commonjs",
         "declaration": true,
         "outDir": "lib",
@@ -22,7 +22,7 @@
         "watchDirectory": "useFsEvents",
         "fallbackPolling": "dynamicPriority"
     },
-    "lib": [ "es2019" ],
+    "lib": [ "es2020" ],
     "types": [
         "node"
     ]

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -13,7 +13,6 @@
     "commit": "commit",
     "test": "npm run test:unit",
     "test:unit": "jest --group=unit --detectOpenHandles --coverage --verbose",
-    "test:e2e:nodejs12x": "RUNTIME=nodejs12x jest --group=e2e",
     "test:e2e:nodejs14x": "RUNTIME=nodejs14x jest --group=e2e",
     "test:e2e:nodejs16x": "RUNTIME=nodejs16x jest --group=e2e",
     "test:e2e": "jest --group=e2e",

--- a/packages/logger/src/Logger.ts
+++ b/packages/logger/src/Logger.ts
@@ -316,7 +316,8 @@ class Logger extends Utility implements ClassThatLogs {
       /**
        * The descriptor.value is the method this decorator decorates, it cannot be undefined.
        */
-      const originalMethod = descriptor.value;
+      /* eslint-disable  @typescript-eslint/no-non-null-assertion */
+      const originalMethod = descriptor.value!;
 
       // eslint-disable-next-line @typescript-eslint/no-this-alias
       const loggerRef = this;
@@ -331,10 +332,9 @@ class Logger extends Utility implements ClassThatLogs {
 
         Logger.injectLambdaContextBefore(loggerRef, event, context, options);
 
-        /* eslint-disable  @typescript-eslint/no-non-null-assertion */
         let result: unknown;
         try {
-          result = await originalMethod!.apply(this, [ event, context, callback ]);
+          result = await originalMethod.apply(this, [ event, context, callback ]);
         } catch (error) {
           throw error;
         } finally {

--- a/packages/logger/tsconfig-dev.json
+++ b/packages/logger/tsconfig-dev.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "experimentalDecorators": true,
         "noImplicitAny": true,
-        "target": "ES2019",
+        "target": "ES2020",
         "module": "commonjs",
         "declaration": true,
         "declarationMap": true,
@@ -22,7 +22,7 @@
         "watchDirectory": "useFsEvents",
         "fallbackPolling": "dynamicPriority"
     },
-    "lib": [ "es2019" ],
+    "lib": [ "es2020" ],
     "types": [
         "jest",
         "node"

--- a/packages/logger/tsconfig.es.json
+++ b/packages/logger/tsconfig.es.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "experimentalDecorators": true,
         "noImplicitAny": true,
-        "target": "ES2019",
+        "target": "ES2020",
         "module": "commonjs",
         "declaration": true,
         "declarationMap": true,
@@ -22,7 +22,7 @@
         "watchDirectory": "useFsEvents",
         "fallbackPolling": "dynamicPriority"
     },
-    "lib": [ "es2019" ],
+    "lib": [ "es2020" ],
     "types": [
         "jest",
         "node"

--- a/packages/logger/tsconfig.json
+++ b/packages/logger/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "experimentalDecorators": true,
         "noImplicitAny": true,
-        "target": "ES2019",
+        "target": "ES2020",
         "module": "commonjs",
         "declaration": true,
         "outDir": "lib",
@@ -22,7 +22,7 @@
         "watchDirectory": "useFsEvents",
         "fallbackPolling": "dynamicPriority"
     },
-    "lib": [ "es2019" ],
+    "lib": [ "es2020" ],
     "types": [
         "jest",
         "node"

--- a/packages/metrics/package.json
+++ b/packages/metrics/package.json
@@ -13,7 +13,6 @@
     "commit": "commit",
     "test": "npm run test:unit",
     "test:unit": "jest --group=unit --detectOpenHandles --coverage --verbose",
-    "test:e2e:nodejs12x": "RUNTIME=nodejs12x jest --group=e2e",
     "test:e2e:nodejs14x": "RUNTIME=nodejs14x jest --group=e2e",
     "test:e2e:nodejs16x": "RUNTIME=nodejs16x jest --group=e2e",
     "test:e2e": "jest --group=e2e",

--- a/packages/metrics/tsconfig.es.json
+++ b/packages/metrics/tsconfig.es.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "experimentalDecorators": true,
         "noImplicitAny": true,
-        "target": "ES2019",
+        "target": "ES2020",
         "module": "commonjs",
         "declaration": true,
         "declarationMap": true,
@@ -23,7 +23,7 @@
         "watchDirectory": "useFsEvents",
         "fallbackPolling": "dynamicPriority"
     },
-    "lib": [ "es2019" ],
+    "lib": [ "es2020" ],
     "types": [
         "jest",
         "node"

--- a/packages/metrics/tsconfig.json
+++ b/packages/metrics/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "experimentalDecorators": true,
         "noImplicitAny": true,
-        "target": "ES2019",
+        "target": "ES2020",
         "module": "commonjs",
         "declaration": true,
         "declarationMap": true,
@@ -24,7 +24,7 @@
         "watchDirectory": "useFsEvents",
         "fallbackPolling": "dynamicPriority"
     },
-    "lib": [ "es2019" ],
+    "lib": [ "es2020" ],
     "types": [
         "jest",
         "node"

--- a/packages/parameters/package.json
+++ b/packages/parameters/package.json
@@ -13,7 +13,6 @@
     "commit": "commit",
     "test": "npm run test:unit",
     "test:unit": "jest --group=unit --detectOpenHandles --coverage --verbose",
-    "test:e2e:nodejs12x": "echo \"Not implemented\"",
     "test:e2e:nodejs14x": "echo \"Not implemented\"",
     "test:e2e:nodejs16x": "echo \"Not implemented\"",
     "test:e2e": "echo \"Not implemented\"",

--- a/packages/parameters/tsconfig-dev.json
+++ b/packages/parameters/tsconfig-dev.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "experimentalDecorators": true,
         "noImplicitAny": true,
-        "target": "ES2019",
+        "target": "ES2020",
         "module": "commonjs",
         "declaration": true,
         "declarationMap": true,
@@ -22,7 +22,7 @@
         "watchDirectory": "useFsEvents",
         "fallbackPolling": "dynamicPriority"
     },
-    "lib": [ "es2019" ],
+    "lib": [ "es2020" ],
     "types": [
         "jest",
         "node"

--- a/packages/parameters/tsconfig.es.json
+++ b/packages/parameters/tsconfig.es.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "experimentalDecorators": true,
         "noImplicitAny": true,
-        "target": "ES2019",
+        "target": "ES2020",
         "module": "commonjs",
         "declaration": true,
         "declarationMap": true,
@@ -22,7 +22,7 @@
         "watchDirectory": "useFsEvents",
         "fallbackPolling": "dynamicPriority"
     },
-    "lib": [ "es2019" ],
+    "lib": [ "es2020" ],
     "types": [
         "jest",
         "node"

--- a/packages/parameters/tsconfig.json
+++ b/packages/parameters/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "experimentalDecorators": true,
         "noImplicitAny": true,
-        "target": "ES2019",
+        "target": "ES2020",
         "module": "commonjs",
         "declaration": true,
         "outDir": "lib",
@@ -22,7 +22,7 @@
         "watchDirectory": "useFsEvents",
         "fallbackPolling": "dynamicPriority"
     },
-    "lib": [ "es2019" ],
+    "lib": [ "es2020" ],
     "types": [
         "jest",
         "node"

--- a/packages/tracer/package.json
+++ b/packages/tracer/package.json
@@ -13,7 +13,6 @@
     "commit": "commit",
     "test": "npm run test:unit",
     "test:unit": "jest --group=unit --detectOpenHandles --coverage --verbose",
-    "test:e2e:nodejs12x": "RUNTIME=nodejs12x jest --group=e2e",
     "test:e2e:nodejs14x": "RUNTIME=nodejs14x jest --group=e2e",
     "test:e2e:nodejs16x": "RUNTIME=nodejs16x jest --group=e2e",
     "test:e2e": "jest --group=e2e",

--- a/packages/tracer/tsconfig.es.json
+++ b/packages/tracer/tsconfig.es.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "experimentalDecorators": true,
         "noImplicitAny": true,
-        "target": "ES2019",
+        "target": "ES2020",
         "module": "commonjs",
         "declaration": true,
         "declarationMap": true,
@@ -23,7 +23,7 @@
         "watchDirectory": "useFsEvents",
         "fallbackPolling": "dynamicPriority"
     },
-    "lib": [ "es2019" ],
+    "lib": [ "es2020" ],
     "types": [
         "jest",
         "node"

--- a/packages/tracer/tsconfig.json
+++ b/packages/tracer/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "experimentalDecorators": true,
         "noImplicitAny": true,
-        "target": "ES2019",
+        "target": "ES2020",
         "module": "commonjs",
         "declaration": true,
         "declarationMap": true,
@@ -24,7 +24,7 @@
         "watchDirectory": "useFsEvents",
         "fallbackPolling": "dynamicPriority"
     },
-    "lib": [ "es2019" ],
+    "lib": [ "es2020" ],
     "types": [
         "jest",
         "node"


### PR DESCRIPTION
<!--- 1. Make sure you follow our Contributing Guidelines: https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/CONTRIBUTING.md -->
<!--- 2. Please follow the template, and do not remove any section in the template. If something is not applicable leave it empty, but leave it in the PR. -->

## Description of your changes

This PR removes support for Node.js 12. This includes the following changes:
- Update config files fro GitHub CodeSpaces & GitPod
- Remove runtime from the test matrixes in CI/CD workflows 
- Remove runtime from compatible layers
- Change engine value in `package.json` to >=14
- Remove related commands from utilities' `package.json` files

Find more info on the deprecation in the linked issue (#1061).

### How to verify this change

Review diff, check results of unit tests, and integration tests (see comment below).

### Related issues, RFCs

<!--- Add here the number (i.e. #42) to the Github Issue or RFC that is related to this PR. -->
<!--- If no issue is present the PR might get blocked and not be reviewed. -->
**Issue number:** #1061 

### PR status

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-typescript/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [ ] I have made corresponding changes to the *documentation*
- [ ] I have made corresponding changes to the *examples*
- [ ] My changes generate *no new warnings*
- [ ] The *code coverage* hasn't decreased
- [ ] I have *added tests* that prove my change is effective and works
- [ ] New and existing *unit tests pass* locally and in Github Actions
- [ ] Any *dependent changes have been merged and published*
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

- [ ] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
