### PR TITLE
feat(parameters): SecretsProvider support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -403,6 +403,353 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/@aws-sdk/client-secrets-manager": {
+      "version": "3.238.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.238.0.tgz",
+      "integrity": "sha512-J3lmceh2txILEh8tWf4ldp8ThAh2WJBSa1t8oJhW58KuE+1a7cwOpgWO6MsSvOrGtp7qzTr8GMBUf7KLdv7wOg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/client-sts": "3.238.0",
+        "@aws-sdk/config-resolver": "3.234.0",
+        "@aws-sdk/credential-provider-node": "3.238.0",
+        "@aws-sdk/fetch-http-handler": "3.226.0",
+        "@aws-sdk/hash-node": "3.226.0",
+        "@aws-sdk/invalid-dependency": "3.226.0",
+        "@aws-sdk/middleware-content-length": "3.226.0",
+        "@aws-sdk/middleware-endpoint": "3.226.0",
+        "@aws-sdk/middleware-host-header": "3.226.0",
+        "@aws-sdk/middleware-logger": "3.226.0",
+        "@aws-sdk/middleware-recursion-detection": "3.226.0",
+        "@aws-sdk/middleware-retry": "3.235.0",
+        "@aws-sdk/middleware-serde": "3.226.0",
+        "@aws-sdk/middleware-signing": "3.226.0",
+        "@aws-sdk/middleware-stack": "3.226.0",
+        "@aws-sdk/middleware-user-agent": "3.226.0",
+        "@aws-sdk/node-config-provider": "3.226.0",
+        "@aws-sdk/node-http-handler": "3.226.0",
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/smithy-client": "3.234.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/url-parser": "3.226.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.234.0",
+        "@aws-sdk/util-defaults-mode-node": "3.234.0",
+        "@aws-sdk/util-endpoints": "3.226.0",
+        "@aws-sdk/util-retry": "3.229.0",
+        "@aws-sdk/util-user-agent-browser": "3.226.0",
+        "@aws-sdk/util-user-agent-node": "3.226.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "tslib": "^2.3.1",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/client-sso": {
+      "version": "3.238.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.238.0.tgz",
+      "integrity": "sha512-KHJJWP7hBDa9KLYiU5+hOb+3AAba93PhWebXkpKyQ/Bs+e7ECCreyLCwuME6uWTV01NDuFDpwZ6zUMpyNIcP6Q==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.234.0",
+        "@aws-sdk/fetch-http-handler": "3.226.0",
+        "@aws-sdk/hash-node": "3.226.0",
+        "@aws-sdk/invalid-dependency": "3.226.0",
+        "@aws-sdk/middleware-content-length": "3.226.0",
+        "@aws-sdk/middleware-endpoint": "3.226.0",
+        "@aws-sdk/middleware-host-header": "3.226.0",
+        "@aws-sdk/middleware-logger": "3.226.0",
+        "@aws-sdk/middleware-recursion-detection": "3.226.0",
+        "@aws-sdk/middleware-retry": "3.235.0",
+        "@aws-sdk/middleware-serde": "3.226.0",
+        "@aws-sdk/middleware-stack": "3.226.0",
+        "@aws-sdk/middleware-user-agent": "3.226.0",
+        "@aws-sdk/node-config-provider": "3.226.0",
+        "@aws-sdk/node-http-handler": "3.226.0",
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/smithy-client": "3.234.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/url-parser": "3.226.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.234.0",
+        "@aws-sdk/util-defaults-mode-node": "3.234.0",
+        "@aws-sdk/util-endpoints": "3.226.0",
+        "@aws-sdk/util-retry": "3.229.0",
+        "@aws-sdk/util-user-agent-browser": "3.226.0",
+        "@aws-sdk/util-user-agent-node": "3.226.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.238.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.238.0.tgz",
+      "integrity": "sha512-kazcA2Kp+cXQRtaZi5/T5YFfU9J3nzu1tXJsh0xAm+J3S9LS1ertY1bSX6KBed2xuxx2mfum8JRqli0TJad/pA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.234.0",
+        "@aws-sdk/fetch-http-handler": "3.226.0",
+        "@aws-sdk/hash-node": "3.226.0",
+        "@aws-sdk/invalid-dependency": "3.226.0",
+        "@aws-sdk/middleware-content-length": "3.226.0",
+        "@aws-sdk/middleware-endpoint": "3.226.0",
+        "@aws-sdk/middleware-host-header": "3.226.0",
+        "@aws-sdk/middleware-logger": "3.226.0",
+        "@aws-sdk/middleware-recursion-detection": "3.226.0",
+        "@aws-sdk/middleware-retry": "3.235.0",
+        "@aws-sdk/middleware-serde": "3.226.0",
+        "@aws-sdk/middleware-stack": "3.226.0",
+        "@aws-sdk/middleware-user-agent": "3.226.0",
+        "@aws-sdk/node-config-provider": "3.226.0",
+        "@aws-sdk/node-http-handler": "3.226.0",
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/smithy-client": "3.234.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/url-parser": "3.226.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.234.0",
+        "@aws-sdk/util-defaults-mode-node": "3.234.0",
+        "@aws-sdk/util-endpoints": "3.226.0",
+        "@aws-sdk/util-retry": "3.229.0",
+        "@aws-sdk/util-user-agent-browser": "3.226.0",
+        "@aws-sdk/util-user-agent-node": "3.226.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/client-sts": {
+      "version": "3.238.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.238.0.tgz",
+      "integrity": "sha512-jQNwHqxWUGvWCN4o8KUFYQES8r41Oobu7x1KZOMrPhPxy27FUcDjBq/h85VoD2/AZlETSCZLiCnKV3KBh5pT5w==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.234.0",
+        "@aws-sdk/credential-provider-node": "3.238.0",
+        "@aws-sdk/fetch-http-handler": "3.226.0",
+        "@aws-sdk/hash-node": "3.226.0",
+        "@aws-sdk/invalid-dependency": "3.226.0",
+        "@aws-sdk/middleware-content-length": "3.226.0",
+        "@aws-sdk/middleware-endpoint": "3.226.0",
+        "@aws-sdk/middleware-host-header": "3.226.0",
+        "@aws-sdk/middleware-logger": "3.226.0",
+        "@aws-sdk/middleware-recursion-detection": "3.226.0",
+        "@aws-sdk/middleware-retry": "3.235.0",
+        "@aws-sdk/middleware-sdk-sts": "3.226.0",
+        "@aws-sdk/middleware-serde": "3.226.0",
+        "@aws-sdk/middleware-signing": "3.226.0",
+        "@aws-sdk/middleware-stack": "3.226.0",
+        "@aws-sdk/middleware-user-agent": "3.226.0",
+        "@aws-sdk/node-config-provider": "3.226.0",
+        "@aws-sdk/node-http-handler": "3.226.0",
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/smithy-client": "3.234.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/url-parser": "3.226.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.234.0",
+        "@aws-sdk/util-defaults-mode-node": "3.234.0",
+        "@aws-sdk/util-endpoints": "3.226.0",
+        "@aws-sdk/util-retry": "3.229.0",
+        "@aws-sdk/util-user-agent-browser": "3.226.0",
+        "@aws-sdk/util-user-agent-node": "3.226.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "fast-xml-parser": "4.0.11",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/config-resolver": {
+      "version": "3.234.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.234.0.tgz",
+      "integrity": "sha512-uZxy4wzllfvgCQxVc+Iqhde0NGAnfmV2hWR6ejadJaAFTuYNvQiRg9IqJy3pkyDPqXySiJ8Bom5PoJfgn55J/A==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/signature-v4": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/util-config-provider": "3.208.0",
+        "@aws-sdk/util-middleware": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.238.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.238.0.tgz",
+      "integrity": "sha512-WmPNtIYyUasjV7VQxvPNq7ihmx0vFsiKAtjNjjakdrt5TPoma4nUYb9tIG9SuG+kcp4DJIgRLJAgZtXbCcVimg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.226.0",
+        "@aws-sdk/credential-provider-imds": "3.226.0",
+        "@aws-sdk/credential-provider-process": "3.226.0",
+        "@aws-sdk/credential-provider-sso": "3.238.0",
+        "@aws-sdk/credential-provider-web-identity": "3.226.0",
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/shared-ini-file-loader": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.238.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.238.0.tgz",
+      "integrity": "sha512-/RN5EyGfgdIIJdFzv+O0nSaHX1/F3anQjTIBeVg8GJ+82m+bDxMdALsG+NzkYnLilN9Uhc1lSNjLBCoPa5DSEg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.226.0",
+        "@aws-sdk/credential-provider-imds": "3.226.0",
+        "@aws-sdk/credential-provider-ini": "3.238.0",
+        "@aws-sdk/credential-provider-process": "3.226.0",
+        "@aws-sdk/credential-provider-sso": "3.238.0",
+        "@aws-sdk/credential-provider-web-identity": "3.226.0",
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/shared-ini-file-loader": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.238.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.238.0.tgz",
+      "integrity": "sha512-i70V4bFlCVYey3QARJ6XxKEg/4YuoFRnePV2oK37UHOGpEn49uXKwVZqLjzJgFHln7BPlC06cWDqrHUQIMvYrQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.238.0",
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/shared-ini-file-loader": "3.226.0",
+        "@aws-sdk/token-providers": "3.238.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/middleware-retry": {
+      "version": "3.235.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.235.0.tgz",
+      "integrity": "sha512-50WHbJGpD3SNp9763MAlHqIhXil++JdQbKejNpHg7HsJne/ao3ub+fDOfx//mMBjpzBV25BGd5UlfL6blrClSg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/service-error-classification": "3.229.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/util-middleware": "3.226.0",
+        "@aws-sdk/util-retry": "3.229.0",
+        "tslib": "^2.3.1",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/smithy-client": {
+      "version": "3.234.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.234.0.tgz",
+      "integrity": "sha512-8AtR/k4vsFvjXeQbIzq/Wy7Nbk48Ou0wUEeVYPHWHPSU8QamFWORkOwmKtKMfHAyZvmqiAPeQqHFkq+UJhWyyQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/middleware-stack": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/token-providers": {
+      "version": "3.238.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.238.0.tgz",
+      "integrity": "sha512-vYUwmy0kTzA99mJCVvad+/5RDlWve/xxnppT8DJK3JIdAgskp+rULY+joVnq2NSl489UAioUnFGs57vUxi8Pog==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/client-sso-oidc": "3.238.0",
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/shared-ini-file-loader": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/util-defaults-mode-browser": {
+      "version": "3.234.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.234.0.tgz",
+      "integrity": "sha512-IHMKXjTbOD8XMz5+2oCOsVP94BYb9YyjXdns0aAXr2NAo7k2+RCzXQ2DebJXppGda1F6opFutoKwyVSN0cmbMw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/util-defaults-mode-node": {
+      "version": "3.234.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.234.0.tgz",
+      "integrity": "sha512-UGjQ+OjBYYhxFVtUY+jtr0ZZgzZh6OHtYwRhFt8IHewJXFCfZTyfsbX20szBj5y1S4HRIUJ7cwBLIytTqMbI5w==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/config-resolver": "3.234.0",
+        "@aws-sdk/credential-provider-imds": "3.226.0",
+        "@aws-sdk/node-config-provider": "3.226.0",
+        "@aws-sdk/property-provider": "3.226.0",
+        "@aws-sdk/types": "3.226.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-secrets-manager/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/@aws-sdk/client-sso": {
       "version": "3.231.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.231.0.tgz",
@@ -16472,6 +16819,11 @@
       "license": "MIT-0",
       "dependencies": {
         "@aws-sdk/util-base64": "^3.208.0"
+      },
+      "devDependencies": {
+        "@aws-sdk/client-secrets-manager": "^3.238.0",
+        "aws-sdk-client-mock": "^2.0.1",
+        "aws-sdk-client-mock-jest": "^2.0.1"
       }
     },
     "packages/tracer": {
@@ -16741,7 +17093,10 @@
     "@aws-lambda-powertools/parameters": {
       "version": "file:packages/parameters",
       "requires": {
-        "@aws-sdk/util-base64": "^3.208.0"
+        "@aws-sdk/client-secrets-manager": "*",
+        "@aws-sdk/util-base64": "^3.208.0",
+        "aws-sdk-client-mock": "^2.0.1",
+        "aws-sdk-client-mock-jest": "^2.0.1"
       }
     },
     "@aws-lambda-powertools/tracer": {
@@ -16815,6 +17170,313 @@
           "version": "8.3.2",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
           "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+        }
+      }
+    },
+    "@aws-sdk/client-secrets-manager": {
+      "version": "3.238.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.238.0.tgz",
+      "integrity": "sha512-J3lmceh2txILEh8tWf4ldp8ThAh2WJBSa1t8oJhW58KuE+1a7cwOpgWO6MsSvOrGtp7qzTr8GMBUf7KLdv7wOg==",
+      "dev": true,
+      "requires": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/client-sts": "3.238.0",
+        "@aws-sdk/config-resolver": "3.234.0",
+        "@aws-sdk/credential-provider-node": "3.238.0",
+        "@aws-sdk/fetch-http-handler": "3.226.0",
+        "@aws-sdk/hash-node": "3.226.0",
+        "@aws-sdk/invalid-dependency": "3.226.0",
+        "@aws-sdk/middleware-content-length": "3.226.0",
+        "@aws-sdk/middleware-endpoint": "3.226.0",
+        "@aws-sdk/middleware-host-header": "3.226.0",
+        "@aws-sdk/middleware-logger": "3.226.0",
+        "@aws-sdk/middleware-recursion-detection": "3.226.0",
+        "@aws-sdk/middleware-retry": "3.235.0",
+        "@aws-sdk/middleware-serde": "3.226.0",
+        "@aws-sdk/middleware-signing": "3.226.0",
+        "@aws-sdk/middleware-stack": "3.226.0",
+        "@aws-sdk/middleware-user-agent": "3.226.0",
+        "@aws-sdk/node-config-provider": "3.226.0",
+        "@aws-sdk/node-http-handler": "3.226.0",
+        "@aws-sdk/protocol-http": "3.226.0",
+        "@aws-sdk/smithy-client": "3.234.0",
+        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/url-parser": "3.226.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.234.0",
+        "@aws-sdk/util-defaults-mode-node": "3.234.0",
+        "@aws-sdk/util-endpoints": "3.226.0",
+        "@aws-sdk/util-retry": "3.229.0",
+        "@aws-sdk/util-user-agent-browser": "3.226.0",
+        "@aws-sdk/util-user-agent-node": "3.226.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "tslib": "^2.3.1",
+        "uuid": "^8.3.2"
+      },
+      "dependencies": {
+        "@aws-sdk/client-sso": {
+          "version": "3.238.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.238.0.tgz",
+          "integrity": "sha512-KHJJWP7hBDa9KLYiU5+hOb+3AAba93PhWebXkpKyQ/Bs+e7ECCreyLCwuME6uWTV01NDuFDpwZ6zUMpyNIcP6Q==",
+          "dev": true,
+          "requires": {
+            "@aws-crypto/sha256-browser": "2.0.0",
+            "@aws-crypto/sha256-js": "2.0.0",
+            "@aws-sdk/config-resolver": "3.234.0",
+            "@aws-sdk/fetch-http-handler": "3.226.0",
+            "@aws-sdk/hash-node": "3.226.0",
+            "@aws-sdk/invalid-dependency": "3.226.0",
+            "@aws-sdk/middleware-content-length": "3.226.0",
+            "@aws-sdk/middleware-endpoint": "3.226.0",
+            "@aws-sdk/middleware-host-header": "3.226.0",
+            "@aws-sdk/middleware-logger": "3.226.0",
+            "@aws-sdk/middleware-recursion-detection": "3.226.0",
+            "@aws-sdk/middleware-retry": "3.235.0",
+            "@aws-sdk/middleware-serde": "3.226.0",
+            "@aws-sdk/middleware-stack": "3.226.0",
+            "@aws-sdk/middleware-user-agent": "3.226.0",
+            "@aws-sdk/node-config-provider": "3.226.0",
+            "@aws-sdk/node-http-handler": "3.226.0",
+            "@aws-sdk/protocol-http": "3.226.0",
+            "@aws-sdk/smithy-client": "3.234.0",
+            "@aws-sdk/types": "3.226.0",
+            "@aws-sdk/url-parser": "3.226.0",
+            "@aws-sdk/util-base64": "3.208.0",
+            "@aws-sdk/util-body-length-browser": "3.188.0",
+            "@aws-sdk/util-body-length-node": "3.208.0",
+            "@aws-sdk/util-defaults-mode-browser": "3.234.0",
+            "@aws-sdk/util-defaults-mode-node": "3.234.0",
+            "@aws-sdk/util-endpoints": "3.226.0",
+            "@aws-sdk/util-retry": "3.229.0",
+            "@aws-sdk/util-user-agent-browser": "3.226.0",
+            "@aws-sdk/util-user-agent-node": "3.226.0",
+            "@aws-sdk/util-utf8-browser": "3.188.0",
+            "@aws-sdk/util-utf8-node": "3.208.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/client-sso-oidc": {
+          "version": "3.238.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.238.0.tgz",
+          "integrity": "sha512-kazcA2Kp+cXQRtaZi5/T5YFfU9J3nzu1tXJsh0xAm+J3S9LS1ertY1bSX6KBed2xuxx2mfum8JRqli0TJad/pA==",
+          "dev": true,
+          "requires": {
+            "@aws-crypto/sha256-browser": "2.0.0",
+            "@aws-crypto/sha256-js": "2.0.0",
+            "@aws-sdk/config-resolver": "3.234.0",
+            "@aws-sdk/fetch-http-handler": "3.226.0",
+            "@aws-sdk/hash-node": "3.226.0",
+            "@aws-sdk/invalid-dependency": "3.226.0",
+            "@aws-sdk/middleware-content-length": "3.226.0",
+            "@aws-sdk/middleware-endpoint": "3.226.0",
+            "@aws-sdk/middleware-host-header": "3.226.0",
+            "@aws-sdk/middleware-logger": "3.226.0",
+            "@aws-sdk/middleware-recursion-detection": "3.226.0",
+            "@aws-sdk/middleware-retry": "3.235.0",
+            "@aws-sdk/middleware-serde": "3.226.0",
+            "@aws-sdk/middleware-stack": "3.226.0",
+            "@aws-sdk/middleware-user-agent": "3.226.0",
+            "@aws-sdk/node-config-provider": "3.226.0",
+            "@aws-sdk/node-http-handler": "3.226.0",
+            "@aws-sdk/protocol-http": "3.226.0",
+            "@aws-sdk/smithy-client": "3.234.0",
+            "@aws-sdk/types": "3.226.0",
+            "@aws-sdk/url-parser": "3.226.0",
+            "@aws-sdk/util-base64": "3.208.0",
+            "@aws-sdk/util-body-length-browser": "3.188.0",
+            "@aws-sdk/util-body-length-node": "3.208.0",
+            "@aws-sdk/util-defaults-mode-browser": "3.234.0",
+            "@aws-sdk/util-defaults-mode-node": "3.234.0",
+            "@aws-sdk/util-endpoints": "3.226.0",
+            "@aws-sdk/util-retry": "3.229.0",
+            "@aws-sdk/util-user-agent-browser": "3.226.0",
+            "@aws-sdk/util-user-agent-node": "3.226.0",
+            "@aws-sdk/util-utf8-browser": "3.188.0",
+            "@aws-sdk/util-utf8-node": "3.208.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/client-sts": {
+          "version": "3.238.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.238.0.tgz",
+          "integrity": "sha512-jQNwHqxWUGvWCN4o8KUFYQES8r41Oobu7x1KZOMrPhPxy27FUcDjBq/h85VoD2/AZlETSCZLiCnKV3KBh5pT5w==",
+          "dev": true,
+          "requires": {
+            "@aws-crypto/sha256-browser": "2.0.0",
+            "@aws-crypto/sha256-js": "2.0.0",
+            "@aws-sdk/config-resolver": "3.234.0",
+            "@aws-sdk/credential-provider-node": "3.238.0",
+            "@aws-sdk/fetch-http-handler": "3.226.0",
+            "@aws-sdk/hash-node": "3.226.0",
+            "@aws-sdk/invalid-dependency": "3.226.0",
+            "@aws-sdk/middleware-content-length": "3.226.0",
+            "@aws-sdk/middleware-endpoint": "3.226.0",
+            "@aws-sdk/middleware-host-header": "3.226.0",
+            "@aws-sdk/middleware-logger": "3.226.0",
+            "@aws-sdk/middleware-recursion-detection": "3.226.0",
+            "@aws-sdk/middleware-retry": "3.235.0",
+            "@aws-sdk/middleware-sdk-sts": "3.226.0",
+            "@aws-sdk/middleware-serde": "3.226.0",
+            "@aws-sdk/middleware-signing": "3.226.0",
+            "@aws-sdk/middleware-stack": "3.226.0",
+            "@aws-sdk/middleware-user-agent": "3.226.0",
+            "@aws-sdk/node-config-provider": "3.226.0",
+            "@aws-sdk/node-http-handler": "3.226.0",
+            "@aws-sdk/protocol-http": "3.226.0",
+            "@aws-sdk/smithy-client": "3.234.0",
+            "@aws-sdk/types": "3.226.0",
+            "@aws-sdk/url-parser": "3.226.0",
+            "@aws-sdk/util-base64": "3.208.0",
+            "@aws-sdk/util-body-length-browser": "3.188.0",
+            "@aws-sdk/util-body-length-node": "3.208.0",
+            "@aws-sdk/util-defaults-mode-browser": "3.234.0",
+            "@aws-sdk/util-defaults-mode-node": "3.234.0",
+            "@aws-sdk/util-endpoints": "3.226.0",
+            "@aws-sdk/util-retry": "3.229.0",
+            "@aws-sdk/util-user-agent-browser": "3.226.0",
+            "@aws-sdk/util-user-agent-node": "3.226.0",
+            "@aws-sdk/util-utf8-browser": "3.188.0",
+            "@aws-sdk/util-utf8-node": "3.208.0",
+            "fast-xml-parser": "4.0.11",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/config-resolver": {
+          "version": "3.234.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.234.0.tgz",
+          "integrity": "sha512-uZxy4wzllfvgCQxVc+Iqhde0NGAnfmV2hWR6ejadJaAFTuYNvQiRg9IqJy3pkyDPqXySiJ8Bom5PoJfgn55J/A==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/signature-v4": "3.226.0",
+            "@aws-sdk/types": "3.226.0",
+            "@aws-sdk/util-config-provider": "3.208.0",
+            "@aws-sdk/util-middleware": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-ini": {
+          "version": "3.238.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.238.0.tgz",
+          "integrity": "sha512-WmPNtIYyUasjV7VQxvPNq7ihmx0vFsiKAtjNjjakdrt5TPoma4nUYb9tIG9SuG+kcp4DJIgRLJAgZtXbCcVimg==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.226.0",
+            "@aws-sdk/credential-provider-imds": "3.226.0",
+            "@aws-sdk/credential-provider-process": "3.226.0",
+            "@aws-sdk/credential-provider-sso": "3.238.0",
+            "@aws-sdk/credential-provider-web-identity": "3.226.0",
+            "@aws-sdk/property-provider": "3.226.0",
+            "@aws-sdk/shared-ini-file-loader": "3.226.0",
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-node": {
+          "version": "3.238.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.238.0.tgz",
+          "integrity": "sha512-/RN5EyGfgdIIJdFzv+O0nSaHX1/F3anQjTIBeVg8GJ+82m+bDxMdALsG+NzkYnLilN9Uhc1lSNjLBCoPa5DSEg==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.226.0",
+            "@aws-sdk/credential-provider-imds": "3.226.0",
+            "@aws-sdk/credential-provider-ini": "3.238.0",
+            "@aws-sdk/credential-provider-process": "3.226.0",
+            "@aws-sdk/credential-provider-sso": "3.238.0",
+            "@aws-sdk/credential-provider-web-identity": "3.226.0",
+            "@aws-sdk/property-provider": "3.226.0",
+            "@aws-sdk/shared-ini-file-loader": "3.226.0",
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-sso": {
+          "version": "3.238.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.238.0.tgz",
+          "integrity": "sha512-i70V4bFlCVYey3QARJ6XxKEg/4YuoFRnePV2oK37UHOGpEn49uXKwVZqLjzJgFHln7BPlC06cWDqrHUQIMvYrQ==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/client-sso": "3.238.0",
+            "@aws-sdk/property-provider": "3.226.0",
+            "@aws-sdk/shared-ini-file-loader": "3.226.0",
+            "@aws-sdk/token-providers": "3.238.0",
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-retry": {
+          "version": "3.235.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.235.0.tgz",
+          "integrity": "sha512-50WHbJGpD3SNp9763MAlHqIhXil++JdQbKejNpHg7HsJne/ao3ub+fDOfx//mMBjpzBV25BGd5UlfL6blrClSg==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/protocol-http": "3.226.0",
+            "@aws-sdk/service-error-classification": "3.229.0",
+            "@aws-sdk/types": "3.226.0",
+            "@aws-sdk/util-middleware": "3.226.0",
+            "@aws-sdk/util-retry": "3.229.0",
+            "tslib": "^2.3.1",
+            "uuid": "^8.3.2"
+          }
+        },
+        "@aws-sdk/smithy-client": {
+          "version": "3.234.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.234.0.tgz",
+          "integrity": "sha512-8AtR/k4vsFvjXeQbIzq/Wy7Nbk48Ou0wUEeVYPHWHPSU8QamFWORkOwmKtKMfHAyZvmqiAPeQqHFkq+UJhWyyQ==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/middleware-stack": "3.226.0",
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/token-providers": {
+          "version": "3.238.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.238.0.tgz",
+          "integrity": "sha512-vYUwmy0kTzA99mJCVvad+/5RDlWve/xxnppT8DJK3JIdAgskp+rULY+joVnq2NSl489UAioUnFGs57vUxi8Pog==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/client-sso-oidc": "3.238.0",
+            "@aws-sdk/property-provider": "3.226.0",
+            "@aws-sdk/shared-ini-file-loader": "3.226.0",
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-defaults-mode-browser": {
+          "version": "3.234.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.234.0.tgz",
+          "integrity": "sha512-IHMKXjTbOD8XMz5+2oCOsVP94BYb9YyjXdns0aAXr2NAo7k2+RCzXQ2DebJXppGda1F6opFutoKwyVSN0cmbMw==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/property-provider": "3.226.0",
+            "@aws-sdk/types": "3.226.0",
+            "bowser": "^2.11.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-defaults-mode-node": {
+          "version": "3.234.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.234.0.tgz",
+          "integrity": "sha512-UGjQ+OjBYYhxFVtUY+jtr0ZZgzZh6OHtYwRhFt8IHewJXFCfZTyfsbX20szBj5y1S4HRIUJ7cwBLIytTqMbI5w==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/config-resolver": "3.234.0",
+            "@aws-sdk/credential-provider-imds": "3.226.0",
+            "@aws-sdk/node-config-provider": "3.226.0",
+            "@aws-sdk/property-provider": "3.226.0",
+            "@aws-sdk/types": "3.226.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+          "dev": true
         }
       }
     },

--- a/packages/parameters/package.json
+++ b/packages/parameters/package.json
@@ -52,5 +52,10 @@
     "secrets",
     "serverless",
     "nodejs"
-  ]
+  ],
+  "devDependencies": {
+    "@aws-sdk/client-secrets-manager": "^3.238.0",
+    "aws-sdk-client-mock": "^2.0.1",
+    "aws-sdk-client-mock-jest": "^2.0.1"
+  }
 }

--- a/packages/parameters/src/BaseProvider.ts
+++ b/packages/parameters/src/BaseProvider.ts
@@ -39,7 +39,7 @@ abstract class BaseProvider implements BaseProviderInterface {
    * this should be an acceptable tradeoff.
    * 
    * @param {string} name - Parameter name
-   * @param {GetOptionsInterface|DynamoDBGetOptionsInterface} options - Options to configure maximum age, trasformation, AWS SDK options, or force fetch
+   * @param {GetOptionsInterface|SecretsGetOptionsInterface} options - Options to configure maximum age, trasformation, AWS SDK options, or force fetch
    */
   public async get(name: string, options?: SecretsGetOptionsInterface): Promise<undefined | string | Uint8Array | Record<string, unknown>>;
   public async get(name: string, options?: GetOptionsInterface): Promise<undefined | string | Uint8Array | Record<string, unknown>> {

--- a/packages/parameters/src/BaseProvider.ts
+++ b/packages/parameters/src/BaseProvider.ts
@@ -5,6 +5,7 @@ import { ExpirableValue } from './ExpirableValue';
 import { TRANSFORM_METHOD_BINARY, TRANSFORM_METHOD_JSON } from './constants';
 import { GetParameterError, TransformParameterError } from './Exceptions';
 import type { BaseProviderInterface, GetMultipleOptionsInterface, GetOptionsInterface, TransformOptions } from './types';
+import type { SecretsGetOptionsInterface } from './types/SecretsProvider';
 
 // These providers are dinamycally intialized on first use of the helper functions
 const DEFAULT_PROVIDERS: Record<string, BaseProvider> = {};
@@ -38,8 +39,9 @@ abstract class BaseProvider implements BaseProviderInterface {
    * this should be an acceptable tradeoff.
    * 
    * @param {string} name - Parameter name
-   * @param {GetOptionsInterface} options - Options to configure maximum age, trasformation, AWS SDK options, or force fetch
+   * @param {GetOptionsInterface|DynamoDBGetOptionsInterface} options - Options to configure maximum age, trasformation, AWS SDK options, or force fetch
    */
+  public async get(name: string, options?: SecretsGetOptionsInterface): Promise<undefined | string | Uint8Array | Record<string, unknown>>;
   public async get(name: string, options?: GetOptionsInterface): Promise<undefined | string | Uint8Array | Record<string, unknown>> {
     const configs = new GetOptions(options);
     const key = [ name, configs.transform ].toString();

--- a/packages/parameters/src/BaseProvider.ts
+++ b/packages/parameters/src/BaseProvider.ts
@@ -132,7 +132,7 @@ abstract class BaseProvider implements BaseProviderInterface {
 
 }
 
-const transformValue = (value: string | Uint8Array | undefined, transform: TransformOptions, throwOnTransformError: boolean, key: string = ''): string | Record<string, unknown> | undefined => {
+const transformValue = (value: string | Uint8Array | undefined, transform: TransformOptions, throwOnTransformError: boolean, key: string): string | Record<string, unknown> | undefined => {
   try {
     const normalizedTransform = transform.toLowerCase();
     if (

--- a/packages/parameters/src/BaseProvider.ts
+++ b/packages/parameters/src/BaseProvider.ts
@@ -60,7 +60,7 @@ abstract class BaseProvider implements BaseProviderInterface {
     }
 
     if (value && configs.transform) {
-      value = transformValue(value, configs.transform, true);
+      value = transformValue(value, configs.transform, true, name);
     }
 
     if (value) {

--- a/packages/parameters/src/SecretsProvider.ts
+++ b/packages/parameters/src/SecretsProvider.ts
@@ -1,0 +1,57 @@
+import { BaseProvider } from './BaseProvider';
+import { SecretsManagerClient, GetSecretValueCommand } from '@aws-sdk/client-secrets-manager';
+import type { GetSecretValueCommandInput } from '@aws-sdk/client-secrets-manager';
+import type { SecretsProviderOptions, SecretsGetOptionsInterface } from 'types/SecretsProvider';
+
+class SecretsProvider extends BaseProvider {
+  public client: SecretsManagerClient;
+
+  public constructor (config?: SecretsProviderOptions) {
+    super();
+
+    const clientConfig = config?.clientConfig || {};
+    this.client = new SecretsManagerClient(clientConfig);
+  }
+
+  public async get(name: string, options?: SecretsGetOptionsInterface): Promise<undefined | string | Uint8Array | Record<string, unknown>> {
+    return super.get(name, options);
+  }
+
+  protected async _get(name: string, options?: SecretsGetOptionsInterface): Promise<string | Uint8Array | undefined> {
+    const sdkOptions: GetSecretValueCommandInput = {
+      SecretId: name,
+    };
+    if (options?.sdkOptions) {
+      this.removeNonOverridableOptions(options.sdkOptions as GetSecretValueCommandInput);
+      Object.assign(sdkOptions, options.sdkOptions);
+    }
+
+    const result = await this.client.send(new GetSecretValueCommand(sdkOptions));
+
+    if (result.SecretString) return result.SecretString;
+
+    return result.SecretBinary;
+  }
+
+  /**
+   * Retrieving multiple parameter values is not supported with AWS Secrets Manager.
+   */
+  protected async _getMultiple(_path: string, _options?: unknown): Promise<Record<string, string | undefined>> {
+    throw new Error('Method not implemented.');
+  }
+
+  /**
+   * Explicit arguments passed to the constructor will take precedence over ones passed to the method.
+   * For users who consume the library with TypeScript, this will be enforced by the type system. However,
+   * for JavaScript users, we need to manually delete the properties that are not allowed to be overridden.
+   */
+  protected removeNonOverridableOptions(options: GetSecretValueCommandInput): void {
+    if (options.hasOwnProperty('SecretId')) {
+      delete options.SecretId;
+    }
+  }
+}
+
+export {
+  SecretsProvider,
+};

--- a/packages/parameters/src/secrets/SecretsProvider.ts
+++ b/packages/parameters/src/secrets/SecretsProvider.ts
@@ -1,7 +1,13 @@
 import { BaseProvider } from '../BaseProvider';
-import { SecretsManagerClient, GetSecretValueCommand } from '@aws-sdk/client-secrets-manager';
+import {
+  SecretsManagerClient,
+  GetSecretValueCommand
+} from '@aws-sdk/client-secrets-manager';
 import type { GetSecretValueCommandInput } from '@aws-sdk/client-secrets-manager';
-import type { SecretsProviderOptions, SecretsGetOptionsInterface } from 'types/SecretsProvider';
+import type {
+  SecretsProviderOptions,
+  SecretsGetOptionsInterface
+} from '../types/SecretsProvider';
 
 class SecretsProvider extends BaseProvider {
   public client: SecretsManagerClient;
@@ -13,18 +19,21 @@ class SecretsProvider extends BaseProvider {
     this.client = new SecretsManagerClient(clientConfig);
   }
 
-  public async get(name: string, options?: SecretsGetOptionsInterface): Promise<undefined | string | Uint8Array | Record<string, unknown>> {
+  public async get(
+    name: string,
+    options?: SecretsGetOptionsInterface
+  ): Promise<undefined | string | Uint8Array | Record<string, unknown>> {
     return super.get(name, options);
   }
 
-  protected async _get(name: string, options?: SecretsGetOptionsInterface): Promise<string | Uint8Array | undefined> {
+  protected async _get(
+    name: string,
+    options?: SecretsGetOptionsInterface
+  ): Promise<string | Uint8Array | undefined> {
     const sdkOptions: GetSecretValueCommandInput = {
+      ...(options?.sdkOptions || {}),
       SecretId: name,
     };
-    if (options?.sdkOptions) {
-      this.removeNonOverridableOptions(options.sdkOptions as GetSecretValueCommandInput);
-      Object.assign(sdkOptions, options.sdkOptions);
-    }
 
     const result = await this.client.send(new GetSecretValueCommand(sdkOptions));
 
@@ -36,20 +45,12 @@ class SecretsProvider extends BaseProvider {
   /**
    * Retrieving multiple parameter values is not supported with AWS Secrets Manager.
    */
-  protected async _getMultiple(_path: string, _options?: unknown): Promise<Record<string, string | undefined>> {
+  protected async _getMultiple(
+    _path: string,
+    _options?: unknown
+  ): Promise<Record<string, string | undefined>> {
     throw new Error('Method not implemented.');
-  }
-
-  /**
-   * Explicit arguments passed to the constructor will take precedence over ones passed to the method.
-   * For users who consume the library with TypeScript, this will be enforced by the type system. However,
-   * for JavaScript users, we need to manually delete the properties that are not allowed to be overridden.
-   */
-  protected removeNonOverridableOptions(options: GetSecretValueCommandInput): void {
-    if (options.hasOwnProperty('SecretId')) {
-      delete options.SecretId;
-    }
-  }
+  } 
 }
 
 export {

--- a/packages/parameters/src/secrets/SecretsProvider.ts
+++ b/packages/parameters/src/secrets/SecretsProvider.ts
@@ -1,4 +1,4 @@
-import { BaseProvider } from './BaseProvider';
+import { BaseProvider } from '../BaseProvider';
 import { SecretsManagerClient, GetSecretValueCommand } from '@aws-sdk/client-secrets-manager';
 import type { GetSecretValueCommandInput } from '@aws-sdk/client-secrets-manager';
 import type { SecretsProviderOptions, SecretsGetOptionsInterface } from 'types/SecretsProvider';

--- a/packages/parameters/src/secrets/getSecret.ts
+++ b/packages/parameters/src/secrets/getSecret.ts
@@ -1,0 +1,15 @@
+import { DEFAULT_PROVIDERS } from '../BaseProvider';
+import { SecretsProvider } from './SecretsProvider';
+import type { SecretsGetOptionsInterface } from '../types/SecretsProvider';
+
+const getSecret = async (name: string, options?: SecretsGetOptionsInterface): Promise<undefined | string | Uint8Array | Record<string, unknown>> => {
+  if (!DEFAULT_PROVIDERS.hasOwnProperty('secrets')) {
+    DEFAULT_PROVIDERS.secrets = new SecretsProvider();
+  }
+  
+  return DEFAULT_PROVIDERS.secrets.get(name, options);
+};
+
+export {
+  getSecret
+};

--- a/packages/parameters/src/secrets/index.ts
+++ b/packages/parameters/src/secrets/index.ts
@@ -1,0 +1,2 @@
+export * from './SecretsProvider';
+export * from './getSecret';

--- a/packages/parameters/src/types/BaseProvider.ts
+++ b/packages/parameters/src/types/BaseProvider.ts
@@ -7,11 +7,7 @@ interface GetOptionsInterface {
   transform?: TransformOptions
 }
 
-interface GetMultipleOptionsInterface {
-  maxAge?: number
-  forceFetch?: boolean
-  sdkOptions?: unknown
-  transform?: string
+interface GetMultipleOptionsInterface extends GetOptionsInterface {
   throwOnTransformError?: boolean
 }
 

--- a/packages/parameters/src/types/SecretsProvider.ts
+++ b/packages/parameters/src/types/SecretsProvider.ts
@@ -1,19 +1,11 @@
-import type { TransformOptions } from './BaseProvider';
+import type { GetOptionsInterface } from './BaseProvider';
 import type { SecretsManagerClientConfig, GetSecretValueCommandInput } from '@aws-sdk/client-secrets-manager';
-
-// TODO: move this to BaseProvider.ts
-interface GetBaseOptionsInterface {
-  maxAge?: number
-  forceFetch?: boolean
-  decrypt?: boolean
-  transform?: TransformOptions
-}
 
 interface SecretsProviderOptions {
   clientConfig?: SecretsManagerClientConfig
 }
 
-interface SecretsGetOptionsInterface extends GetBaseOptionsInterface {
+interface SecretsGetOptionsInterface extends GetOptionsInterface {
   sdkOptions?: Omit<Partial<GetSecretValueCommandInput>, 'SecretId'>
 }
 

--- a/packages/parameters/src/types/SecretsProvider.ts
+++ b/packages/parameters/src/types/SecretsProvider.ts
@@ -1,0 +1,23 @@
+import type { TransformOptions } from './BaseProvider';
+import type { SecretsManagerClientConfig, GetSecretValueCommandInput } from '@aws-sdk/client-secrets-manager';
+
+// TODO: move this to BaseProvider.ts
+interface GetBaseOptionsInterface {
+  maxAge?: number
+  forceFetch?: boolean
+  decrypt?: boolean
+  transform?: TransformOptions
+}
+
+interface SecretsProviderOptions {
+  clientConfig?: SecretsManagerClientConfig
+}
+
+interface SecretsGetOptionsInterface extends GetBaseOptionsInterface {
+  sdkOptions?: Omit<Partial<GetSecretValueCommandInput>, 'SecretId'>
+}
+
+export type {
+  SecretsProviderOptions,
+  SecretsGetOptionsInterface,
+};

--- a/packages/parameters/tests/unit/BaseProvider.test.ts
+++ b/packages/parameters/tests/unit/BaseProvider.test.ts
@@ -217,6 +217,21 @@ describe('Class: BaseProvider', () => {
       expect(value).toEqual('my-value');
 
     });
+    
+    test('when called with an auto transform, and the value is a valid JSON, it returns the parsed value', async () => {
+
+      // Prepare
+      const mockData = JSON.stringify({ foo: 'bar' });
+      const provider = new TestProvider();
+      jest.spyOn(provider, '_get').mockImplementation(() => new Promise((resolve, _reject) => resolve(mockData)));
+
+      // Act
+      const value = await provider.get('my-parameter.json', { transform: 'auto' });
+
+      // Assess
+      expect(value).toStrictEqual({ foo: 'bar' });
+
+    });
 
   });
 

--- a/packages/parameters/tests/unit/SecretsProvider.test.ts
+++ b/packages/parameters/tests/unit/SecretsProvider.test.ts
@@ -80,6 +80,29 @@ describe('Class: SecretsProvider', () => {
 
     });
 
+    test('when called with sdkOptions that override arguments passed to the method, it gets the secret using the arguments', async () => {
+
+      // Prepare
+      const provider = new SecretsProvider();
+      const secretName = 'foo';
+      client.on(GetSecretValueCommand).resolves({
+        SecretString: 'bar',
+      });
+
+      // Act
+      await provider.get(secretName, {
+        sdkOptions: {
+          SecretId: 'test-secret',
+        } as unknown as GetSecretValueCommandInput,
+      });
+
+      // Assess
+      expect(client).toReceiveCommandWith(GetSecretValueCommand, {
+        SecretId: secretName,
+      });
+
+    });
+
   });
 
   describe('Method: _getMultiple', () => {
@@ -91,35 +114,6 @@ describe('Class: SecretsProvider', () => {
       
       // Act & Assess
       await expect(provider.getMultiple('foo')).rejects.toThrow('Method not implemented.');
-
-    });
-
-  });
-
-  describe('Method: removeNonOverridableOptions', () => {
-
-    class DummyProvider extends SecretsProvider {
-      public removeNonOverridableOptions(options: GetSecretValueCommandInput): void {
-        super.removeNonOverridableOptions(options);
-      }
-    }
-
-    test('when called with a valid GetSecretValueCommandInput, it removes the non-overridable options', () => {
-
-      // Prepare
-      const provider = new DummyProvider();
-      const options: GetSecretValueCommandInput = {
-        SecretId: 'test-secret',
-        VersionId: 'test-version',
-      };
-
-      // Act
-      provider.removeNonOverridableOptions(options);
-
-      // Assess
-      expect(options).toEqual({
-        VersionId: 'test-version',
-      });
 
     });
 

--- a/packages/parameters/tests/unit/SecretsProvider.test.ts
+++ b/packages/parameters/tests/unit/SecretsProvider.test.ts
@@ -3,7 +3,7 @@
  *
  * @group unit/parameters/SecretsProvider/class
  */
-import { SecretsProvider } from '../../src/SecretsProvider';
+import { SecretsProvider } from '../../src/secrets';
 import { SecretsManagerClient, GetSecretValueCommand } from '@aws-sdk/client-secrets-manager';
 import type { GetSecretValueCommandInput } from '@aws-sdk/client-secrets-manager';
 import { mockClient } from 'aws-sdk-client-mock';

--- a/packages/parameters/tests/unit/SecretsProvider.test.ts
+++ b/packages/parameters/tests/unit/SecretsProvider.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Test SecretsProvider class
+ *
+ * @group unit/parameters/SecretsProvider/class
+ */
+import { SecretsProvider } from '../../src/SecretsProvider';
+import { SecretsManagerClient, GetSecretValueCommand } from '@aws-sdk/client-secrets-manager';
+import type { GetSecretValueCommandInput } from '@aws-sdk/client-secrets-manager';
+import { mockClient } from 'aws-sdk-client-mock';
+import 'aws-sdk-client-mock-jest';
+
+const encoder = new TextEncoder();
+
+describe('Class: SecretsProvider', () => {
+
+  const client = mockClient(SecretsManagerClient);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('Method: _get', () => {
+
+    test('when called with only a name, it gets the secret string', async () => {
+
+      // Prepare
+      const provider = new SecretsProvider();
+      const secretName = 'foo';
+      client.on(GetSecretValueCommand).resolves({
+        SecretString: 'bar',
+      });
+
+      // Act
+      const result = await provider.get(secretName);
+
+      // Assess
+      expect(result).toBe('bar');
+
+    });
+
+    test('when called with only a name, it gets the secret binary', async () => {
+
+      // Prepare
+      const provider = new SecretsProvider();
+      const secretName = 'foo';
+      const mockData = encoder.encode('my-value');
+      client.on(GetSecretValueCommand).resolves({
+        SecretBinary: mockData,
+      });
+
+      // Act
+      const result = await provider.get(secretName);
+
+      // Assess
+      expect(result).toBe(mockData);
+
+    });
+
+    test('when called with a name and sdkOptions, it gets the secret using the options provided', async () => {
+
+      // Prepare
+      const provider = new SecretsProvider();
+      const secretName = 'foo';
+      client.on(GetSecretValueCommand).resolves({
+        SecretString: 'bar',
+      });
+
+      // Act
+      await provider.get(secretName, {
+        sdkOptions: {
+          VersionId: 'test-version',
+        }
+      });
+
+      // Assess
+      expect(client).toReceiveCommandWith(GetSecretValueCommand, {
+        SecretId: secretName,
+        VersionId: 'test-version',
+      });
+
+    });
+
+  });
+
+  describe('Method: _getMultiple', () => {
+    
+    test('when called, it throws an error', async () => {
+
+      // Prepare
+      const provider = new SecretsProvider();
+      
+      // Act & Assess
+      await expect(provider.getMultiple('foo')).rejects.toThrow('Method not implemented.');
+
+    });
+
+  });
+
+  describe('Method: removeNonOverridableOptions', () => {
+
+    class DummyProvider extends SecretsProvider {
+      public removeNonOverridableOptions(options: GetSecretValueCommandInput): void {
+        super.removeNonOverridableOptions(options);
+      }
+    }
+
+    test('when called with a valid GetSecretValueCommandInput, it removes the non-overridable options', () => {
+
+      // Prepare
+      const provider = new DummyProvider();
+      const options: GetSecretValueCommandInput = {
+        SecretId: 'test-secret',
+        VersionId: 'test-version',
+      };
+
+      // Act
+      provider.removeNonOverridableOptions(options);
+
+      // Assess
+      expect(options).toEqual({
+        VersionId: 'test-version',
+      });
+
+    });
+
+  });
+
+});

--- a/packages/parameters/tests/unit/getSecret.test.ts
+++ b/packages/parameters/tests/unit/getSecret.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Test getSecret function
+ *
+ * @group unit/parameters/SecretsProvider/getSecret/function
+ */
+import { DEFAULT_PROVIDERS } from '../../src/BaseProvider';
+import { SecretsProvider, getSecret } from '../../src/secrets';
+import { SecretsManagerClient, GetSecretValueCommand } from '@aws-sdk/client-secrets-manager';
+import { mockClient } from 'aws-sdk-client-mock';
+import 'aws-sdk-client-mock-jest';
+
+const encoder = new TextEncoder();
+
+describe('Function: getSecret', () => {
+
+  const client = mockClient(SecretsManagerClient);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('when called and a default provider doesn\'t exist, it instantiates one and returns the value', async () => {
+
+    // Prepare
+    const secretName = 'foo';
+    const secretValue = 'bar';
+    client.on(GetSecretValueCommand).resolves({
+      SecretString: secretValue,
+    });
+
+    // Act
+    const result = await getSecret(secretName);
+
+    // Assess
+    expect(client).toReceiveCommandWith(GetSecretValueCommand, { SecretId: secretName });
+    expect(result).toBe(secretValue);
+
+  });
+
+  test('when called and a default provider exists, it uses it and returns the value', async () => {
+
+    // Prepare
+    const provider = new SecretsProvider();
+    DEFAULT_PROVIDERS.secrets = provider;
+    const secretName = 'foo';
+    const secretValue = 'bar';
+    const binary = encoder.encode(secretValue);
+    client.on(GetSecretValueCommand).resolves({
+      SecretBinary: binary,
+    });
+
+    // Act
+    const result = await getSecret(secretName);
+
+    // Assess
+    expect(client).toReceiveCommandWith(GetSecretValueCommand, { SecretId: secretName });
+    expect(result).toStrictEqual(binary);
+    expect(DEFAULT_PROVIDERS.secrets).toBe(provider);
+
+  });
+
+});


### PR DESCRIPTION
## Description of your changes

This PR introduces the `SecretsProvider` class which will allow the future Parameters utility to support retrieving secrets from AWS Secrets Manager.

The `SecretsProvider` supports two retrieval modes, both for retrieving one secret at the time. This is in line with the current functionalities supported by the Parameters utility in Powertools for Python.

- `get` this class method allows customers to retrieve a single secret by name and allows to specify aspects like the transformation to apply (none, binary, json, automatic) and max age (aka time to live for the item in the cache).

The class method will be used as such:
```ts
const secrets = new SecretsProvider();

const secret = secrets.get('foo');
console.log(secret); // value as string or binary
```

- `getSecret` utility function that behaves the same as the the method, but doesn't require instantiating a class. 

```ts
const secret = getSecret('foo');
console.log(secret); // value as string or binary
```

In both cases users can configure how long the secret should be cached in the Lambda's execution environment:
```ts
const secretOne = secrets.get('foo', { maxAge: 5000 }); // This will be cached for 5 seconds
// or
const secretTwo = getSecret('foo', { maxAge: 10000 }); // This will be cached for 10 seconds
```

Secrets Manger allows to store secrets both as `SecretString` and `SecretBinary`. Both of them can be base64-encoded.

Using the provider or helper function, users can optionally specify a transform (`json`, `binary`, or `auto`) and SecretsProvider will try to transform the string or binary accordingly. When using `auto`, the name of the secret must have a suffix that specifies the transform to use (i.e. `my-secret.json` will result in a `json` transform). If no transform is specified, the secret will be returned as-is (aka `string` or `Uint8Array`).

Examples:

> **Note**
> The examples below use the `getSecret` notation for brevity, but the are 1:1 equivalent to `SecretsProvider.get(...)`

```ts
// SecretString: foo.json - value: "{ \"hello\": \"world\" }" (stringified version of an object)
const a = getSecret('foo.json');
console.log(a); // "{ \"hello\": \"world\" }" (returned as-is)

const b = getSecret('foo.json', { transform: 'auto' });
console.log(b); // { hello: 'world' } (type object)

const c = getSecret('foo.json', { transform: 'json' });
console.log(c); // { hello: 'world' } (type object)

// SecretString: bar.binary - value: "Yw==" (base64 encoded string - 'hello world')
const a = getSecret('bar.binary');
console.log(a); // "Yw==" (returned as-is)

const b = getSecret('bar.binary', { transform: 'auto' });
console.log(b); // "hello world" (type string - base64 decoded)

const c = getSecret('bar.binary', { transform: 'binary' });
console.log(c); // "hello world" (type string - base64 decoded)

// SecretBinary: baz.binary - value: "Yw==" (base64 encoded string - 'hello world')
const a = getSecret('bar.binary');
console.log(a); // [104, 101, 108, 108, 111,  32, 119, 111, 114, 108, 100] (Uint8Array - returned as-is)

const b = getSecret('bar.binary', { transform: 'auto' });
console.log(b); // "hello world" (type string - base64 decoded)

const c = getSecret('bar.binary', { transform: 'binary' });
console.log(c); // "hello world" (type string - base64 decoded)
```

Finally, users can also customize the behavior of the underlying AWS SDK client calls by passing an optional `sdkOptions` of type `GetSecretValueCommandInput` in the second argument:
```ts
const secret = getSecret('bar.binary', {
  sdkOptions: {
    VersionId: 'test-version',
  }
});
// or
const secrets = new SecretsProvider();

const secret = secrets.get('bar.binary', {
  sdkOptions: {
    VersionId: 'test-version',
  }
});
```

Or, **for class-based usage only**, they can pass their own SDK client config (of type `SecretsManagerClient`) altogether while initialising the instance:
```ts
const secrets = new SecretsProvider({
  clientConfig: { region: 'eu-west-1' }
});
```

### How to verify this change

See the newly added unit test cases & optionally compare also the API surface with the implementation [found in Powertools for Python](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/aws_lambda_powertools/utilities/parameters/secrets.py).

### Related issues, RFCs

<!--- Add here the number (i.e. #42) to the Github Issue or RFC that is related to this PR. -->
<!--- If no issue is present the PR might get blocked and not be reviewed. -->
**Issue number:** #1175 

### PR status

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-typescript/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [ ] I have made corresponding changes to the *documentation*
- [ ] I have made corresponding changes to the *examples*
- [x] My changes generate *no new warnings*
- [x] The *code coverage* hasn't decreased
- [x] I have *added tests* that prove my change is effective and works
- [x] New and existing *unit tests pass* locally and in Github Actions
- [x] Any *dependent changes have been merged and published*
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

- [ ] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
