### PR TITLE
chore(parameters): revisit utility types

### DIFF
--- a/packages/parameters/src/BaseProvider.ts
+++ b/packages/parameters/src/BaseProvider.ts
@@ -65,7 +65,6 @@ abstract class BaseProvider implements BaseProviderInterface {
       this.addToCache(key, value, configs.maxAge);
     }
 
-    // TODO: revisit return type once providers are implemented, it might be missing binary when not transformed
     return value;
   }
 
@@ -94,7 +93,6 @@ abstract class BaseProvider implements BaseProviderInterface {
       this.addToCache(key, values, configs.maxAge);
     }
 
-    // TODO: revisit return type once providers are implemented, it might be missing something
     return values;
   }
 

--- a/packages/parameters/src/ssm/SSMProvider.ts
+++ b/packages/parameters/src/ssm/SSMProvider.ts
@@ -21,7 +21,7 @@ import type {
   SSMGetParametersByNameOptionsInterface,
   SSMSplitBatchAndDecryptParametersOutputType,
   SSMGetParametersByNameFromCacheOutputType,
-} from 'types/SSMProvider';
+} from '../types/SSMProvider';
 import type { PaginationConfiguration } from '@aws-sdk/types';
 
 class SSMProvider extends BaseProvider {

--- a/packages/parameters/src/ssm/getParametersByName.ts
+++ b/packages/parameters/src/ssm/getParametersByName.ts
@@ -1,10 +1,12 @@
 import { SSMProvider, DEFAULT_PROVIDERS } from './SSMProvider';
-import type { SSMGetParametersByNameOptionsInterface } from '../types/SSMProvider';
+import type {
+  SSMGetParametersByNameOptionsInterface
+} from '../types/SSMProvider';
 
 const getParametersByName = (
   parameters: Record<string, SSMGetParametersByNameOptionsInterface>,
   options?: SSMGetParametersByNameOptionsInterface
-): Promise<Record<string, unknown>> => {
+): Promise<Record<string, unknown> & { _errors?: string[] }> => {
   if (!DEFAULT_PROVIDERS.hasOwnProperty('ssm')) {
     DEFAULT_PROVIDERS.ssm = new SSMProvider();
   }

--- a/packages/parameters/src/ssm/index.ts
+++ b/packages/parameters/src/ssm/index.ts
@@ -2,3 +2,4 @@ export * from './SSMProvider';
 export * from './getParameter';
 export * from './getParameters';
 export * from './getParametersByName';
+export * from '../types/SSMProvider';

--- a/packages/parameters/src/types/AppConfigProvider.ts
+++ b/packages/parameters/src/types/AppConfigProvider.ts
@@ -43,7 +43,7 @@ interface GetAppConfigCombinedInterface
   extends Omit<AppConfigProviderOptions, 'clientConfig'>,
   AppConfigGetOptionsInterface {}
 
-export {
+export type {
   AppConfigProviderOptions,
   AppConfigGetOptionsInterface,
   GetAppConfigCombinedInterface,

--- a/packages/parameters/src/types/BaseProvider.ts
+++ b/packages/parameters/src/types/BaseProvider.ts
@@ -21,7 +21,7 @@ interface BaseProviderInterface {
   getMultiple(path: string, options?: GetMultipleOptionsInterface): Promise<void | Record<string, unknown>>
 }
 
-export {
+export type {
   GetOptionsInterface,
   GetMultipleOptionsInterface,
   BaseProviderInterface,

--- a/packages/parameters/src/types/SSMProvider.ts
+++ b/packages/parameters/src/types/SSMProvider.ts
@@ -3,7 +3,11 @@ import type {
   GetParameterCommandInput,
   GetParametersByPathCommandInput
 } from '@aws-sdk/client-ssm';
-import type { GetOptionsInterface, GetMultipleOptionsInterface, TransformOptions } from './BaseProvider';
+import type {
+  GetOptionsInterface,
+  GetMultipleOptionsInterface,
+  TransformOptions
+} from './BaseProvider';
 
 interface SSMProviderOptionsInterface {
   clientConfig: SSMClientConfig
@@ -51,7 +55,7 @@ type SSMGetParametersByNameFromCacheOutputType = {
   toFetch: Record<string, SSMGetParametersByNameOptionsInterface>
 };
 
-export {
+export type {
   SSMProviderOptionsInterface,
   SSMGetOptionsInterface,
   SSMGetMultipleOptionsInterface,

--- a/packages/parameters/src/types/index.ts
+++ b/packages/parameters/src/types/index.ts
@@ -1,1 +1,5 @@
 export * from './BaseProvider';
+export * from './AppConfigProvider';
+export * from './SSMProvider';
+export * from './SecretsProvider';
+export * from './DynamoDBProvider';

--- a/packages/parameters/tests/unit/AppConfigProvider.test.ts
+++ b/packages/parameters/tests/unit/AppConfigProvider.test.ts
@@ -4,7 +4,7 @@
  * @group unit/parameters/AppConfigProvider/class
  */
 import { AppConfigProvider } from '../../src/appconfig/index';
-
+import { AppConfigProviderOptions } from '../../src/types/AppConfigProvider';
 import {
   AppConfigDataClient,
   StartConfigurationSessionCommand,
@@ -12,7 +12,6 @@ import {
 } from '@aws-sdk/client-appconfigdata';
 import { mockClient } from 'aws-sdk-client-mock';
 import 'aws-sdk-client-mock-jest';
-import { AppConfigProviderOptions } from '../../src/types/AppConfigProvider';
 
 describe('Class: AppConfigProvider', () => {
   const client = mockClient(AppConfigDataClient);

--- a/packages/parameters/tests/unit/BaseProvider.test.ts
+++ b/packages/parameters/tests/unit/BaseProvider.test.ts
@@ -3,8 +3,12 @@
  *
  * @group unit/parameters/baseProvider/class
  */
-
-import { BaseProvider, ExpirableValue, GetParameterError, TransformParameterError } from '../../src';
+import {
+  BaseProvider,
+  ExpirableValue,
+  GetParameterError,
+  TransformParameterError
+} from '../../src';
 import { toBase64 } from '@aws-sdk/util-base64';
 
 const encoder = new TextEncoder();

--- a/packages/parameters/tests/unit/getParametersByName.test.ts
+++ b/packages/parameters/tests/unit/getParametersByName.test.ts
@@ -5,6 +5,7 @@
  */
 import { DEFAULT_PROVIDERS } from '../../src/BaseProvider';
 import { SSMProvider, getParametersByName } from '../../src/ssm';
+import type { SSMGetParametersByNameOptionsInterface } from '../../src/types/SSMProvider';
 
 describe('Function: getParametersByName', () => {
 
@@ -15,12 +16,13 @@ describe('Function: getParametersByName', () => {
   test('when called and a default provider doesn\'t exist, it instantiates one and returns the value', async () => {
 
     // Prepare
-    const parameters = {
+    const parameters: Record<string, SSMGetParametersByNameOptionsInterface> = {
       '/foo/bar': {
         maxAge: 1000,
       },
       '/foo/baz': {
         maxAge: 2000,
+        transform: 'json',
       }
     };
     const getParametersByNameSpy = jest.spyOn(SSMProvider.prototype, 'getParametersByName').mockImplementation();


### PR DESCRIPTION
## Description of your changes

As discussed in #1172, now that the main implementation of the utility is complete, we are able to pencil down the types of the various providers.

This PR removes the `# TODO` items from the code as well as fixing the types and their exports. 

### How to verify this change

See unit tests.

### Related issues, RFCs

<!--- Add here the number (i.e. #42) to the Github Issue or RFC that is related to this PR. -->
<!--- If no issue is present the PR might get blocked and not be reviewed. -->
**Issue number:** #1172 

### PR status

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-typescript/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [ ] I have made corresponding changes to the *documentation*
- [ ] I have made corresponding changes to the *examples*
- [x] My changes generate *no new warnings*
- [x] The *code coverage* hasn't decreased
- [ ] I have *added tests* that prove my change is effective and works
- [x] New and existing *unit tests pass* locally and in Github Actions
- [x] Any *dependent changes have been merged and published*
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

- [ ] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
