### PR TITLE
refactor(all): add middy-like types to commons

### DIFF
--- a/packages/commons/src/index.ts
+++ b/packages/commons/src/index.ts
@@ -3,3 +3,4 @@ export * from './Utility';
 export * from './config';
 export * as ContextExamples from './samples/resources/contexts';
 export * as Events from './samples/resources/events';
+export * from './utils/middleware/middy';

--- a/packages/commons/src/index.ts
+++ b/packages/commons/src/index.ts
@@ -3,4 +3,4 @@ export * from './Utility';
 export * from './config';
 export * as ContextExamples from './samples/resources/contexts';
 export * as Events from './samples/resources/events';
-export * from './utils/middleware/middy';
+export * from './types/middy';

--- a/packages/commons/src/types/middy.ts
+++ b/packages/commons/src/types/middy.ts
@@ -7,7 +7,7 @@ import { Context } from 'aws-lambda';
  * and use `tsc` to compile their code will get an error if we import from @middy/core, see #1068.
  * Given that we use a subset of the @middy/core types, we can define them here and avoid the dependency.
  */
-interface Request<TEvent = unknown, TResult = unknown, TErr = Error, TContext extends Context = Context> {
+type Request<TEvent = unknown, TResult = unknown, TErr = Error, TContext extends Context = Context> = {
   event: TEvent
   context: TContext
   response: TResult | null
@@ -15,19 +15,19 @@ interface Request<TEvent = unknown, TResult = unknown, TErr = Error, TContext ex
   internal: {
     [key: string]: unknown
   }
-}
+};
 
 declare type MiddlewareFn<TEvent = unknown, TResult = unknown, TErr = Error, TContext extends Context = Context> = (request: Request<TEvent, TResult, TErr, TContext>) => unknown;
 
-export interface MiddlewareLikeObj<TEvent = unknown, TResult = unknown, TErr = Error, TContext extends Context = Context> {
+export type MiddlewareLikeObj<TEvent = unknown, TResult = unknown, TErr = Error, TContext extends Context = Context> = {
   before?: MiddlewareFn<TEvent, TResult, TErr, TContext>
   after?: MiddlewareFn<TEvent, TResult, TErr, TContext>
   onError?: MiddlewareFn<TEvent, TResult, TErr, TContext>
-}
+};
 
-export interface MiddyLikeRequest {
+export type MiddyLikeRequest = {
   event: unknown
   context: Context
   response: unknown | null
   error: Error | null
-}
+};

--- a/packages/commons/src/utils/middleware/middy.ts
+++ b/packages/commons/src/utils/middleware/middy.ts
@@ -1,0 +1,33 @@
+import { Context } from 'aws-lambda';
+
+/**
+ * We need to define these types and interfaces here because we can't import them from @middy/core.
+ * Importing them from @middy/core would introduce a dependency on @middy/core, which we don't want
+ * because we want to keep it as an optional dependency. Those users who don't use the Powertools middleware
+ * and use `tsc` to compile their code will get an error if we import from @middy/core, see #1068.
+ * Given that we use a subset of the @middy/core types, we can define them here and avoid the dependency.
+ */
+interface Request<TEvent = unknown, TResult = unknown, TErr = Error, TContext extends Context = Context> {
+  event: TEvent
+  context: TContext
+  response: TResult | null
+  error: TErr | null
+  internal: {
+    [key: string]: unknown
+  }
+}
+
+declare type MiddlewareFn<TEvent = unknown, TResult = unknown, TErr = Error, TContext extends Context = Context> = (request: Request<TEvent, TResult, TErr, TContext>) => unknown;
+
+export interface MiddlewareLikeObj<TEvent = unknown, TResult = unknown, TErr = Error, TContext extends Context = Context> {
+  before?: MiddlewareFn<TEvent, TResult, TErr, TContext>
+  after?: MiddlewareFn<TEvent, TResult, TErr, TContext>
+  onError?: MiddlewareFn<TEvent, TResult, TErr, TContext>
+}
+
+export interface MiddyLikeRequest {
+  event: unknown
+  context: Context
+  response: unknown | null
+  error: Error | null
+}

--- a/packages/logger/src/middleware/middy.ts
+++ b/packages/logger/src/middleware/middy.ts
@@ -1,6 +1,9 @@
 import { Logger } from '../Logger';
-import type middy from '@middy/core';
 import { HandlerOptions, LogAttributes } from '../types';
+import type {
+  MiddlewareLikeObj,
+  MiddyLikeRequest
+} from '@aws-lambda-powertools/commons';
 
 /**
  * A middy middleware that helps emitting CloudWatch EMF metrics in your logs.
@@ -26,12 +29,12 @@ import { HandlerOptions, LogAttributes } from '../types';
  * @param options - (_optional_) Options for the middleware
  * @returns - The middy middleware object
  */
