### PR TITLE
refactor(parameters): BaseProvider support for Uint8Array

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16471,18 +16471,7 @@
       "version": "1.4.1",
       "license": "MIT-0",
       "dependencies": {
-        "@aws-sdk/util-base64-node": "^3.209.0"
-      }
-    },
-    "packages/parameters/node_modules/@aws-sdk/util-base64-node": {
-      "version": "3.209.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/util-buffer-from": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
+        "@aws-sdk/util-base64": "^3.208.0"
       }
     },
     "packages/tracer": {
@@ -16752,16 +16741,7 @@
     "@aws-lambda-powertools/parameters": {
       "version": "file:packages/parameters",
       "requires": {
-        "@aws-sdk/util-base64-node": "^3.209.0"
-      },
-      "dependencies": {
-        "@aws-sdk/util-base64-node": {
-          "version": "3.209.0",
-          "requires": {
-            "@aws-sdk/util-buffer-from": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        }
+        "@aws-sdk/util-base64": "^3.208.0"
       }
     },
     "@aws-lambda-powertools/tracer": {

--- a/packages/parameters/package.json
+++ b/packages/parameters/package.json
@@ -42,7 +42,7 @@
     "url": "https://github.com/awslabs/aws-lambda-powertools-typescript/issues"
   },
   "dependencies": {
-    "@aws-sdk/util-base64-node": "^3.209.0"
+    "@aws-sdk/util-base64": "^3.208.0"
   },
   "keywords": [
     "aws",

--- a/packages/parameters/package.json
+++ b/packages/parameters/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-lambda-powertools/parameters",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "description": "The parameters package for the AWS Lambda Powertools for TypeScript library",
   "author": {
     "name": "Amazon Web Services",

--- a/packages/parameters/src/ExpirableValue.ts
+++ b/packages/parameters/src/ExpirableValue.ts
@@ -2,9 +2,9 @@ import type { ExpirableValueInterface } from './types';
 
 class ExpirableValue implements ExpirableValueInterface {
   public ttl: number;
-  public value: string | Record<string, unknown>;
+  public value: string | Uint8Array | Record<string, unknown>;
 
-  public constructor(value: string | Record<string, unknown>, maxAge: number) {
+  public constructor(value: string | Uint8Array | Record<string, unknown>, maxAge: number) {
     this.value = value;
     const timeNow = new Date();
     this.ttl = timeNow.setSeconds(timeNow.getSeconds() + maxAge);
@@ -15,6 +15,6 @@ class ExpirableValue implements ExpirableValueInterface {
   }
 }
 
-export { 
+export {
   ExpirableValue
 };

--- a/packages/parameters/src/types/BaseProvider.ts
+++ b/packages/parameters/src/types/BaseProvider.ts
@@ -16,12 +16,12 @@ interface GetMultipleOptionsInterface {
 }
 
 interface ExpirableValueInterface {
-  value: string | Record<string, unknown>
+  value: string | Uint8Array | Record<string, unknown>
   ttl: number
 }
 
 interface BaseProviderInterface {
-  get(name: string, options?: GetOptionsInterface): Promise<undefined | string | Record<string, unknown>>
+  get(name: string, options?: GetOptionsInterface): Promise<undefined | string | Uint8Array | Record<string, unknown>>
   getMultiple(path: string, options?: GetMultipleOptionsInterface): Promise<void | Record<string, unknown>>
 }
 

--- a/packages/parameters/tests/unit/BaseProvider.test.ts
+++ b/packages/parameters/tests/unit/BaseProvider.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { BaseProvider, ExpirableValue, GetParameterError, TransformParameterError } from '../../src';
-import { toBase64 } from '@aws-sdk/util-base64-node';
+import { toBase64 } from '@aws-sdk/util-base64';
 
 const encoder = new TextEncoder();
 
@@ -76,7 +76,7 @@ describe('Class: BaseProvider', () => {
       // Prepare
       const provider = new TestProvider();
 
-      // Act / Assess
+      // Act & Assess
       await expect(provider.get('my-parameter')).rejects.toThrowError(GetParameterError);
 
     });
@@ -154,7 +154,7 @@ describe('Class: BaseProvider', () => {
       const provider = new TestProvider();
       jest.spyOn(provider, '_get').mockImplementation(() => new Promise((resolve, _reject) => resolve(mockData)));
 
-      // Act / Assess
+      // Act & Assess
       await expect(provider.get('my-parameter', { transform: 'json' })).rejects.toThrowError(TransformParameterError);
 
     });
@@ -181,8 +181,40 @@ describe('Class: BaseProvider', () => {
       const provider = new TestProvider();
       jest.spyOn(provider, '_get').mockImplementation(() => new Promise((resolve, _reject) => resolve(mockData)));
 
-      // Act / Assess
+      // Act & Assess
       await expect(provider.get('my-parameter', { transform: 'binary' })).rejects.toThrowError(TransformParameterError);
+
+    });
+    
+    test('when called with no transform, and the value is a valid binary, it returns the binary as-is', async () => {
+
+      // Prepare
+      const mockData = encoder.encode('my-value');
+      const provider = new TestProvider();
+      jest.spyOn(provider, '_get').mockImplementation(() => new Promise((resolve, _reject) => resolve(mockData as unknown as string)));
+
+      // Act
+      const value = await provider.get('my-parameter');
+
+      // Assess
+      expect(value).toBeInstanceOf(Uint8Array);
+      expect(value).toEqual(mockData);
+
+    });
+    
+    test('when called with a binary transform, and the value is a valid binary, it returns the decoded value', async () => {
+
+      // Prepare
+      const mockData = encoder.encode('my-value');
+      const provider = new TestProvider();
+      jest.spyOn(provider, '_get').mockImplementation(() => new Promise((resolve, _reject) => resolve(mockData as unknown as string)));
+
+      // Act
+      const value = await provider.get('my-parameter', { transform: 'binary' });
+
+      // Assess
+      expect(typeof value).toBe('string');
+      expect(value).toEqual('my-value');
 
     });
 
@@ -195,7 +227,7 @@ describe('Class: BaseProvider', () => {
       const provider = new TestProvider();
       jest.spyOn(provider, '_getMultiple').mockImplementation(() => new Promise((_resolve, reject) => reject(new Error('Some error.'))));
 
-      // Act / Assess
+      // Act & Assess
       await expect(provider.getMultiple('my-parameter')).rejects.toThrowError(GetParameterError);
 
     });
@@ -267,7 +299,7 @@ describe('Class: BaseProvider', () => {
       const provider = new TestProvider();
       jest.spyOn(provider, '_getMultiple').mockImplementation(() => new Promise((resolve, _reject) => resolve(mockData)));
 
-      // Act / Assess
+      // Act & Assess
       await expect(provider.getMultiple('my-path', { transform: 'json', throwOnTransformError: true })).rejects.toThrowError(TransformParameterError);
 
     });
@@ -316,7 +348,7 @@ describe('Class: BaseProvider', () => {
       const provider = new TestProvider();
       jest.spyOn(provider, '_getMultiple').mockImplementation(() => new Promise((resolve, _reject) => resolve(mockData)));
 
-      // Act / Assess
+      // Act & Assess
       await expect(provider.getMultiple('my-path', { transform: 'binary', throwOnTransformError: true })).rejects.toThrowError(TransformParameterError);
 
     });


### PR DESCRIPTION
## Description of your changes

This PR introduces some changes to the typing in `BaseProvider` so that it's now able to handle, transform, or return `Uint8Array` objects without necessarily coercing them to `string`.

The change came from the fact that AWS Secrets Manager can return both `string` (when the secret is stored as `SecretString`) and pure binaries aka `Uint8Array` (when the secret is stored as `SecretBinary`).

Consumers of the library should be able to both retrieve the latter and have them automatically transformed by the Parameters utility but also have them returned as-is (`Uint8Array`) in case they don't want to apply any transform.

The PR enables the behavior described above.

The PR introduces also some light housekeeping around dependencies (switches from `@aws-sdk/util-base64-node` to `@aws-sdk/util-base64` due to the former having being marked as being on a deprecation path) and the introduction of the `DEFAULT_PROVIDERS` object which is required by the other providers.

### How to verify this change

See status checks under this PR.

### Related issues, RFCs

<!--- Add here the number (i.e. #42) to the Github Issue or RFC that is related to this PR. -->
<!--- If no issue is present the PR might get blocked and not be reviewed. -->
**Issue number:** #1172

### PR status

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-typescript/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [ ] I have made corresponding changes to the *documentation*
- [ ] I have made corresponding changes to the *examples*
- [x] My changes generate *no new warnings*
- [x] The *code coverage* hasn't decreased
- [x] I have *added tests* that prove my change is effective and works
- [x] New and existing *unit tests pass* locally and in Github Actions
- [ ] Any *dependent changes have been merged and published*
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

- [ ] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
