### PR TITLE
docs(tracer): extract Tracer code snippets in separate files #1219

### DIFF
--- a/docs/snippets/tracer/accessRootTraceId.ts
+++ b/docs/snippets/tracer/accessRootTraceId.ts
@@ -1,0 +1,18 @@
+import { Tracer } from '@aws-lambda-powertools/tracer';
+
+const tracer = new Tracer({ serviceName: 'serverlessAirline' });
+
+export const handler = async (event: unknown, context: Context): Promise<void> => {
+    try {
+    
+    } catch (err) {
+        const rootTraceId = tracer.getRootXrayTraceId();
+
+        // Example of returning an error response
+        return {
+            statusCode: 500,
+            body: `Internal Error - Please contact support and quote the following id: ${rootTraceId}`,
+            headers: { '_X_AMZN_TRACE_ID': rootTraceId },
+        };
+    }
+};

--- a/docs/snippets/tracer/basicUsage.ts
+++ b/docs/snippets/tracer/basicUsage.ts
@@ -1,0 +1,7 @@
+import { Tracer } from '@aws-lambda-powertools/tracer';
+
+const tracer = new Tracer({ serviceName: 'serverlessAirline' });
+
+export const handler = async (_event, _context): Promise<void> => {
+    // ...
+};

--- a/docs/snippets/tracer/captureAWS.ts
+++ b/docs/snippets/tracer/captureAWS.ts
@@ -1,0 +1,5 @@
+import { S3 } from 'aws-sdk';
+import { Tracer } from '@aws-lambda-powertools/tracer';
+
+const tracer = new Tracer({ serviceName: 'serverlessAirline' });
+const s3 = tracer.captureAWSClient(new S3());

--- a/docs/snippets/tracer/captureAWSAll.ts
+++ b/docs/snippets/tracer/captureAWSAll.ts
@@ -1,0 +1,4 @@
+import { Tracer } from '@aws-lambda-powertools/tracer';
+
+const tracer = new Tracer({ serviceName: 'serverlessAirline' });
+const AWS = tracer.captureAWS(require('aws-sdk'));

--- a/docs/snippets/tracer/captureAWSv3.ts
+++ b/docs/snippets/tracer/captureAWSv3.ts
@@ -1,0 +1,5 @@
+import { S3Client } from '@aws-sdk/client-s3';
+import { Tracer } from '@aws-lambda-powertools/tracer';
+
+const tracer = new Tracer({ serviceName: 'serverlessAirline' });
+const client = tracer.captureAWSv3Client(new S3Client({}));

--- a/docs/snippets/tracer/captureHTTP.ts
+++ b/docs/snippets/tracer/captureHTTP.ts
@@ -1,0 +1,8 @@
+import { Tracer } from '@aws-lambda-powertools/tracer';
+import axios from 'axios'; // (1)
+
+const tracer = new Tracer({ serviceName: 'serverlessAirline' });
+
+export const handler = async (event: unknown, context: Context): Promise<void> => {
+    await axios.get('https://httpbin.org/status/200');
+};

--- a/docs/snippets/tracer/captureMethodDecorator.ts
+++ b/docs/snippets/tracer/captureMethodDecorator.ts
@@ -1,0 +1,20 @@
+import { Tracer } from '@aws-lambda-powertools/tracer';
+import { LambdaInterface } from '@aws-lambda-powertools/commons';
+
+const tracer = new Tracer({ serviceName: 'serverlessAirline' });
+
+class Lambda implements LambdaInterface {
+    // Decorate your class method
+    @tracer.captureMethod() // (1)
+    public getChargeId(): string {
+        /* ... */
+        return 'foo bar';
+    }
+
+    public async handler(_event: any, _context: any): Promise<void> {
+        /* ... */
+    }
+}
+ 
+const handlerClass = new Lambda();
+export const handler = handlerClass.handler.bind(handlerClass); // (2)

