### PR TITLE
chore(docs): bumped mkdocs-material to latest + small tweaks

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
 mike==1.1.2
-mkdocs-material==8.5.9
+mkdocs-material==9.0.2
 mkdocs-git-revision-date-plugin==0.3.2

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,12 +21,13 @@ theme:
   palette:
     - scheme: default
       primary: deep orange
+      accent: deep orange
       toggle:
         icon: material/toggle-switch-off-outline
         name: Switch to dark mode
     - scheme: slate
-      primary: indigo
-      accent: teal
+      primary: deep orange
+      accent: deep orange
       toggle:
         icon: material/toggle-switch
         name: Switch to light mode
@@ -41,6 +42,7 @@ theme:
     - content.code.annotate
     - toc.follow
     - toc.integrate
+    - announce.dismiss
   icon:
     repo: fontawesome/brands/github
   logo: media/aws-logo-light.svg
@@ -88,3 +90,9 @@ extra:
   version:
     provider: mike
     default: latest
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/awslabs/aws-lambda-powertools-typescript
+    - icon: fontawesome/brands/discord
+      link: https://discord.gg/B8zZKbbyET
+      name: Join our Discord Server!


### PR DESCRIPTION
## Description of your changes

This PR bumps the version of `mkdocs-material` to `9.0.2` (from `8.5.9`) and introduces a handful minor tweaks to the docs:
- Consolidate primary & accent colors to `deep orange` in both light & dark themes
- Add option to dismiss announcements / banners
- Add icon links for repo & Discord Server in site footer

### How to verify this change

See published version after merge.

### Related issues, RFCs

<!--- Add here the number (i.e. #42) to the Github Issue or RFC that is related to this PR. -->
<!--- If no issue is present the PR might get blocked and not be reviewed. -->
**Issue number:** #1216

### PR status

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-typescript/#tenets)
- [x] I have performed a *self-review* of my own code
- [ ] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [x] I have made corresponding changes to the *documentation*
- [ ] I have made corresponding changes to the *examples*
- [ ] My changes generate *no new warnings*
- [x] The *code coverage* hasn't decreased
- [ ] I have *added tests* that prove my change is effective and works
- [ ] New and existing *unit tests pass* locally and in Github Actions
- [ ] Any *dependent changes have been merged and published*
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

- [ ] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
