### PR TITLE
docs: remove Node.js 12 deprecation notice from docs

### DIFF
--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -6,12 +6,3 @@ You're not viewing the latest version.
   <strong>Click here to go to latest.</strong>
 </a>
 {% endblock %}
-
-{% block announce %}
-Version 1.5.0 will be the last version to support Node.js 12. <br /> Node.js 12 has reached end-of-life and the
-corresponding
-AWS Lambda runtime will be deprecated at the end of March 2023. Please upgrade to Node.js 14 or later.<br />
-<a href="https://github.com/awslabs/aws-lambda-powertools-typescript/issues/1061#issuecomment-1349031362"
-  target="_blank">Click here to read the full announcement</a>, or <a href="https://discord.gg/B8zZKbbyET"
-  target="_blank">join our Discord server</a> to chime in the discussion.
-{% endblock %}


### PR DESCRIPTION
## Description of your changes

With `v1.5.1` released support for Node.js 12 has ended, so we can remove the deprecation notice that was at the top of the documentation.

Fixes #1236

### How to verify this change

See updated docs.

### Related issues, RFCs

<!--- Add here the number (i.e. #42) to the Github Issue or RFC that is related to this PR. -->
<!--- If no issue is present the PR might get blocked and not be reviewed. -->
**Issue number:** #1236

### PR status

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-typescript/#tenets)
- [x] I have performed a *self-review* of my own code
- [ ] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [x] I have made corresponding changes to the *documentation*
- [ ] I have made corresponding changes to the *examples*
- [ ] My changes generate *no new warnings*
- [ ] The *code coverage* hasn't decreased
- [ ] I have *added tests* that prove my change is effective and works
- [ ] New and existing *unit tests pass* locally and in Github Actions
- [x] Any *dependent changes have been merged and published*
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

- [ ] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
