### PR TITLE
refactor: types in BaseProvider + added getMultiple alias to SecretsProvider

### DIFF
--- a/packages/parameters/src/BaseProvider.ts
+++ b/packages/parameters/src/BaseProvider.ts
@@ -5,7 +5,6 @@ import { ExpirableValue } from './ExpirableValue';
 import { TRANSFORM_METHOD_BINARY, TRANSFORM_METHOD_JSON } from './constants';
 import { GetParameterError, TransformParameterError } from './Exceptions';
 import type { BaseProviderInterface, GetMultipleOptionsInterface, GetOptionsInterface, TransformOptions } from './types';
-import type { SecretsGetOptionsInterface } from './types/SecretsProvider';
 
 // These providers are dinamycally intialized on first use of the helper functions
 const DEFAULT_PROVIDERS: Record<string, BaseProvider> = {};
@@ -39,9 +38,8 @@ abstract class BaseProvider implements BaseProviderInterface {
    * this should be an acceptable tradeoff.
    * 
    * @param {string} name - Parameter name
-   * @param {GetOptionsInterface|SecretsGetOptionsInterface} options - Options to configure maximum age, trasformation, AWS SDK options, or force fetch
+   * @param {GetOptionsInterface} options - Options to configure maximum age, trasformation, AWS SDK options, or force fetch
    */
-  public async get(name: string, options?: SecretsGetOptionsInterface): Promise<undefined | string | Uint8Array | Record<string, unknown>>;
   public async get(name: string, options?: GetOptionsInterface): Promise<undefined | string | Uint8Array | Record<string, unknown>> {
     const configs = new GetOptions(options);
     const key = [ name, configs.transform ].toString();

--- a/packages/parameters/src/secrets/SecretsProvider.ts
+++ b/packages/parameters/src/secrets/SecretsProvider.ts
@@ -26,6 +26,16 @@ class SecretsProvider extends BaseProvider {
     return super.get(name, options);
   }
 
+  /**
+   * Retrieving multiple parameter values is not supported with AWS Secrets Manager.
+   */
+  public async getMultiple(
+    path: string,
+    _options?: unknown
+  ): Promise<undefined | Record<string, unknown>> {
+    return super.getMultiple(path);
+  }
+
   protected async _get(
     name: string,
     options?: SecretsGetOptionsInterface


### PR DESCRIPTION
## Description of your changes

This PR removes the method overrides from the `get` and `getMultiple` methods in the `BaseProvider` so that children classes can set their own types on these methods. See #1213 for full details.

### How to verify this change

See existing checks under the PR.

### Related issues, RFCs

<!--- Add here the number (i.e. #42) to the Github Issue or RFC that is related to this PR. -->
<!--- If no issue is present the PR might get blocked and not be reviewed. -->
**Issue number:** #1213

### PR status

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-typescript/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [ ] I have made corresponding changes to the *documentation*
- [ ] I have made corresponding changes to the *examples*
- [x] My changes generate *no new warnings*
- [x] The *code coverage* hasn't decreased
- [x] I have *added tests* that prove my change is effective and works
- [x] New and existing *unit tests pass* locally and in Github Actions
- [ ] Any *dependent changes have been merged and published*
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

- [ ] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