-const injectLambdaContext = (target: Logger | Logger[], options?: HandlerOptions): middy.MiddlewareObj => {
+const injectLambdaContext = (target: Logger | Logger[], options?: HandlerOptions): MiddlewareLikeObj => {
 
   const loggers = target instanceof Array ? target : [target];
   const persistentAttributes: LogAttributes[] = [];
 
-  const injectLambdaContextBefore = async (request: middy.Request): Promise<void> => {
+  const injectLambdaContextBefore = async (request: MiddyLikeRequest): Promise<void> => {
     loggers.forEach((logger: Logger) => {
       if (options && options.clearState === true) {
         persistentAttributes.push({ ...logger.getPersistentLogAttributes() });

--- a/packages/metrics/src/middleware/middy.ts
+++ b/packages/metrics/src/middleware/middy.ts
@@ -1,6 +1,9 @@
 import type { Metrics } from '../Metrics';
-import type middy from '@middy/core';
 import type { ExtraOptions } from '../types';
+import type {
+  MiddlewareLikeObj,
+  MiddyLikeRequest
+} from '@aws-lambda-powertools/commons';
 
 /**
  * A middy middleware automating capture of metadata and annotations on segments or subsegments for a Lambda Handler.
@@ -29,10 +32,10 @@ import type { ExtraOptions } from '../types';
  * @param options - (_optional_) Options for the middleware
  * @returns middleware - The middy middleware object
  */
-const logMetrics = (target: Metrics | Metrics[], options: ExtraOptions = {}): middy.MiddlewareObj => {
+const logMetrics = (target: Metrics | Metrics[], options: ExtraOptions = {}): MiddlewareLikeObj => {
   const metricsInstances = target instanceof Array ? target : [target];
 
-  const logMetricsBefore = async (request: middy.Request): Promise<void> => {
+  const logMetricsBefore = async (request: MiddyLikeRequest): Promise<void> => {
     metricsInstances.forEach((metrics: Metrics) => {
       metrics.setFunctionName(request.context.functionName);
       const { throwOnEmptyMetrics, defaultDimensions, captureColdStartMetric } = options;

--- a/packages/tracer/src/middleware/middy.ts
+++ b/packages/tracer/src/middleware/middy.ts
@@ -1,7 +1,10 @@
-import type middy from '@middy/core';
 import type { Tracer } from '../Tracer';
 import type { Segment, Subsegment } from 'aws-xray-sdk-core';
 import type { CaptureLambdaHandlerOptions } from '../types';
+import type {
+  MiddlewareLikeObj,
+  MiddyLikeRequest
+} from '@aws-lambda-powertools/commons';
 
 /**
  * A middy middleware automating capture of metadata and annotations on segments or subsegments for a Lambda Handler.
@@ -30,7 +33,7 @@ import type { CaptureLambdaHandlerOptions } from '../types';
  * @param options - (_optional_) Options for the middleware
  * @returns middleware - The middy middleware object
  */
-const captureLambdaHandler = (target: Tracer, options?: CaptureLambdaHandlerOptions): middy.MiddlewareObj => {
+const captureLambdaHandler = (target: Tracer, options?: CaptureLambdaHandlerOptions): MiddlewareLikeObj => {
   let lambdaSegment: Subsegment | Segment;
 
   const open = (): void => {
@@ -53,7 +56,7 @@ const captureLambdaHandler = (target: Tracer, options?: CaptureLambdaHandlerOpti
     }
   };
   
-  const captureLambdaHandlerAfter = async (request: middy.Request): Promise<void> => {
+  const captureLambdaHandlerAfter = async (request: MiddyLikeRequest): Promise<void> => {
     if (target.isTracingEnabled()) {
       if (options?.captureResponse ?? true) {
         target.addResponseAsMetadata(request.response, process.env._HANDLER);
@@ -62,7 +65,7 @@ const captureLambdaHandler = (target: Tracer, options?: CaptureLambdaHandlerOpti
     }
   };
   
-  const captureLambdaHandlerError = async (request: middy.Request): Promise<void> => {
+  const captureLambdaHandlerError = async (request: MiddyLikeRequest): Promise<void> => {
     if (target.isTracingEnabled()) {
       target.addErrorAsMetadata(request.error as Error);
       close();


### PR DESCRIPTION
## Description of your changes

Following the discussion in the linked issue (#1068), as well as other issues (#1080, #1081), customers who are using Powertools and bundling their TypeScript project with `tsc`, but that were not using any of the Middy-compatible middleware were having compile issues due to the dependency being missing.

We have investigated several workarounds:
- Adding the `@middy/core` dependency (#1218)
- Changing the exports to isolate the middleware & thus the dependency ([#1068#issuecomment-1377575328](https://github.com/awslabs/aws-lambda-powertools-typescript/issues/1068#issuecomment-1377575328))
- Reworking the types (this PR)

The first option was a no-go as it would have introduced an unnecessary dependency for those users having the issue. The second one would have constituted a breaking change, requiring a major release.

The last option (**credits to @saragerion for proposing it**) allows us to maintain backwards compatibility while solving the issue described above.

The solution that this PR proposes (again, credits to @saragerion), introduces some of the types previously imported from `@middy/core` into `@aws-lambda-powertools/commons`. By bringing these types into the project, we can remove the dependency to `@middy/core` from our codebase and allow customers to bundle using `tsc` as well as `esbuild`.

> **Note**
> The `@middy/core` dependency was used only for its types. Powertools still supports Middy middleware, and customers who want to use them still need to opt-in by adding the dependency to their Lambda functions.

### How to verify this change

See existing unit tests below this PR and successful integration test run: https://github.com/awslabs/aws-lambda-powertools-typescript/actions/runs/3894429621

### Related issues, RFCs

<!--- Add here the number (i.e. #42) to the Github Issue or RFC that is related to this PR. -->
<!--- If no issue is present the PR might get blocked and not be reviewed. -->
**Issue number:** #1068

### PR status

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-typescript/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [ ] I have made corresponding changes to the *documentation*
- [ ] I have made corresponding changes to the *examples*
- [x] My changes generate *no new warnings*
- [x] The *code coverage* hasn't decreased
- [ ] I have *added tests* that prove my change is effective and works
- [x] New and existing *unit tests pass* locally and in Github Actions
- [ ] Any *dependent changes have been merged and published*
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

- [ ] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
