### PR TITLE
chore: remove httpbinorg request from integration tests

### DIFF
--- a/packages/tracer/tests/e2e/allFeatures.decorator.test.functionCode.ts
+++ b/packages/tracer/tests/e2e/allFeatures.decorator.test.functionCode.ts
@@ -58,7 +58,7 @@ export class MyFunctionBase {
     return Promise.all([
       dynamoDBv2.put({ TableName: testTableName, Item: { id: `${serviceName}-${event.invocation}-sdkv2` } }).promise(),
       dynamoDBv3.send(new PutItemCommand({ TableName: testTableName, Item: { id: { 'S': `${serviceName}-${event.invocation}-sdkv3` } } })),
-      axios.get('https://httpbin.org/status/200'),
+      axios.get('https://awslabs.github.io/aws-lambda-powertools-typescript/latest/'),
       new Promise((resolve, reject) => {
         setTimeout(() => {
           const res = this.myMethod();

--- a/packages/tracer/tests/e2e/allFeatures.decorator.test.functionCode.ts
+++ b/packages/tracer/tests/e2e/allFeatures.decorator.test.functionCode.ts
@@ -58,7 +58,7 @@ export class MyFunctionBase {
     return Promise.all([
       dynamoDBv2.put({ TableName: testTableName, Item: { id: `${serviceName}-${event.invocation}-sdkv2` } }).promise(),
       dynamoDBv3.send(new PutItemCommand({ TableName: testTableName, Item: { id: { 'S': `${serviceName}-${event.invocation}-sdkv3` } } })),
-      axios.get('https://awslabs.github.io/aws-lambda-powertools-typescript/latest/'),
+      axios.get('https://awslabs.github.io/aws-lambda-powertools-typescript/latest/', { timeout: 5000 }),
       new Promise((resolve, reject) => {
         setTimeout(() => {
           const res = this.myMethod();

--- a/packages/tracer/tests/e2e/allFeatures.decorator.test.ts
+++ b/packages/tracer/tests/e2e/allFeatures.decorator.test.ts
@@ -206,7 +206,7 @@ describe(`Tracer E2E tests, all features with decorator instantiation for runtim
        * 2. Lambda Function (AWS::Lambda::Function)
        * 3. DynamoDB (AWS::DynamoDB)
        * 4. DynamoDB Table (AWS::DynamoDB::Table)
-       * 5. Remote call (httpbin.org)
+       * 5. Remote call (awslabs.github.io)
        */
       expect(trace.Segments.length).toBe(5);
       const invocationSubsegment = getInvocationSubsegment(trace);
@@ -216,7 +216,7 @@ describe(`Tracer E2E tests, all features with decorator instantiation for runtim
        * '## index.handler' subsegment should have 4 subsegments
        * 1. DynamoDB (PutItem on the table)
        * 2. DynamoDB (PutItem overhead)
-       * 3. httpbin.org (Remote call)
+       * 3. awslabs.github.io (Remote call)
        * 4. '### myMethod' (method decorator)
        */
       const handlerSubsegment = getFirstSubsegment(invocationSubsegment);
@@ -226,9 +226,9 @@ describe(`Tracer E2E tests, all features with decorator instantiation for runtim
       if (!handlerSubsegment.subsegments) {
         fail('"## index.handler" subsegment should have subsegments');
       }
-      const subsegments = splitSegmentsByName(handlerSubsegment.subsegments, [ 'DynamoDB', 'httpbin.org', '### myMethod' ]);
+      const subsegments = splitSegmentsByName(handlerSubsegment.subsegments, [ 'DynamoDB', 'awslabs.github.io', '### myMethod' ]);
       expect(subsegments.get('DynamoDB')?.length).toBe(2);
-      expect(subsegments.get('httpbin.org')?.length).toBe(1);
+      expect(subsegments.get('awslabs.github.io')?.length).toBe(1);
       expect(subsegments.get('### myMethod')?.length).toBe(1);
       expect(subsegments.get('other')?.length).toBe(0);
       
@@ -289,7 +289,7 @@ describe(`Tracer E2E tests, all features with decorator instantiation for runtim
        * 2. Lambda Function (AWS::Lambda::Function)
        * 3. DynamoDB (AWS::DynamoDB)
        * 4. DynamoDB Table (AWS::DynamoDB::Table)
-       * 5. Remote call (httpbin.org)
+       * 5. Remote call (awslabs.github.io)
        */
       expect(trace.Segments.length).toBe(5);
       const invocationSubsegment = getInvocationSubsegment(trace);
@@ -299,7 +299,7 @@ describe(`Tracer E2E tests, all features with decorator instantiation for runtim
        * '## index.handler' subsegment should have 4 subsegments
        * 1. DynamoDB (PutItem on the table)
        * 2. DynamoDB (PutItem overhead)
-       * 3. httpbin.org (Remote call)
+       * 3. awslabs.github.io (Remote call)
        * 4. '### myMethod' (method decorator)
        */
       const handlerSubsegment = getFirstSubsegment(invocationSubsegment);
@@ -309,9 +309,9 @@ describe(`Tracer E2E tests, all features with decorator instantiation for runtim
       if (!handlerSubsegment.subsegments) {
         fail('"## index.handler" subsegment should have subsegments');
       }
-      const subsegments = splitSegmentsByName(handlerSubsegment.subsegments, [ 'DynamoDB', 'httpbin.org', '### myMethod' ]);
+      const subsegments = splitSegmentsByName(handlerSubsegment.subsegments, [ 'DynamoDB', 'awslabs.github.io', '### myMethod' ]);
       expect(subsegments.get('DynamoDB')?.length).toBe(2);
-      expect(subsegments.get('httpbin.org')?.length).toBe(1);
+      expect(subsegments.get('awslabs.github.io')?.length).toBe(1);
       expect(subsegments.get('### myMethod')?.length).toBe(1);
       expect(subsegments.get('other')?.length).toBe(0);
       
@@ -343,7 +343,7 @@ describe(`Tracer E2E tests, all features with decorator instantiation for runtim
        * 2. Lambda Function (AWS::Lambda::Function)
        * 3. DynamoDB (AWS::DynamoDB)
        * 4. DynamoDB Table (AWS::DynamoDB::Table)
-       * 5. Remote call (httpbin.org)
+       * 5. Remote call (awslabs.github.io)
        */
       expect(trace.Segments.length).toBe(5);
       const invocationSubsegment = getInvocationSubsegment(trace);
@@ -353,7 +353,7 @@ describe(`Tracer E2E tests, all features with decorator instantiation for runtim
        * '## index.handler' subsegment should have 4 subsegments
        * 1. DynamoDB (PutItem on the table)
        * 2. DynamoDB (PutItem overhead)
-       * 3. httpbin.org (Remote call)
+       * 3. awslabs.github.io (Remote call)
        * 4. '### myMethod' (method decorator)
        */
       const handlerSubsegment = getFirstSubsegment(invocationSubsegment);
@@ -363,9 +363,9 @@ describe(`Tracer E2E tests, all features with decorator instantiation for runtim
       if (!handlerSubsegment.subsegments) {
         fail('"## index.handlerWithCaptureResponseFalse" subsegment should have subsegments');
       }
-      const subsegments = splitSegmentsByName(handlerSubsegment.subsegments, [ 'DynamoDB', 'httpbin.org', '### myMethod' ]);
+      const subsegments = splitSegmentsByName(handlerSubsegment.subsegments, [ 'DynamoDB', 'awslabs.github.io', '### myMethod' ]);
       expect(subsegments.get('DynamoDB')?.length).toBe(2);
-      expect(subsegments.get('httpbin.org')?.length).toBe(1);
+      expect(subsegments.get('awslabs.github.io')?.length).toBe(1);
       expect(subsegments.get('### myMethod')?.length).toBe(1);
       expect(subsegments.get('other')?.length).toBe(0);
 

--- a/packages/tracer/tests/e2e/allFeatures.manual.test.functionCode.ts
+++ b/packages/tracer/tests/e2e/allFeatures.manual.test.functionCode.ts
@@ -9,8 +9,8 @@ const serviceName = process.env.EXPECTED_SERVICE_NAME ?? 'MyFunctionWithStandard
 const customAnnotationKey = process.env.EXPECTED_CUSTOM_ANNOTATION_KEY ?? 'myAnnotation';
 const customAnnotationValue = process.env.EXPECTED_CUSTOM_ANNOTATION_VALUE ?? 'myValue';
 const customMetadataKey = process.env.EXPECTED_CUSTOM_METADATA_KEY ?? 'myMetadata';
-const customMetadataValue = JSON.parse(process.env.EXPECTED_CUSTOM_METADATA_VALUE) ?? { bar: 'baz' };
-const customResponseValue = JSON.parse(process.env.EXPECTED_CUSTOM_RESPONSE_VALUE) ?? { foo: 'bar' };
+const customMetadataValue = process.env.EXPECTED_CUSTOM_METADATA_VALUE ? JSON.parse(process.env.EXPECTED_CUSTOM_METADATA_VALUE) : { bar: 'baz' };
+const customResponseValue = process.env.EXPECTED_CUSTOM_RESPONSE_VALUE ? JSON.parse(process.env.EXPECTED_CUSTOM_RESPONSE_VALUE) : { foo: 'bar' };
 const customErrorMessage = process.env.EXPECTED_CUSTOM_ERROR_MESSAGE ?? 'An error has occurred';
 const testTableName = process.env.TEST_TABLE_NAME ?? 'TestTable';
 
@@ -58,7 +58,7 @@ export const handler = async (event: CustomEvent, _context: Context): Promise<vo
   try {
     await dynamoDBv2.put({ TableName: testTableName, Item: { id: `${serviceName}-${event.invocation}-sdkv2` } }).promise();
     await dynamoDBv3.send(new PutItemCommand({ TableName: testTableName, Item: { id: { 'S': `${serviceName}-${event.invocation}-sdkv3` } } }));
-    await axios.get('https://httpbin.org/status/200');
+    await axios.get('https://awslabs.github.io/aws-lambda-powertools-typescript/latest/');
 
     const res = customResponseValue;
     if (event.throw) {

--- a/packages/tracer/tests/e2e/allFeatures.manual.test.functionCode.ts
+++ b/packages/tracer/tests/e2e/allFeatures.manual.test.functionCode.ts
@@ -58,7 +58,7 @@ export const handler = async (event: CustomEvent, _context: Context): Promise<vo
   try {
     await dynamoDBv2.put({ TableName: testTableName, Item: { id: `${serviceName}-${event.invocation}-sdkv2` } }).promise();
     await dynamoDBv3.send(new PutItemCommand({ TableName: testTableName, Item: { id: { 'S': `${serviceName}-${event.invocation}-sdkv3` } } }));
-    await axios.get('https://awslabs.github.io/aws-lambda-powertools-typescript/latest/');
+    await axios.get('https://awslabs.github.io/aws-lambda-powertools-typescript/latest/', { timeout: 5000 });
 
     const res = customResponseValue;
     if (event.throw) {

--- a/packages/tracer/tests/e2e/allFeatures.manual.test.ts
+++ b/packages/tracer/tests/e2e/allFeatures.manual.test.ts
@@ -128,7 +128,7 @@ describe(`Tracer E2E tests, all features with manual instantiation for runtime: 
        * 2. Lambda Function (AWS::Lambda::Function)
        * 3. DynamoDB (AWS::DynamoDB)
        * 4. DynamoDB Table (AWS::DynamoDB::Table)
-       * 5. Remote call (httpbin.org)
+       * 5. Remote call (awslabs.github.io)
        */
       expect(trace.Segments.length).toBe(5);
       const invocationSubsegment = getInvocationSubsegment(trace);
@@ -138,7 +138,7 @@ describe(`Tracer E2E tests, all features with manual instantiation for runtime: 
        * '## index.handler' subsegment should have 3 subsegments
        * 1. DynamoDB (PutItem on the table)
        * 2. DynamoDB (PutItem overhead)
-       * 3. httpbin.org (Remote call)
+       * 3. awslabs.github.io (Remote call)
        */
       const handlerSubsegment = getFirstSubsegment(invocationSubsegment);
       expect(handlerSubsegment.name).toBe('## index.handler');
@@ -147,9 +147,9 @@ describe(`Tracer E2E tests, all features with manual instantiation for runtime: 
       if (!handlerSubsegment.subsegments) {
         fail('"## index.handler" subsegment should have subsegments');
       }
-      const subsegments = splitSegmentsByName(handlerSubsegment.subsegments, [ 'DynamoDB', 'httpbin.org' ]);
+      const subsegments = splitSegmentsByName(handlerSubsegment.subsegments, [ 'DynamoDB', 'awslabs.github.io' ]);
       expect(subsegments.get('DynamoDB')?.length).toBe(2);
-      expect(subsegments.get('httpbin.org')?.length).toBe(1);
+      expect(subsegments.get('awslabs.github.io')?.length).toBe(1);
       expect(subsegments.get('other')?.length).toBe(0);
       
       const shouldThrowAnError = (i === (invocations - 1));

--- a/packages/tracer/tests/e2e/allFeatures.middy.test.functionCode.ts
+++ b/packages/tracer/tests/e2e/allFeatures.middy.test.functionCode.ts
@@ -10,8 +10,8 @@ const serviceName = process.env.EXPECTED_SERVICE_NAME ?? 'MyFunctionWithStandard
 const customAnnotationKey = process.env.EXPECTED_CUSTOM_ANNOTATION_KEY ?? 'myAnnotation';
 const customAnnotationValue = process.env.EXPECTED_CUSTOM_ANNOTATION_VALUE ?? 'myValue';
 const customMetadataKey = process.env.EXPECTED_CUSTOM_METADATA_KEY ?? 'myMetadata';
-const customMetadataValue = JSON.parse(process.env.EXPECTED_CUSTOM_METADATA_VALUE) ?? { bar: 'baz' };
-const customResponseValue = JSON.parse(process.env.EXPECTED_CUSTOM_RESPONSE_VALUE) ?? { foo: 'bar' };
+const customMetadataValue = process.env.EXPECTED_CUSTOM_METADATA_VALUE ? JSON.parse(process.env.EXPECTED_CUSTOM_METADATA_VALUE) : { bar: 'baz' };
+const customResponseValue = process.env.EXPECTED_CUSTOM_RESPONSE_VALUE ? JSON.parse(process.env.EXPECTED_CUSTOM_RESPONSE_VALUE) : { foo: 'bar' };
 const customErrorMessage = process.env.EXPECTED_CUSTOM_ERROR_MESSAGE ?? 'An error has occurred';
 const testTableName = process.env.TEST_TABLE_NAME ?? 'TestTable';
 
@@ -52,7 +52,7 @@ const testHandler = async (event: CustomEvent, _context: Context): Promise<void>
   try {
     await dynamoDBv2.put({ TableName: testTableName, Item: { id: `${serviceName}-${event.invocation}-sdkv2` } }).promise();
     await dynamoDBv3.send(new PutItemCommand({ TableName: testTableName, Item: { id: { 'S': `${serviceName}-${event.invocation}-sdkv3` } } }));
-    await axios.get('https://httpbin.org/status/200');
+    await axios.get('https://awslabs.github.io/aws-lambda-powertools-typescript/latest/');
 
     const res = customResponseValue;
     if (event.throw) {

--- a/packages/tracer/tests/e2e/allFeatures.middy.test.functionCode.ts
+++ b/packages/tracer/tests/e2e/allFeatures.middy.test.functionCode.ts
@@ -52,7 +52,7 @@ const testHandler = async (event: CustomEvent, _context: Context): Promise<void>
   try {
     await dynamoDBv2.put({ TableName: testTableName, Item: { id: `${serviceName}-${event.invocation}-sdkv2` } }).promise();
     await dynamoDBv3.send(new PutItemCommand({ TableName: testTableName, Item: { id: { 'S': `${serviceName}-${event.invocation}-sdkv3` } } }));
-    await axios.get('https://awslabs.github.io/aws-lambda-powertools-typescript/latest/');
+    await axios.get('https://awslabs.github.io/aws-lambda-powertools-typescript/latest/', { timeout: 5000 });
 
     const res = customResponseValue;
     if (event.throw) {

--- a/packages/tracer/tests/e2e/allFeatures.middy.test.ts
+++ b/packages/tracer/tests/e2e/allFeatures.middy.test.ts
@@ -206,7 +206,7 @@ describe(`Tracer E2E tests, all features with middy instantiation for runtime: $
        * 2. Lambda Function (AWS::Lambda::Function)
        * 3. DynamoDB (AWS::DynamoDB)
        * 4. DynamoDB Table (AWS::DynamoDB::Table)
-       * 5. Remote call (httpbin.org)
+       * 5. Remote call (awslabs.github.io)
        */
       expect(trace.Segments.length).toBe(5);
       const invocationSubsegment = getInvocationSubsegment(trace);
@@ -216,7 +216,7 @@ describe(`Tracer E2E tests, all features with middy instantiation for runtime: $
        * '## index.handler' subsegment should have 3 subsegments
        * 1. DynamoDB (PutItem on the table)
        * 2. DynamoDB (PutItem overhead)
-       * 3. httpbin.org (Remote call)
+       * 3. awslabs.github.io (Remote call)
        */
       const handlerSubsegment = getFirstSubsegment(invocationSubsegment);
       expect(handlerSubsegment.name).toBe('## index.handler');
@@ -225,9 +225,9 @@ describe(`Tracer E2E tests, all features with middy instantiation for runtime: $
       if (!handlerSubsegment.subsegments) {
         fail('"## index.handler" subsegment should have subsegments');
       }
-      const subsegments = splitSegmentsByName(handlerSubsegment.subsegments, [ 'DynamoDB', 'httpbin.org' ]);
+      const subsegments = splitSegmentsByName(handlerSubsegment.subsegments, [ 'DynamoDB', 'awslabs.github.io' ]);
       expect(subsegments.get('DynamoDB')?.length).toBe(2);
-      expect(subsegments.get('httpbin.org')?.length).toBe(1);
+      expect(subsegments.get('awslabs.github.io')?.length).toBe(1);
       expect(subsegments.get('other')?.length).toBe(0);
       
       const shouldThrowAnError = (i === (invocations - 1));
@@ -287,7 +287,7 @@ describe(`Tracer E2E tests, all features with middy instantiation for runtime: $
        * 2. Lambda Function (AWS::Lambda::Function)
        * 3. DynamoDB (AWS::DynamoDB)
        * 4. DynamoDB Table (AWS::DynamoDB::Table)
-       * 5. Remote call (httpbin.org)
+       * 5. Remote call (awslabs.github.io)
        */
       expect(trace.Segments.length).toBe(5);
       const invocationSubsegment = getInvocationSubsegment(trace);
@@ -297,7 +297,7 @@ describe(`Tracer E2E tests, all features with middy instantiation for runtime: $
        * '## index.handler' subsegment should have 3 subsegments
        * 1. DynamoDB (PutItem on the table)
        * 2. DynamoDB (PutItem overhead)
-       * 3. httpbin.org (Remote call)
+       * 3. awslabs.github.io (Remote call)
        */
       const handlerSubsegment = getFirstSubsegment(invocationSubsegment);
       expect(handlerSubsegment.name).toBe('## index.handler');
@@ -306,9 +306,9 @@ describe(`Tracer E2E tests, all features with middy instantiation for runtime: $
       if (!handlerSubsegment.subsegments) {
         fail('"## index.handler" subsegment should have subsegments');
       }
-      const subsegments = splitSegmentsByName(handlerSubsegment.subsegments, [ 'DynamoDB', 'httpbin.org' ]);
+      const subsegments = splitSegmentsByName(handlerSubsegment.subsegments, [ 'DynamoDB', 'awslabs.github.io' ]);
       expect(subsegments.get('DynamoDB')?.length).toBe(2);
-      expect(subsegments.get('httpbin.org')?.length).toBe(1);
+      expect(subsegments.get('awslabs.github.io')?.length).toBe(1);
       expect(subsegments.get('other')?.length).toBe(0);
       
       const shouldThrowAnError = (i === (invocations - 1));
@@ -339,7 +339,7 @@ describe(`Tracer E2E tests, all features with middy instantiation for runtime: $
        * 2. Lambda Function (AWS::Lambda::Function)
        * 3. DynamoDB (AWS::DynamoDB)
        * 4. DynamoDB Table (AWS::DynamoDB::Table)
-       * 5. Remote call (httpbin.org)
+       * 5. Remote call (awslabs.github.io)
        */
       expect(trace.Segments.length).toBe(5);
       const invocationSubsegment = getInvocationSubsegment(trace);
@@ -349,7 +349,7 @@ describe(`Tracer E2E tests, all features with middy instantiation for runtime: $
        * '## index.handlerWithNoCaptureResponseViaMiddlewareOption' subsegment should have 3 subsegments
        * 1. DynamoDB (PutItem on the table)
        * 2. DynamoDB (PutItem overhead)
-       * 3. httpbin.org (Remote call)
+       * 3. awslabs.github.io (Remote call)
        */
       const handlerSubsegment = getFirstSubsegment(invocationSubsegment);
       expect(handlerSubsegment.name).toBe('## index.handlerWithNoCaptureResponseViaMiddlewareOption');
@@ -358,9 +358,9 @@ describe(`Tracer E2E tests, all features with middy instantiation for runtime: $
       if (!handlerSubsegment.subsegments) {
         fail('"## index.handlerWithNoCaptureResponseViaMiddlewareOption" subsegment should have subsegments');
       }
-      const subsegments = splitSegmentsByName(handlerSubsegment.subsegments, [ 'DynamoDB', 'httpbin.org' ]);
+      const subsegments = splitSegmentsByName(handlerSubsegment.subsegments, [ 'DynamoDB', 'awslabs.github.io' ]);
       expect(subsegments.get('DynamoDB')?.length).toBe(2);
-      expect(subsegments.get('httpbin.org')?.length).toBe(1);
+      expect(subsegments.get('awslabs.github.io')?.length).toBe(1);
       expect(subsegments.get('other')?.length).toBe(0);
       
       const shouldThrowAnError = (i === (invocations - 1));

--- a/packages/tracer/tests/e2e/asyncHandler.decorator.test.functionCode.ts
+++ b/packages/tracer/tests/e2e/asyncHandler.decorator.test.functionCode.ts
@@ -59,7 +59,7 @@ export class MyFunctionBase {
     try {
       await dynamoDBv2.put({ TableName: testTableName, Item: { id: `${serviceName}-${event.invocation}-sdkv2` } }).promise();
       await dynamoDBv3.send(new PutItemCommand({ TableName: testTableName, Item: { id: { 'S': `${serviceName}-${event.invocation}-sdkv3` } } }));
-      await axios.get('https://awslabs.github.io/aws-lambda-powertools-typescript/latest/');
+      await axios.get('https://awslabs.github.io/aws-lambda-powertools-typescript/latest/', { timeout: 5000 });
 
       const res = this.myMethod();
       if (event.throw) {

--- a/packages/tracer/tests/e2e/asyncHandler.decorator.test.functionCode.ts
+++ b/packages/tracer/tests/e2e/asyncHandler.decorator.test.functionCode.ts
@@ -59,7 +59,7 @@ export class MyFunctionBase {
     try {
       await dynamoDBv2.put({ TableName: testTableName, Item: { id: `${serviceName}-${event.invocation}-sdkv2` } }).promise();
       await dynamoDBv3.send(new PutItemCommand({ TableName: testTableName, Item: { id: { 'S': `${serviceName}-${event.invocation}-sdkv3` } } }));
-      await axios.get('https://httpbin.org/status/200');
+      await axios.get('https://awslabs.github.io/aws-lambda-powertools-typescript/latest/');
 
       const res = this.myMethod();
       if (event.throw) {

--- a/packages/tracer/tests/e2e/asyncHandler.decorator.test.ts
+++ b/packages/tracer/tests/e2e/asyncHandler.decorator.test.ts
@@ -155,7 +155,7 @@ describe(`Tracer E2E tests, asynchronous handler with decorator instantiation fo
        * 2. Lambda Function (AWS::Lambda::Function)
        * 3. DynamoDB (AWS::DynamoDB)
        * 4. DynamoDB Table (AWS::DynamoDB::Table)
-       * 5. Remote call (httpbin.org)
+       * 5. Remote call (awslabs.github.io)
        */
       expect(trace.Segments.length).toBe(5);
       const invocationSubsegment = getInvocationSubsegment(trace);
@@ -165,7 +165,7 @@ describe(`Tracer E2E tests, asynchronous handler with decorator instantiation fo
        * '## index.handler' subsegment should have 4 subsegments
        * 1. DynamoDB (PutItem on the table)
        * 2. DynamoDB (PutItem overhead)
-       * 3. httpbin.org (Remote call)
+       * 3. awslabs.github.io (Remote call)
        * 4. '### myMethod' (method decorator)
        */
       const handlerSubsegment = getFirstSubsegment(invocationSubsegment);
@@ -175,9 +175,9 @@ describe(`Tracer E2E tests, asynchronous handler with decorator instantiation fo
       if (!handlerSubsegment.subsegments) {
         fail('"## index.handler" subsegment should have subsegments');
       }
-      const subsegments = splitSegmentsByName(handlerSubsegment.subsegments, [ 'DynamoDB', 'httpbin.org', '### myMethod' ]);
+      const subsegments = splitSegmentsByName(handlerSubsegment.subsegments, [ 'DynamoDB', 'awslabs.github.io', '### myMethod' ]);
       expect(subsegments.get('DynamoDB')?.length).toBe(2);
-      expect(subsegments.get('httpbin.org')?.length).toBe(1);
+      expect(subsegments.get('awslabs.github.io')?.length).toBe(1);
       expect(subsegments.get('### myMethod')?.length).toBe(1);
       expect(subsegments.get('other')?.length).toBe(0);
       
@@ -238,7 +238,7 @@ describe(`Tracer E2E tests, asynchronous handler with decorator instantiation fo
        * 2. Lambda Function (AWS::Lambda::Function)
        * 3. DynamoDB (AWS::DynamoDB)
        * 4. DynamoDB Table (AWS::DynamoDB::Table)
-       * 5. Remote call (httpbin.org)
+       * 5. Remote call (awslabs.github.io)
        */
       expect(trace.Segments.length).toBe(5);
       const invocationSubsegment = getInvocationSubsegment(trace);
@@ -248,7 +248,7 @@ describe(`Tracer E2E tests, asynchronous handler with decorator instantiation fo
        * '## index.handler' subsegment should have 4 subsegments
        * 1. DynamoDB (PutItem on the table)
        * 2. DynamoDB (PutItem overhead)
-       * 3. httpbin.org (Remote call)
+       * 3. awslabs.github.io (Remote call)
        * 4. '### mySubsegment' (method decorator with custom name)
        */
       const handlerSubsegment = getFirstSubsegment(invocationSubsegment);
@@ -258,9 +258,9 @@ describe(`Tracer E2E tests, asynchronous handler with decorator instantiation fo
       if (!handlerSubsegment.subsegments) {
         fail('"## index.handler" subsegment should have subsegments');
       }
-      const subsegments = splitSegmentsByName(handlerSubsegment.subsegments, [ 'DynamoDB', 'httpbin.org', expectedCustomSubSegmentName ]);
+      const subsegments = splitSegmentsByName(handlerSubsegment.subsegments, [ 'DynamoDB', 'awslabs.github.io', expectedCustomSubSegmentName ]);
       expect(subsegments.get('DynamoDB')?.length).toBe(2);
-      expect(subsegments.get('httpbin.org')?.length).toBe(1);
+      expect(subsegments.get('awslabs.github.io')?.length).toBe(1);
       expect(subsegments.get(expectedCustomSubSegmentName)?.length).toBe(1);
       expect(subsegments.get('other')?.length).toBe(0);
       


### PR DESCRIPTION
## Description of your changes

As described in the linked issue, before this PR the integration tests were using `httpbin.org` as destination for some requests made during the Tracer tests.

This PR replaces that host with the base URL of the project's documentation to avoid reliance on 3rd party services.

### How to verify this change

See test run of integration tests published in the comments below the PR.

### Related issues, RFCs

<!--- Add here the number (i.e. #42) to the Github Issue or RFC that is related to this PR. -->
<!--- If no issue is present the PR might get blocked and not be reviewed. -->
**Issue number:** #1193

### PR status

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-typescript/#tenets)
- [x] I have performed a *self-review* of my own code
- [ ] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [ ] I have made corresponding changes to the *documentation*
- [ ] I have made corresponding changes to the *examples*
- [ ] My changes generate *no new warnings*
- [x] The *code coverage* hasn't decreased
- [ ] I have *added tests* that prove my change is effective and works
- [x] New and existing *unit tests pass* locally and in Github Actions
- [ ] Any *dependent changes have been merged and published*
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

- [ ] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