--- a/docs/snippets/tracer/captureMethodDecorator.ts
+++ b/docs/snippets/tracer/captureMethodDecorator.ts
@@ -6,7 +6,7 @@ const tracer = new Tracer({ serviceName: 'serverlessAirline' });
 class Lambda implements LambdaInterface {
     // Decorate your class method
     @tracer.captureMethod() // (1)
-    public getChargeId(): string {
+    public async getChargeId(): Promise<string> {
         /* ... */
         return 'foo bar';
     }

--- a/docs/snippets/tracer/captureMethodManual.ts
+++ b/docs/snippets/tracer/captureMethodManual.ts
@@ -1,0 +1,34 @@
+import { Tracer } from '@aws-lambda-powertools/tracer';
+
+const tracer = new Tracer({ serviceName: 'serverlessAirline' });
+
+const getChargeId = async (): Promise<unknown> => {
+    const parentSubsegment = tracer.getSegment(); // This is the subsegment currently active
+    // Create subsegment for the function & set it as active
+    const subsegment = parentSubsegment.addNewSubsegment(`### chargeId`);
+    tracer.setSegment(subsegment);
+
+    let res;
+    try {
+        /* ... */
+        // Add the response as metadata
+        tracer.addResponseAsMetadata(res, 'chargeId');
+    } catch (err) {
+        // Add the error as metadata
+        tracer.addErrorAsMetadata(err as Error);
+        throw err;
+    }
+
+    // Close subsegment (the AWS Lambda one is closed automatically)
+    subsegment.close();
+    // Set the facade segment as active again
+    tracer.setSegment(parentSubsegment);
+
+    return res;
+};
+
+export const handler = async (_event: any, _context: any): Promise<void> => {
+    const chargeId = getChargeId();
+    const payment = collectPayment(chargeId);
+    /* ... */
+};

--- a/docs/snippets/tracer/decorator.ts
+++ b/docs/snippets/tracer/decorator.ts
@@ -1,0 +1,15 @@
+import { Tracer } from '@aws-lambda-powertools/tracer';
+import { LambdaInterface } from '@aws-lambda-powertools/commons';
+
+const tracer = new Tracer({ serviceName: 'serverlessAirline' });
+
+class Lambda implements LambdaInterface {
+    // Decorate your handler class method
+    @tracer.captureLambdaHandler()
+    public async handler(_event: any, _context: any): Promise<void> {
+        /* ... */
+    }
+}
+ 
+const handlerClass = new Lambda();
+export const handler = handlerClass.handler.bind(handlerClass); // (1)

--- a/docs/snippets/tracer/disableCaptureResponseHandler.ts
+++ b/docs/snippets/tracer/disableCaptureResponseHandler.ts
@@ -1,0 +1,14 @@
+import { Tracer } from '@aws-lambda-powertools/tracer';
+import { LambdaInterface } from '@aws-lambda-powertools/commons';
+
+const tracer = new Tracer({ serviceName: 'serverlessAirline' });
+
+class Lambda implements LambdaInterface {
+    @tracer.captureLambdaHandler({ captureResponse: false })
+    async handler(_event: any, _context: any): Promise<void> {
+        /* ... */
+    }
+}
+
+const handlerClass = new Lambda();
+export const handler = handlerClass.handler.bind(handlerClass);

--- a/docs/snippets/tracer/disableCaptureResponseMethod.ts
+++ b/docs/snippets/tracer/disableCaptureResponseMethod.ts
@@ -3,8 +3,8 @@ import { Tracer } from '@aws-lambda-powertools/tracer';
 const tracer = new Tracer({ serviceName: 'serverlessAirline' });
 
 class Lambda implements LambdaInterface {
-    @tracer.captureMethod({ captureResult: false })
-    public getChargeId(): string {
+    @tracer.captureMethod({ captureResponse: false })
+    public async getChargeId(): Promise<string> {
         /* ... */
         return 'foo bar';
     }

--- a/docs/snippets/tracer/disableCaptureResponseMethod.ts
+++ b/docs/snippets/tracer/disableCaptureResponseMethod.ts
@@ -1,0 +1,18 @@
+import { Tracer } from '@aws-lambda-powertools/tracer';
+
+const tracer = new Tracer({ serviceName: 'serverlessAirline' });
+
+class Lambda implements LambdaInterface {
+    @tracer.captureMethod({ captureResult: false })
+    public getChargeId(): string {
+        /* ... */
+        return 'foo bar';
+    }
+
+    public async handler(_event: any, _context: any): Promise<void> {
+        /* ... */
+    }
+}
+
+const handlerClass = new Lambda();
+export const handler = handlerClass.handler.bind(handlerClass);

--- a/docs/snippets/tracer/disableCaptureResponseMiddy.ts
+++ b/docs/snippets/tracer/disableCaptureResponseMiddy.ts
@@ -1,0 +1,14 @@
+import { Tracer, captureLambdaHandler } from '@aws-lambda-powertools/tracer';
+import middy from '@middy/core';
+
+const tracer = new Tracer({ serviceName: 'serverlessAirline' });
+
+const lambdaHandler = async (_event: any, _context: any): Promise<void> => {
+    /* ... */
+};
+
+// Wrap the handler with middy
+export const handler = middy(lambdaHandler)
+    // Use the middleware by passing the Tracer instance as a parameter,
+    // but specify the captureResponse option as false.
+    .use(captureLambdaHandler(tracer, { captureResponse: false }));

--- a/docs/snippets/tracer/escapeHatch.ts
+++ b/docs/snippets/tracer/escapeHatch.ts
@@ -1,0 +1,7 @@
+import { Logger } from '@aws-lambda-powertools/logger';
+import { Tracer } from '@aws-lambda-powertools/tracer';
+
+const serviceName = 'serverlessAirline';
+const logger = new Logger({ serviceName: serviceName });
+const tracer = new Tracer({ serviceName: serviceName });
+tracer.provider.setLogger(logger);

--- a/docs/snippets/tracer/manual.ts
+++ b/docs/snippets/tracer/manual.ts
@@ -1,0 +1,32 @@
+import { Tracer } from '@aws-lambda-powertools/tracer';
+
+const tracer = new Tracer({ serviceName: 'serverlessAirline' });
+
+export const handler = async (_event: any, context: any): Promise<unknown> => {
+    const segment = tracer.getSegment(); // This is the facade segment (the one that is created by AWS Lambda)
+    // Create subsegment for the function & set it as active
+    const subsegment = segment.addNewSubsegment(`## ${process.env._HANDLER}`);
+    tracer.setSegment(subsegment);
+
+    // Annotate the subsegment with the cold start & serviceName
+    tracer.annotateColdStart();
+    tracer.addServiceNameAnnotation();
+
+    let res;
+    try {
+        /* ... */
+        // Add the response as metadata 
+        tracer.addResponseAsMetadata(res, process.env._HANDLER);
+    } catch (err) {
+        // Add the error as metadata
+        tracer.addErrorAsMetadata(err as Error);
+        throw err;
+    } finally {
+        // Close subsegment (the AWS Lambda one is closed automatically)
+        subsegment.close();
+        // Set back the facade segment as active again
+        tracer.setSegment(segment);
+    }
+
+    return res;
+};

--- a/docs/snippets/tracer/middy.ts
+++ b/docs/snippets/tracer/middy.ts
@@ -1,0 +1,13 @@
+import { Tracer, captureLambdaHandler } from '@aws-lambda-powertools/tracer';
+import middy from '@middy/core'; // (1)
+
+const tracer = new Tracer({ serviceName: 'serverlessAirline' });
+
+const lambdaHandler = async (_event: any, _context: any): Promise<void> => {
+    /* ... */
+};
+
+// Wrap the handler with middy
+export const handler = middy(lambdaHandler)
+    // Use the middleware by passing the Tracer instance as a parameter
+    .use(captureLambdaHandler(tracer));

--- a/docs/snippets/tracer/putAnnotation.ts
+++ b/docs/snippets/tracer/putAnnotation.ts
@@ -1,0 +1,7 @@
+import { Tracer } from '@aws-lambda-powertools/tracer';
+
+const tracer = new Tracer({ serviceName: 'serverlessAirline' });
+
+export const handler = async (_event: any, _context: any): Promise<void> => {
+    tracer.putAnnotation('successfulBooking', true);
+};

--- a/docs/snippets/tracer/putMetadata.ts
+++ b/docs/snippets/tracer/putMetadata.ts
@@ -1,0 +1,8 @@
+import { Tracer } from '@aws-lambda-powertools/tracer';
+
+const tracer = new Tracer({ serviceName: 'serverlessAirline' });
+
+export const handler = async (_event: any, _context: any): Promise<void> => {
+    const res; /* ... */
+    tracer.putMetadata('paymentResponse', res);
+};

--- a/docs/snippets/tracer/sam.ts
+++ b/docs/snippets/tracer/sam.ts
@@ -1,0 +1,9 @@
+import { Tracer } from '@aws-lambda-powertools/tracer';
+
+// Tracer parameter fetched from the environment variables (see template.yaml tab)
+const tracer = new Tracer();
+
+// You can also pass the parameter in the constructor
+// const tracer = new Tracer({
+//     serviceName: 'serverlessAirline'
+// });


### PR DESCRIPTION
<!--- 1. Make sure you follow our Contributing Guidelines: https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/CONTRIBUTING.md -->
<!--- 2. Please follow the template, and do not remove any section in the template. If something is not applicable leave it empty, but leave it in the PR. -->

## Description of your changes

<!--- Include here a summary of the change. -->
The code snippets are extracted to their own separate files, placed under `docs/snippets/tracer`.
And project documentation in `docs/core/tracer.md` references  the code snippets, which are extracted to their own separate files.

<!--- Please include also relevant motivation and context. -->
Code snippets of tracer created, in path `docs/snippets/tracer`: 

1. `basicUsage.ts`
2. `sam.ts`
3. `middy.ts`
4. `decorator.ts`
5. `manual.ts`
6. `putAnnotation.ts`
7. `putMetadata.ts`
8. `captureMethodDecorator.ts`
9. `captureMethodManual.ts`
10. `captureAWSv3.ts`
11. `captureAWSAll.ts`
12. `captureAWS.ts`
13. `captureHTTP.ts`
14. `disableCaptureResponseMethod.ts`
15. `disableCaptureResponseHandler.ts`
16. `disableCaptureResponseMiddy.ts`
17. `accessRootTraceId.ts`
18. `escapeHatch.ts`

Each code snippet is referenced as `--8<-- "docs/snippets/tracer/<code-snippet>.ts"` in `docs/core/tracer.md` .

<!--- List any dependencies that are required for this change. -->

<!--- If this PR is part of a sequence of related PRs or TODOs, list the high level TODO items. -->
TODO items:
- Lint code snippets created in path `docs/snippets/tracer` by using current [eslint rules](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.eslintrc.js) that are used for packages managed by monorepo as workspaces 
-  Correct code snippets by consulting the `eslint findings`. 
- May Adjust the [eslint configuration](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/package.json) to documentation needs, e.g. allow `any type` or adjust the code snippets by `removing event and context from the handler signature` .  
- By consulting the eslint findings, that Fix should be discovered:  `captureMethodDecorator.ts` , see #1203
- By consulting the eslint findings, that Fix should be discovered:  `disableCaptureResponseMethod.ts` , see [type](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/packages/tracer/src/types/Tracer.ts#L96)
- introduce `docs/snippets/tracer` as workspace in [package.json](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/package.json) managed by monorepo

### How to verify this change

<!--- Add any applicable config, projects, screenshots or other resources -->
<!--- that can help us verify your changes. -->
Modified `docs/core/tracer.md`
Added code snippets as ts files in path `docs/snippets/tracer`

<!--- Examples: -->
<!--- Screenshots, cloud configuration, anything helping us evaluate better. -->

### Related issues, RFCs

<!--- Add here the number (i.e. #42) to the Github Issue or RFC that is related to this PR. -->
<!--- If no issue is present the PR might get blocked and not be reviewed. -->
**Issue number:**  #1219 , #729 

### PR status

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-typescript/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [x] I have made corresponding changes to the *documentation*
- [ ] I have made corresponding changes to the *examples*
- [ ] My changes generate *no new warnings*
- [x] The *code coverage* hasn't decreased
- [ ] I have *added tests* that prove my change is effective and works
- [x] New and existing *unit tests pass* locally and in Github Actions
- [ ] Any *dependent changes have been merged and published*
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

- [ ] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
