### PR TITLE
chore(docs): add `docs/snippets` to npm workspace

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,2 +1,2 @@
 FROM squidfunk/mkdocs-material
-RUN pip install mkdocs-git-revision-date-plugin mkdocs-glightbox
+RUN pip install mkdocs-git-revision-date-plugin==0.3.2 mkdocs-exclude==1.0.2

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
 mike==1.1.2
 mkdocs-material==9.0.2
 mkdocs-git-revision-date-plugin==0.3.2
+mkdocs-exclude==1.0.2

--- a/docs/snippets/package.json
+++ b/docs/snippets/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "docs",
+  "version": "0.0.1",
+  "description": "A collection code snippets for the AWS Lambda Powertools for TypeScript docs",
+  "author": {
+    "name": "Amazon Web Services",
+    "url": "https://aws.amazon.com"
+  },
+  "scripts": {
+    "test": "echo 'Not Applicable'",
+    "test:e2e": "echo 'Not Applicable'",
+    "build": "echo 'Not Applicable'",
+    "lint": "echo 'Not Applicable'",
+    "lint-fix": "echo 'Not Applicable'"
+  },
+  "license": "MIT-0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/awslabs/aws-lambda-powertools-typescript.git"
+  },
+  "bugs": {
+    "url": "https://github.com/awslabs/aws-lambda-powertools-typescript/issues"
+  },
+  "homepage": "https://github.com/awslabs/aws-lambda-powertools-typescript#readme",
+  "devDependencies": {
+    "@aws-sdk/client-appconfigdata": "^3.245.0",
+    "@aws-sdk/client-dynamodb": "^3.245.0",
+    "@aws-sdk/client-secrets-manager": "^3.250.0",
+    "@aws-sdk/client-ssm": "^3.245.0",
+    "@aws-sdk/util-dynamodb": "^3.245.0"
+  }
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -79,6 +79,10 @@ copyright: Copyright &copy; 2023 Amazon Web Services
 plugins:
   - git-revision-date
   - search
+  - exclude:
+      glob:
+        - snippets/node_modules/*
+        - snippets/package.json
 
 extra_css:
   - stylesheets/extra.css

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "packages/metrics",
         "packages/tracer",
         "packages/parameters",
-        "packages/idempotency"
+        "packages/idempotency",
+        "docs/snippets"
       ],
       "dependencies": {
         "hosted-git-info": "^6.1.1"
@@ -56,6 +57,30 @@
       },
       "engines": {
         "node": ">=14"
+      }
+    },
+    "docs/snippets": {
+      "name": "docs",
+      "version": "0.0.1",
+      "license": "MIT-0",
+      "devDependencies": {
+        "@aws-sdk/client-appconfigdata": "^3.245.0",
+        "@aws-sdk/client-dynamodb": "^3.245.0",
+        "@aws-sdk/client-secrets-manager": "^3.250.0",
+        "@aws-sdk/client-ssm": "^3.245.0",
+        "@aws-sdk/util-dynamodb": "^3.245.0"
+      }
+    },
+    "docs/snippets/node_modules/@aws-sdk/util-dynamodb": {
+      "version": "3.245.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-dynamodb/-/util-dynamodb-3.245.0.tgz",
+      "integrity": "sha512-Wx06Ey92DRRSQTFfpQs1DkHSoajcwVu2TLWTg07yHXgGxdi6EveJPNqh111ot5yzHGmzPIHas/IPZe3hDttzcw==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -347,16 +372,16 @@
       }
     },
     "node_modules/@aws-sdk/client-appconfigdata": {
-      "version": "3.241.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-appconfigdata/-/client-appconfigdata-3.241.0.tgz",
-      "integrity": "sha512-5AVfSc6ZQ17dF0cdIrmpEe0H6vmGumBvsFGn89e2clSPtqqtsFDpBeAsS5jCMbxO9pakkCM0RPAh+sci6MnlYg==",
+      "version": "3.245.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-appconfigdata/-/client-appconfigdata-3.245.0.tgz",
+      "integrity": "sha512-XxyUEEYcL6xvFUnrd10sVtmWaqYTHwn9IfScqyqz2K8wrAnbHPeaWc197UulqhIXYfz11foOAEleiUBKM1kHdw==",
       "dev": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.241.0",
+        "@aws-sdk/client-sts": "3.245.0",
         "@aws-sdk/config-resolver": "3.234.0",
-        "@aws-sdk/credential-provider-node": "3.241.0",
+        "@aws-sdk/credential-provider-node": "3.245.0",
         "@aws-sdk/fetch-http-handler": "3.226.0",
         "@aws-sdk/hash-node": "3.226.0",
         "@aws-sdk/invalid-dependency": "3.226.0",
@@ -381,7 +406,7 @@
         "@aws-sdk/util-body-length-node": "3.208.0",
         "@aws-sdk/util-defaults-mode-browser": "3.234.0",
         "@aws-sdk/util-defaults-mode-node": "3.234.0",
-        "@aws-sdk/util-endpoints": "3.241.0",
+        "@aws-sdk/util-endpoints": "3.245.0",
         "@aws-sdk/util-retry": "3.229.0",
         "@aws-sdk/util-user-agent-browser": "3.226.0",
         "@aws-sdk/util-user-agent-node": "3.226.0",
@@ -391,318 +416,6 @@
       },
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-appconfigdata/node_modules/@aws-sdk/client-sso": {
-      "version": "3.241.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.241.0.tgz",
-      "integrity": "sha512-Jm4HR+RYAqKMEYZvvWaq0NYUKKonyInOeubObXH4BLXZpmUBSdYCSjjLdNJY3jkQoxbDVPVMIurVNh5zT5SMRw==",
-      "dev": true,
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.234.0",
-        "@aws-sdk/fetch-http-handler": "3.226.0",
-        "@aws-sdk/hash-node": "3.226.0",
-        "@aws-sdk/invalid-dependency": "3.226.0",
-        "@aws-sdk/middleware-content-length": "3.226.0",
-        "@aws-sdk/middleware-endpoint": "3.226.0",
-        "@aws-sdk/middleware-host-header": "3.226.0",
-        "@aws-sdk/middleware-logger": "3.226.0",
-        "@aws-sdk/middleware-recursion-detection": "3.226.0",
-        "@aws-sdk/middleware-retry": "3.235.0",
-        "@aws-sdk/middleware-serde": "3.226.0",
-        "@aws-sdk/middleware-stack": "3.226.0",
-        "@aws-sdk/middleware-user-agent": "3.226.0",
-        "@aws-sdk/node-config-provider": "3.226.0",
-        "@aws-sdk/node-http-handler": "3.226.0",
-        "@aws-sdk/protocol-http": "3.226.0",
-        "@aws-sdk/smithy-client": "3.234.0",
-        "@aws-sdk/types": "3.226.0",
-        "@aws-sdk/url-parser": "3.226.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.234.0",
-        "@aws-sdk/util-defaults-mode-node": "3.234.0",
-        "@aws-sdk/util-endpoints": "3.241.0",
-        "@aws-sdk/util-retry": "3.229.0",
-        "@aws-sdk/util-user-agent-browser": "3.226.0",
-        "@aws-sdk/util-user-agent-node": "3.226.0",
-        "@aws-sdk/util-utf8-browser": "3.188.0",
-        "@aws-sdk/util-utf8-node": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-appconfigdata/node_modules/@aws-sdk/client-sso-oidc": {
-      "version": "3.241.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.241.0.tgz",
-      "integrity": "sha512-/Ml2QBGpGfUEeBrPzBZhSTBkHuXFD2EAZEIHGCBH4tKaURDI6/FoGI8P1Rl4BzoFt+II/Cr91Eox6YT9EwChsQ==",
-      "dev": true,
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.234.0",
-        "@aws-sdk/fetch-http-handler": "3.226.0",
-        "@aws-sdk/hash-node": "3.226.0",
-        "@aws-sdk/invalid-dependency": "3.226.0",
-        "@aws-sdk/middleware-content-length": "3.226.0",
-        "@aws-sdk/middleware-endpoint": "3.226.0",
-        "@aws-sdk/middleware-host-header": "3.226.0",
-        "@aws-sdk/middleware-logger": "3.226.0",
-        "@aws-sdk/middleware-recursion-detection": "3.226.0",
-        "@aws-sdk/middleware-retry": "3.235.0",
-        "@aws-sdk/middleware-serde": "3.226.0",
-        "@aws-sdk/middleware-stack": "3.226.0",
-        "@aws-sdk/middleware-user-agent": "3.226.0",
-        "@aws-sdk/node-config-provider": "3.226.0",
-        "@aws-sdk/node-http-handler": "3.226.0",
-        "@aws-sdk/protocol-http": "3.226.0",
-        "@aws-sdk/smithy-client": "3.234.0",
-        "@aws-sdk/types": "3.226.0",
-        "@aws-sdk/url-parser": "3.226.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.234.0",
-        "@aws-sdk/util-defaults-mode-node": "3.234.0",
-        "@aws-sdk/util-endpoints": "3.241.0",
-        "@aws-sdk/util-retry": "3.229.0",
-        "@aws-sdk/util-user-agent-browser": "3.226.0",
-        "@aws-sdk/util-user-agent-node": "3.226.0",
-        "@aws-sdk/util-utf8-browser": "3.188.0",
-        "@aws-sdk/util-utf8-node": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-appconfigdata/node_modules/@aws-sdk/client-sts": {
-      "version": "3.241.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.241.0.tgz",
-      "integrity": "sha512-vmlG8cJzRf8skCtTJbA2wBvD2c3NQ5gZryzJvTKDS06KzBzcEpnjlLseuTekcnOiRNekbFUX5hRu5Zj3N2ReLg==",
-      "dev": true,
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.234.0",
-        "@aws-sdk/credential-provider-node": "3.241.0",
-        "@aws-sdk/fetch-http-handler": "3.226.0",
-        "@aws-sdk/hash-node": "3.226.0",
-        "@aws-sdk/invalid-dependency": "3.226.0",
-        "@aws-sdk/middleware-content-length": "3.226.0",
-        "@aws-sdk/middleware-endpoint": "3.226.0",
-        "@aws-sdk/middleware-host-header": "3.226.0",
-        "@aws-sdk/middleware-logger": "3.226.0",
-        "@aws-sdk/middleware-recursion-detection": "3.226.0",
-        "@aws-sdk/middleware-retry": "3.235.0",
-        "@aws-sdk/middleware-sdk-sts": "3.226.0",
-        "@aws-sdk/middleware-serde": "3.226.0",
-        "@aws-sdk/middleware-signing": "3.226.0",
-        "@aws-sdk/middleware-stack": "3.226.0",
-        "@aws-sdk/middleware-user-agent": "3.226.0",
-        "@aws-sdk/node-config-provider": "3.226.0",
-        "@aws-sdk/node-http-handler": "3.226.0",
-        "@aws-sdk/protocol-http": "3.226.0",
-        "@aws-sdk/smithy-client": "3.234.0",
-        "@aws-sdk/types": "3.226.0",
-        "@aws-sdk/url-parser": "3.226.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.234.0",
-        "@aws-sdk/util-defaults-mode-node": "3.234.0",
-        "@aws-sdk/util-endpoints": "3.241.0",
-        "@aws-sdk/util-retry": "3.229.0",
-        "@aws-sdk/util-user-agent-browser": "3.226.0",
-        "@aws-sdk/util-user-agent-node": "3.226.0",
-        "@aws-sdk/util-utf8-browser": "3.188.0",
-        "@aws-sdk/util-utf8-node": "3.208.0",
-        "fast-xml-parser": "4.0.11",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-appconfigdata/node_modules/@aws-sdk/config-resolver": {
-      "version": "3.234.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.234.0.tgz",
-      "integrity": "sha512-uZxy4wzllfvgCQxVc+Iqhde0NGAnfmV2hWR6ejadJaAFTuYNvQiRg9IqJy3pkyDPqXySiJ8Bom5PoJfgn55J/A==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/signature-v4": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "@aws-sdk/util-config-provider": "3.208.0",
-        "@aws-sdk/util-middleware": "3.226.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-appconfigdata/node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.241.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.241.0.tgz",
-      "integrity": "sha512-CI+mu6h74Kzmscw35TvNkc/wYHsHPGAwP7humSHoWw53H9mVw21Ggft/dT1iFQQZWQ8BNXkzuXlNo1IlqwMgOA==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.226.0",
-        "@aws-sdk/credential-provider-imds": "3.226.0",
-        "@aws-sdk/credential-provider-process": "3.226.0",
-        "@aws-sdk/credential-provider-sso": "3.241.0",
-        "@aws-sdk/credential-provider-web-identity": "3.226.0",
-        "@aws-sdk/property-provider": "3.226.0",
-        "@aws-sdk/shared-ini-file-loader": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-appconfigdata/node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.241.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.241.0.tgz",
-      "integrity": "sha512-08zPQcD5o9brQmzEipWHeHgU85aQcEF8MWLfpeyjO6e1/l7ysQ35NsS+PYtv77nLpGCx/X+ZuW/KXWoRrbw77w==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.226.0",
-        "@aws-sdk/credential-provider-imds": "3.226.0",
-        "@aws-sdk/credential-provider-ini": "3.241.0",
-        "@aws-sdk/credential-provider-process": "3.226.0",
-        "@aws-sdk/credential-provider-sso": "3.241.0",
-        "@aws-sdk/credential-provider-web-identity": "3.226.0",
-        "@aws-sdk/property-provider": "3.226.0",
-        "@aws-sdk/shared-ini-file-loader": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-appconfigdata/node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.241.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.241.0.tgz",
-      "integrity": "sha512-6Bjd6eEIrVomRTrPrM4dlxusQm+KMJ9hLYKECCpFkwDKIK+pTgZNLRtQdalHyzwneHJPdimrm8cOv1kUQ8hPoA==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/client-sso": "3.241.0",
-        "@aws-sdk/property-provider": "3.226.0",
-        "@aws-sdk/shared-ini-file-loader": "3.226.0",
-        "@aws-sdk/token-providers": "3.241.0",
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-appconfigdata/node_modules/@aws-sdk/middleware-retry": {
-      "version": "3.235.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.235.0.tgz",
-      "integrity": "sha512-50WHbJGpD3SNp9763MAlHqIhXil++JdQbKejNpHg7HsJne/ao3ub+fDOfx//mMBjpzBV25BGd5UlfL6blrClSg==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.226.0",
-        "@aws-sdk/service-error-classification": "3.229.0",
-        "@aws-sdk/types": "3.226.0",
-        "@aws-sdk/util-middleware": "3.226.0",
-        "@aws-sdk/util-retry": "3.229.0",
-        "tslib": "^2.3.1",
-        "uuid": "^8.3.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-appconfigdata/node_modules/@aws-sdk/smithy-client": {
-      "version": "3.234.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.234.0.tgz",
-      "integrity": "sha512-8AtR/k4vsFvjXeQbIzq/Wy7Nbk48Ou0wUEeVYPHWHPSU8QamFWORkOwmKtKMfHAyZvmqiAPeQqHFkq+UJhWyyQ==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/middleware-stack": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-appconfigdata/node_modules/@aws-sdk/token-providers": {
-      "version": "3.241.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.241.0.tgz",
-      "integrity": "sha512-79okvuOS7V559OIL/RalIPG98wzmWxeFOChFnbEjn2pKOyGQ6FJRwLPYZaVRtNdAtnkBNgRpmFq9dX843QxhtQ==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/client-sso-oidc": "3.241.0",
-        "@aws-sdk/property-provider": "3.226.0",
-        "@aws-sdk/shared-ini-file-loader": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-appconfigdata/node_modules/@aws-sdk/util-defaults-mode-browser": {
-      "version": "3.234.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.234.0.tgz",
-      "integrity": "sha512-IHMKXjTbOD8XMz5+2oCOsVP94BYb9YyjXdns0aAXr2NAo7k2+RCzXQ2DebJXppGda1F6opFutoKwyVSN0cmbMw==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/property-provider": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "bowser": "^2.11.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-appconfigdata/node_modules/@aws-sdk/util-defaults-mode-node": {
-      "version": "3.234.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.234.0.tgz",
-      "integrity": "sha512-UGjQ+OjBYYhxFVtUY+jtr0ZZgzZh6OHtYwRhFt8IHewJXFCfZTyfsbX20szBj5y1S4HRIUJ7cwBLIytTqMbI5w==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/config-resolver": "3.234.0",
-        "@aws-sdk/credential-provider-imds": "3.226.0",
-        "@aws-sdk/node-config-provider": "3.226.0",
-        "@aws-sdk/property-provider": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-appconfigdata/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.241.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.241.0.tgz",
-      "integrity": "sha512-jVf8bKrN22Ey0xLmj75sL7EUvm5HFpuOMkXsZkuXycKhCwLBcEUWlvtJYtRjOU1zScPQv9GMJd2QXQglp34iOQ==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-appconfigdata/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@aws-sdk/client-dynamodb": {
@@ -754,18 +467,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.245.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.245.0.tgz",
-      "integrity": "sha512-UNOFquB1tKx+8RT8n82Zb5tIwDyZHVPBg/m0LB0RsLETjr6krien5ASpqWezsXKIR1hftN9uaxN4bvf2dZrWHg==",
-      "dependencies": {
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-sdk/client-dynamodb/node_modules/uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -775,16 +476,16 @@
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager": {
-      "version": "3.238.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.238.0.tgz",
-      "integrity": "sha512-J3lmceh2txILEh8tWf4ldp8ThAh2WJBSa1t8oJhW58KuE+1a7cwOpgWO6MsSvOrGtp7qzTr8GMBUf7KLdv7wOg==",
+      "version": "3.250.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.250.0.tgz",
+      "integrity": "sha512-CB4OcFJPpAuW3rRXBxgOtF9RXHBixEvJSDkh8RsCAamt37Fw61+e+CsdXixSWA4rzQA+3PQuts7zlwhcxobbJg==",
       "dev": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.238.0",
+        "@aws-sdk/client-sts": "3.245.0",
         "@aws-sdk/config-resolver": "3.234.0",
-        "@aws-sdk/credential-provider-node": "3.238.0",
+        "@aws-sdk/credential-provider-node": "3.245.0",
         "@aws-sdk/fetch-http-handler": "3.226.0",
         "@aws-sdk/hash-node": "3.226.0",
         "@aws-sdk/invalid-dependency": "3.226.0",
@@ -809,7 +510,7 @@
         "@aws-sdk/util-body-length-node": "3.208.0",
         "@aws-sdk/util-defaults-mode-browser": "3.234.0",
         "@aws-sdk/util-defaults-mode-node": "3.234.0",
-        "@aws-sdk/util-endpoints": "3.226.0",
+        "@aws-sdk/util-endpoints": "3.245.0",
         "@aws-sdk/util-retry": "3.229.0",
         "@aws-sdk/util-user-agent-browser": "3.226.0",
         "@aws-sdk/util-user-agent-node": "3.226.0",
@@ -817,246 +518,6 @@
         "@aws-sdk/util-utf8-node": "3.208.0",
         "tslib": "^2.3.1",
         "uuid": "^8.3.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/client-sso": {
-      "version": "3.238.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.238.0.tgz",
-      "integrity": "sha512-KHJJWP7hBDa9KLYiU5+hOb+3AAba93PhWebXkpKyQ/Bs+e7ECCreyLCwuME6uWTV01NDuFDpwZ6zUMpyNIcP6Q==",
-      "dev": true,
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.234.0",
-        "@aws-sdk/fetch-http-handler": "3.226.0",
-        "@aws-sdk/hash-node": "3.226.0",
-        "@aws-sdk/invalid-dependency": "3.226.0",
-        "@aws-sdk/middleware-content-length": "3.226.0",
-        "@aws-sdk/middleware-endpoint": "3.226.0",
-        "@aws-sdk/middleware-host-header": "3.226.0",
-        "@aws-sdk/middleware-logger": "3.226.0",
-        "@aws-sdk/middleware-recursion-detection": "3.226.0",
-        "@aws-sdk/middleware-retry": "3.235.0",
-        "@aws-sdk/middleware-serde": "3.226.0",
-        "@aws-sdk/middleware-stack": "3.226.0",
-        "@aws-sdk/middleware-user-agent": "3.226.0",
-        "@aws-sdk/node-config-provider": "3.226.0",
-        "@aws-sdk/node-http-handler": "3.226.0",
-        "@aws-sdk/protocol-http": "3.226.0",
-        "@aws-sdk/smithy-client": "3.234.0",
-        "@aws-sdk/types": "3.226.0",
-        "@aws-sdk/url-parser": "3.226.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.234.0",
-        "@aws-sdk/util-defaults-mode-node": "3.234.0",
-        "@aws-sdk/util-endpoints": "3.226.0",
-        "@aws-sdk/util-retry": "3.229.0",
-        "@aws-sdk/util-user-agent-browser": "3.226.0",
-        "@aws-sdk/util-user-agent-node": "3.226.0",
-        "@aws-sdk/util-utf8-browser": "3.188.0",
-        "@aws-sdk/util-utf8-node": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/client-sso-oidc": {
-      "version": "3.238.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.238.0.tgz",
-      "integrity": "sha512-kazcA2Kp+cXQRtaZi5/T5YFfU9J3nzu1tXJsh0xAm+J3S9LS1ertY1bSX6KBed2xuxx2mfum8JRqli0TJad/pA==",
-      "dev": true,
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.234.0",
-        "@aws-sdk/fetch-http-handler": "3.226.0",
-        "@aws-sdk/hash-node": "3.226.0",
-        "@aws-sdk/invalid-dependency": "3.226.0",
-        "@aws-sdk/middleware-content-length": "3.226.0",
-        "@aws-sdk/middleware-endpoint": "3.226.0",
-        "@aws-sdk/middleware-host-header": "3.226.0",
-        "@aws-sdk/middleware-logger": "3.226.0",
-        "@aws-sdk/middleware-recursion-detection": "3.226.0",
-        "@aws-sdk/middleware-retry": "3.235.0",
-        "@aws-sdk/middleware-serde": "3.226.0",
-        "@aws-sdk/middleware-stack": "3.226.0",
-        "@aws-sdk/middleware-user-agent": "3.226.0",
-        "@aws-sdk/node-config-provider": "3.226.0",
-        "@aws-sdk/node-http-handler": "3.226.0",
-        "@aws-sdk/protocol-http": "3.226.0",
-        "@aws-sdk/smithy-client": "3.234.0",
-        "@aws-sdk/types": "3.226.0",
-        "@aws-sdk/url-parser": "3.226.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.234.0",
-        "@aws-sdk/util-defaults-mode-node": "3.234.0",
-        "@aws-sdk/util-endpoints": "3.226.0",
-        "@aws-sdk/util-retry": "3.229.0",
-        "@aws-sdk/util-user-agent-browser": "3.226.0",
-        "@aws-sdk/util-user-agent-node": "3.226.0",
-        "@aws-sdk/util-utf8-browser": "3.188.0",
-        "@aws-sdk/util-utf8-node": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/client-sts": {
-      "version": "3.238.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.238.0.tgz",
-      "integrity": "sha512-jQNwHqxWUGvWCN4o8KUFYQES8r41Oobu7x1KZOMrPhPxy27FUcDjBq/h85VoD2/AZlETSCZLiCnKV3KBh5pT5w==",
-      "dev": true,
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.234.0",
-        "@aws-sdk/credential-provider-node": "3.238.0",
-        "@aws-sdk/fetch-http-handler": "3.226.0",
-        "@aws-sdk/hash-node": "3.226.0",
-        "@aws-sdk/invalid-dependency": "3.226.0",
-        "@aws-sdk/middleware-content-length": "3.226.0",
-        "@aws-sdk/middleware-endpoint": "3.226.0",
-        "@aws-sdk/middleware-host-header": "3.226.0",
-        "@aws-sdk/middleware-logger": "3.226.0",
-        "@aws-sdk/middleware-recursion-detection": "3.226.0",
-        "@aws-sdk/middleware-retry": "3.235.0",
-        "@aws-sdk/middleware-sdk-sts": "3.226.0",
-        "@aws-sdk/middleware-serde": "3.226.0",
-        "@aws-sdk/middleware-signing": "3.226.0",
-        "@aws-sdk/middleware-stack": "3.226.0",
-        "@aws-sdk/middleware-user-agent": "3.226.0",
-        "@aws-sdk/node-config-provider": "3.226.0",
-        "@aws-sdk/node-http-handler": "3.226.0",
-        "@aws-sdk/protocol-http": "3.226.0",
-        "@aws-sdk/smithy-client": "3.234.0",
-        "@aws-sdk/types": "3.226.0",
-        "@aws-sdk/url-parser": "3.226.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.234.0",
-        "@aws-sdk/util-defaults-mode-node": "3.234.0",
-        "@aws-sdk/util-endpoints": "3.226.0",
-        "@aws-sdk/util-retry": "3.229.0",
-        "@aws-sdk/util-user-agent-browser": "3.226.0",
-        "@aws-sdk/util-user-agent-node": "3.226.0",
-        "@aws-sdk/util-utf8-browser": "3.188.0",
-        "@aws-sdk/util-utf8-node": "3.208.0",
-        "fast-xml-parser": "4.0.11",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/config-resolver": {
-      "version": "3.234.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.234.0.tgz",
-      "integrity": "sha512-uZxy4wzllfvgCQxVc+Iqhde0NGAnfmV2hWR6ejadJaAFTuYNvQiRg9IqJy3pkyDPqXySiJ8Bom5PoJfgn55J/A==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/signature-v4": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "@aws-sdk/util-config-provider": "3.208.0",
-        "@aws-sdk/util-middleware": "3.226.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.238.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.238.0.tgz",
-      "integrity": "sha512-WmPNtIYyUasjV7VQxvPNq7ihmx0vFsiKAtjNjjakdrt5TPoma4nUYb9tIG9SuG+kcp4DJIgRLJAgZtXbCcVimg==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.226.0",
-        "@aws-sdk/credential-provider-imds": "3.226.0",
-        "@aws-sdk/credential-provider-process": "3.226.0",
-        "@aws-sdk/credential-provider-sso": "3.238.0",
-        "@aws-sdk/credential-provider-web-identity": "3.226.0",
-        "@aws-sdk/property-provider": "3.226.0",
-        "@aws-sdk/shared-ini-file-loader": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.238.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.238.0.tgz",
-      "integrity": "sha512-/RN5EyGfgdIIJdFzv+O0nSaHX1/F3anQjTIBeVg8GJ+82m+bDxMdALsG+NzkYnLilN9Uhc1lSNjLBCoPa5DSEg==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.226.0",
-        "@aws-sdk/credential-provider-imds": "3.226.0",
-        "@aws-sdk/credential-provider-ini": "3.238.0",
-        "@aws-sdk/credential-provider-process": "3.226.0",
-        "@aws-sdk/credential-provider-sso": "3.238.0",
-        "@aws-sdk/credential-provider-web-identity": "3.226.0",
-        "@aws-sdk/property-provider": "3.226.0",
-        "@aws-sdk/shared-ini-file-loader": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.238.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.238.0.tgz",
-      "integrity": "sha512-i70V4bFlCVYey3QARJ6XxKEg/4YuoFRnePV2oK37UHOGpEn49uXKwVZqLjzJgFHln7BPlC06cWDqrHUQIMvYrQ==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/client-sso": "3.238.0",
-        "@aws-sdk/property-provider": "3.226.0",
-        "@aws-sdk/shared-ini-file-loader": "3.226.0",
-        "@aws-sdk/token-providers": "3.238.0",
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/smithy-client": {
-      "version": "3.234.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.234.0.tgz",
-      "integrity": "sha512-8AtR/k4vsFvjXeQbIzq/Wy7Nbk48Ou0wUEeVYPHWHPSU8QamFWORkOwmKtKMfHAyZvmqiAPeQqHFkq+UJhWyyQ==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/middleware-stack": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/token-providers": {
-      "version": "3.238.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.238.0.tgz",
-      "integrity": "sha512-vYUwmy0kTzA99mJCVvad+/5RDlWve/xxnppT8DJK3JIdAgskp+rULY+joVnq2NSl489UAioUnFGs57vUxi8Pog==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/client-sso-oidc": "3.238.0",
-        "@aws-sdk/property-provider": "3.226.0",
-        "@aws-sdk/shared-ini-file-loader": "3.226.0",
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -1115,19 +576,6 @@
         "@aws-sdk/util-waiter": "3.226.0",
         "tslib": "^2.3.1",
         "uuid": "^8.3.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.245.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.245.0.tgz",
-      "integrity": "sha512-UNOFquB1tKx+8RT8n82Zb5tIwDyZHVPBg/m0LB0RsLETjr6krien5ASpqWezsXKIR1hftN9uaxN4bvf2dZrWHg==",
-      "dev": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -1228,30 +676,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.245.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.245.0.tgz",
-      "integrity": "sha512-UNOFquB1tKx+8RT8n82Zb5tIwDyZHVPBg/m0LB0RsLETjr6krien5ASpqWezsXKIR1hftN9uaxN4bvf2dZrWHg==",
-      "dependencies": {
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.245.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.245.0.tgz",
-      "integrity": "sha512-UNOFquB1tKx+8RT8n82Zb5tIwDyZHVPBg/m0LB0RsLETjr6krien5ASpqWezsXKIR1hftN9uaxN4bvf2dZrWHg==",
-      "dependencies": {
-        "@aws-sdk/types": "3.226.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-sdk/client-sts": {
       "version": "3.245.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.245.0.tgz",
@@ -1293,18 +717,6 @@
         "@aws-sdk/util-utf8-browser": "3.188.0",
         "@aws-sdk/util-utf8-node": "3.208.0",
         "fast-xml-parser": "4.0.11",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.245.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.245.0.tgz",
-      "integrity": "sha512-UNOFquB1tKx+8RT8n82Zb5tIwDyZHVPBg/m0LB0RsLETjr6krien5ASpqWezsXKIR1hftN9uaxN4bvf2dZrWHg==",
-      "dependencies": {
-        "@aws-sdk/types": "3.226.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -1959,10 +1371,9 @@
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.226.0.tgz",
-      "integrity": "sha512-iqOkac/zLmyPBUJd7SLN0PeZMkOmlGgD5PHmmekTClOkce2eUjK9SNX1PzL73aXPoPTyhg9QGLH8uEZEQ8YUzg==",
-      "dev": true,
+      "version": "3.245.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.245.0.tgz",
+      "integrity": "sha512-UNOFquB1tKx+8RT8n82Zb5tIwDyZHVPBg/m0LB0RsLETjr6krien5ASpqWezsXKIR1hftN9uaxN4bvf2dZrWHg==",
       "dependencies": {
         "@aws-sdk/types": "3.226.0",
         "tslib": "^2.3.1"
@@ -8777,6 +8188,10 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/docs": {
+      "resolved": "docs/snippets",
+      "link": true
     },
     "node_modules/doctrine": {
       "version": "3.0.0",
@@ -17208,7 +16623,7 @@
     },
     "packages/commons": {
       "name": "@aws-lambda-powertools/commons",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "license": "MIT-0"
     },
     "packages/idempotency": {
@@ -17226,10 +16641,10 @@
     },
     "packages/logger": {
       "name": "@aws-lambda-powertools/logger",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "license": "MIT",
       "dependencies": {
-        "@aws-lambda-powertools/commons": "^1.5.0",
+        "@aws-lambda-powertools/commons": "^1.5.1",
         "lodash.merge": "^4.6.2"
       },
       "devDependencies": {
@@ -17238,10 +16653,10 @@
     },
     "packages/metrics": {
       "name": "@aws-lambda-powertools/metrics",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "license": "MIT-0",
       "dependencies": {
-        "@aws-lambda-powertools/commons": "^1.5.0"
+        "@aws-lambda-powertools/commons": "^1.5.1"
       },
       "devDependencies": {
         "@types/promise-retry": "^1.1.3",
@@ -17279,10 +16694,10 @@
     },
     "packages/tracer": {
       "name": "@aws-lambda-powertools/tracer",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "license": "MIT-0",
       "dependencies": {
-        "@aws-lambda-powertools/commons": "^1.5.0",
+        "@aws-lambda-powertools/commons": "^1.5.1",
         "aws-xray-sdk-core": "^3.4.0"
       },
       "devDependencies": {
@@ -17528,7 +16943,7 @@
     "@aws-lambda-powertools/logger": {
       "version": "file:packages/logger",
       "requires": {
-        "@aws-lambda-powertools/commons": "^1.5.0",
+        "@aws-lambda-powertools/commons": "^1.5.1",
         "@types/lodash.merge": "^4.6.7",
         "lodash.merge": "^4.6.2"
       }
@@ -17536,7 +16951,7 @@
     "@aws-lambda-powertools/metrics": {
       "version": "file:packages/metrics",
       "requires": {
-        "@aws-lambda-powertools/commons": "^1.5.0",
+        "@aws-lambda-powertools/commons": "^1.5.1",
         "@types/promise-retry": "^1.1.3",
         "promise-retry": "^2.0.1"
       }
@@ -17568,7 +16983,7 @@
     "@aws-lambda-powertools/tracer": {
       "version": "file:packages/tracer",
       "requires": {
-        "@aws-lambda-powertools/commons": "^1.5.0",
+        "@aws-lambda-powertools/commons": "^1.5.1",
         "@aws-sdk/client-dynamodb": "^3.231.0",
         "@types/promise-retry": "^1.1.3",
         "aws-sdk": "^2.1276.0",
@@ -17587,16 +17002,16 @@
       }
     },
     "@aws-sdk/client-appconfigdata": {
-      "version": "3.241.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-appconfigdata/-/client-appconfigdata-3.241.0.tgz",
-      "integrity": "sha512-5AVfSc6ZQ17dF0cdIrmpEe0H6vmGumBvsFGn89e2clSPtqqtsFDpBeAsS5jCMbxO9pakkCM0RPAh+sci6MnlYg==",
+      "version": "3.245.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-appconfigdata/-/client-appconfigdata-3.245.0.tgz",
+      "integrity": "sha512-XxyUEEYcL6xvFUnrd10sVtmWaqYTHwn9IfScqyqz2K8wrAnbHPeaWc197UulqhIXYfz11foOAEleiUBKM1kHdw==",
       "dev": true,
       "requires": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.241.0",
+        "@aws-sdk/client-sts": "3.245.0",
         "@aws-sdk/config-resolver": "3.234.0",
-        "@aws-sdk/credential-provider-node": "3.241.0",
+        "@aws-sdk/credential-provider-node": "3.245.0",
         "@aws-sdk/fetch-http-handler": "3.226.0",
         "@aws-sdk/hash-node": "3.226.0",
         "@aws-sdk/invalid-dependency": "3.226.0",
@@ -17621,285 +17036,13 @@
         "@aws-sdk/util-body-length-node": "3.208.0",
         "@aws-sdk/util-defaults-mode-browser": "3.234.0",
         "@aws-sdk/util-defaults-mode-node": "3.234.0",
-        "@aws-sdk/util-endpoints": "3.241.0",
+        "@aws-sdk/util-endpoints": "3.245.0",
         "@aws-sdk/util-retry": "3.229.0",
         "@aws-sdk/util-user-agent-browser": "3.226.0",
         "@aws-sdk/util-user-agent-node": "3.226.0",
         "@aws-sdk/util-utf8-browser": "3.188.0",
         "@aws-sdk/util-utf8-node": "3.208.0",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "@aws-sdk/client-sso": {
-          "version": "3.241.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.241.0.tgz",
-          "integrity": "sha512-Jm4HR+RYAqKMEYZvvWaq0NYUKKonyInOeubObXH4BLXZpmUBSdYCSjjLdNJY3jkQoxbDVPVMIurVNh5zT5SMRw==",
-          "dev": true,
-          "requires": {
-            "@aws-crypto/sha256-browser": "2.0.0",
-            "@aws-crypto/sha256-js": "2.0.0",
-            "@aws-sdk/config-resolver": "3.234.0",
-            "@aws-sdk/fetch-http-handler": "3.226.0",
-            "@aws-sdk/hash-node": "3.226.0",
-            "@aws-sdk/invalid-dependency": "3.226.0",
-            "@aws-sdk/middleware-content-length": "3.226.0",
-            "@aws-sdk/middleware-endpoint": "3.226.0",
-            "@aws-sdk/middleware-host-header": "3.226.0",
-            "@aws-sdk/middleware-logger": "3.226.0",
-            "@aws-sdk/middleware-recursion-detection": "3.226.0",
-            "@aws-sdk/middleware-retry": "3.235.0",
-            "@aws-sdk/middleware-serde": "3.226.0",
-            "@aws-sdk/middleware-stack": "3.226.0",
-            "@aws-sdk/middleware-user-agent": "3.226.0",
-            "@aws-sdk/node-config-provider": "3.226.0",
-            "@aws-sdk/node-http-handler": "3.226.0",
-            "@aws-sdk/protocol-http": "3.226.0",
-            "@aws-sdk/smithy-client": "3.234.0",
-            "@aws-sdk/types": "3.226.0",
-            "@aws-sdk/url-parser": "3.226.0",
-            "@aws-sdk/util-base64": "3.208.0",
-            "@aws-sdk/util-body-length-browser": "3.188.0",
-            "@aws-sdk/util-body-length-node": "3.208.0",
-            "@aws-sdk/util-defaults-mode-browser": "3.234.0",
-            "@aws-sdk/util-defaults-mode-node": "3.234.0",
-            "@aws-sdk/util-endpoints": "3.241.0",
-            "@aws-sdk/util-retry": "3.229.0",
-            "@aws-sdk/util-user-agent-browser": "3.226.0",
-            "@aws-sdk/util-user-agent-node": "3.226.0",
-            "@aws-sdk/util-utf8-browser": "3.188.0",
-            "@aws-sdk/util-utf8-node": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/client-sso-oidc": {
-          "version": "3.241.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.241.0.tgz",
-          "integrity": "sha512-/Ml2QBGpGfUEeBrPzBZhSTBkHuXFD2EAZEIHGCBH4tKaURDI6/FoGI8P1Rl4BzoFt+II/Cr91Eox6YT9EwChsQ==",
-          "dev": true,
-          "requires": {
-            "@aws-crypto/sha256-browser": "2.0.0",
-            "@aws-crypto/sha256-js": "2.0.0",
-            "@aws-sdk/config-resolver": "3.234.0",
-            "@aws-sdk/fetch-http-handler": "3.226.0",
-            "@aws-sdk/hash-node": "3.226.0",
-            "@aws-sdk/invalid-dependency": "3.226.0",
-            "@aws-sdk/middleware-content-length": "3.226.0",
-            "@aws-sdk/middleware-endpoint": "3.226.0",
-            "@aws-sdk/middleware-host-header": "3.226.0",
-            "@aws-sdk/middleware-logger": "3.226.0",
-            "@aws-sdk/middleware-recursion-detection": "3.226.0",
-            "@aws-sdk/middleware-retry": "3.235.0",
-            "@aws-sdk/middleware-serde": "3.226.0",
-            "@aws-sdk/middleware-stack": "3.226.0",
-            "@aws-sdk/middleware-user-agent": "3.226.0",
-            "@aws-sdk/node-config-provider": "3.226.0",
-            "@aws-sdk/node-http-handler": "3.226.0",
-            "@aws-sdk/protocol-http": "3.226.0",
-            "@aws-sdk/smithy-client": "3.234.0",
-            "@aws-sdk/types": "3.226.0",
-            "@aws-sdk/url-parser": "3.226.0",
-            "@aws-sdk/util-base64": "3.208.0",
-            "@aws-sdk/util-body-length-browser": "3.188.0",
-            "@aws-sdk/util-body-length-node": "3.208.0",
-            "@aws-sdk/util-defaults-mode-browser": "3.234.0",
-            "@aws-sdk/util-defaults-mode-node": "3.234.0",
-            "@aws-sdk/util-endpoints": "3.241.0",
-            "@aws-sdk/util-retry": "3.229.0",
-            "@aws-sdk/util-user-agent-browser": "3.226.0",
-            "@aws-sdk/util-user-agent-node": "3.226.0",
-            "@aws-sdk/util-utf8-browser": "3.188.0",
-            "@aws-sdk/util-utf8-node": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/client-sts": {
-          "version": "3.241.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.241.0.tgz",
-          "integrity": "sha512-vmlG8cJzRf8skCtTJbA2wBvD2c3NQ5gZryzJvTKDS06KzBzcEpnjlLseuTekcnOiRNekbFUX5hRu5Zj3N2ReLg==",
-          "dev": true,
-          "requires": {
-            "@aws-crypto/sha256-browser": "2.0.0",
-            "@aws-crypto/sha256-js": "2.0.0",
-            "@aws-sdk/config-resolver": "3.234.0",
-            "@aws-sdk/credential-provider-node": "3.241.0",
-            "@aws-sdk/fetch-http-handler": "3.226.0",
-            "@aws-sdk/hash-node": "3.226.0",
-            "@aws-sdk/invalid-dependency": "3.226.0",
-            "@aws-sdk/middleware-content-length": "3.226.0",
-            "@aws-sdk/middleware-endpoint": "3.226.0",
-            "@aws-sdk/middleware-host-header": "3.226.0",
-            "@aws-sdk/middleware-logger": "3.226.0",
-            "@aws-sdk/middleware-recursion-detection": "3.226.0",
-            "@aws-sdk/middleware-retry": "3.235.0",
-            "@aws-sdk/middleware-sdk-sts": "3.226.0",
-            "@aws-sdk/middleware-serde": "3.226.0",
-            "@aws-sdk/middleware-signing": "3.226.0",
-            "@aws-sdk/middleware-stack": "3.226.0",
-            "@aws-sdk/middleware-user-agent": "3.226.0",
-            "@aws-sdk/node-config-provider": "3.226.0",
-            "@aws-sdk/node-http-handler": "3.226.0",
-            "@aws-sdk/protocol-http": "3.226.0",
-            "@aws-sdk/smithy-client": "3.234.0",
-            "@aws-sdk/types": "3.226.0",
-            "@aws-sdk/url-parser": "3.226.0",
-            "@aws-sdk/util-base64": "3.208.0",
-            "@aws-sdk/util-body-length-browser": "3.188.0",
-            "@aws-sdk/util-body-length-node": "3.208.0",
-            "@aws-sdk/util-defaults-mode-browser": "3.234.0",
-            "@aws-sdk/util-defaults-mode-node": "3.234.0",
-            "@aws-sdk/util-endpoints": "3.241.0",
-            "@aws-sdk/util-retry": "3.229.0",
-            "@aws-sdk/util-user-agent-browser": "3.226.0",
-            "@aws-sdk/util-user-agent-node": "3.226.0",
-            "@aws-sdk/util-utf8-browser": "3.188.0",
-            "@aws-sdk/util-utf8-node": "3.208.0",
-            "fast-xml-parser": "4.0.11",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/config-resolver": {
-          "version": "3.234.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.234.0.tgz",
-          "integrity": "sha512-uZxy4wzllfvgCQxVc+Iqhde0NGAnfmV2hWR6ejadJaAFTuYNvQiRg9IqJy3pkyDPqXySiJ8Bom5PoJfgn55J/A==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/signature-v4": "3.226.0",
-            "@aws-sdk/types": "3.226.0",
-            "@aws-sdk/util-config-provider": "3.208.0",
-            "@aws-sdk/util-middleware": "3.226.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/credential-provider-ini": {
-          "version": "3.241.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.241.0.tgz",
-          "integrity": "sha512-CI+mu6h74Kzmscw35TvNkc/wYHsHPGAwP7humSHoWw53H9mVw21Ggft/dT1iFQQZWQ8BNXkzuXlNo1IlqwMgOA==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/credential-provider-env": "3.226.0",
-            "@aws-sdk/credential-provider-imds": "3.226.0",
-            "@aws-sdk/credential-provider-process": "3.226.0",
-            "@aws-sdk/credential-provider-sso": "3.241.0",
-            "@aws-sdk/credential-provider-web-identity": "3.226.0",
-            "@aws-sdk/property-provider": "3.226.0",
-            "@aws-sdk/shared-ini-file-loader": "3.226.0",
-            "@aws-sdk/types": "3.226.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/credential-provider-node": {
-          "version": "3.241.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.241.0.tgz",
-          "integrity": "sha512-08zPQcD5o9brQmzEipWHeHgU85aQcEF8MWLfpeyjO6e1/l7ysQ35NsS+PYtv77nLpGCx/X+ZuW/KXWoRrbw77w==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/credential-provider-env": "3.226.0",
-            "@aws-sdk/credential-provider-imds": "3.226.0",
-            "@aws-sdk/credential-provider-ini": "3.241.0",
-            "@aws-sdk/credential-provider-process": "3.226.0",
-            "@aws-sdk/credential-provider-sso": "3.241.0",
-            "@aws-sdk/credential-provider-web-identity": "3.226.0",
-            "@aws-sdk/property-provider": "3.226.0",
-            "@aws-sdk/shared-ini-file-loader": "3.226.0",
-            "@aws-sdk/types": "3.226.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/credential-provider-sso": {
-          "version": "3.241.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.241.0.tgz",
-          "integrity": "sha512-6Bjd6eEIrVomRTrPrM4dlxusQm+KMJ9hLYKECCpFkwDKIK+pTgZNLRtQdalHyzwneHJPdimrm8cOv1kUQ8hPoA==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/client-sso": "3.241.0",
-            "@aws-sdk/property-provider": "3.226.0",
-            "@aws-sdk/shared-ini-file-loader": "3.226.0",
-            "@aws-sdk/token-providers": "3.241.0",
-            "@aws-sdk/types": "3.226.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/middleware-retry": {
-          "version": "3.235.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.235.0.tgz",
-          "integrity": "sha512-50WHbJGpD3SNp9763MAlHqIhXil++JdQbKejNpHg7HsJne/ao3ub+fDOfx//mMBjpzBV25BGd5UlfL6blrClSg==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/protocol-http": "3.226.0",
-            "@aws-sdk/service-error-classification": "3.229.0",
-            "@aws-sdk/types": "3.226.0",
-            "@aws-sdk/util-middleware": "3.226.0",
-            "@aws-sdk/util-retry": "3.229.0",
-            "tslib": "^2.3.1",
-            "uuid": "^8.3.2"
-          }
-        },
-        "@aws-sdk/smithy-client": {
-          "version": "3.234.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.234.0.tgz",
-          "integrity": "sha512-8AtR/k4vsFvjXeQbIzq/Wy7Nbk48Ou0wUEeVYPHWHPSU8QamFWORkOwmKtKMfHAyZvmqiAPeQqHFkq+UJhWyyQ==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/middleware-stack": "3.226.0",
-            "@aws-sdk/types": "3.226.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/token-providers": {
-          "version": "3.241.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.241.0.tgz",
-          "integrity": "sha512-79okvuOS7V559OIL/RalIPG98wzmWxeFOChFnbEjn2pKOyGQ6FJRwLPYZaVRtNdAtnkBNgRpmFq9dX843QxhtQ==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/client-sso-oidc": "3.241.0",
-            "@aws-sdk/property-provider": "3.226.0",
-            "@aws-sdk/shared-ini-file-loader": "3.226.0",
-            "@aws-sdk/types": "3.226.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-defaults-mode-browser": {
-          "version": "3.234.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.234.0.tgz",
-          "integrity": "sha512-IHMKXjTbOD8XMz5+2oCOsVP94BYb9YyjXdns0aAXr2NAo7k2+RCzXQ2DebJXppGda1F6opFutoKwyVSN0cmbMw==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/property-provider": "3.226.0",
-            "@aws-sdk/types": "3.226.0",
-            "bowser": "^2.11.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-defaults-mode-node": {
-          "version": "3.234.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.234.0.tgz",
-          "integrity": "sha512-UGjQ+OjBYYhxFVtUY+jtr0ZZgzZh6OHtYwRhFt8IHewJXFCfZTyfsbX20szBj5y1S4HRIUJ7cwBLIytTqMbI5w==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/config-resolver": "3.234.0",
-            "@aws-sdk/credential-provider-imds": "3.226.0",
-            "@aws-sdk/node-config-provider": "3.226.0",
-            "@aws-sdk/property-provider": "3.226.0",
-            "@aws-sdk/types": "3.226.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-endpoints": {
-          "version": "3.241.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.241.0.tgz",
-          "integrity": "sha512-jVf8bKrN22Ey0xLmj75sL7EUvm5HFpuOMkXsZkuXycKhCwLBcEUWlvtJYtRjOU1zScPQv9GMJd2QXQglp34iOQ==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/types": "3.226.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "uuid": {
-          "version": "8.3.2",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-          "dev": true
-        }
       }
     },
     "@aws-sdk/client-dynamodb": {
@@ -17948,15 +17091,6 @@
         "uuid": "^8.3.2"
       },
       "dependencies": {
-        "@aws-sdk/util-endpoints": {
-          "version": "3.245.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.245.0.tgz",
-          "integrity": "sha512-UNOFquB1tKx+8RT8n82Zb5tIwDyZHVPBg/m0LB0RsLETjr6krien5ASpqWezsXKIR1hftN9uaxN4bvf2dZrWHg==",
-          "requires": {
-            "@aws-sdk/types": "3.226.0",
-            "tslib": "^2.3.1"
-          }
-        },
         "uuid": {
           "version": "8.3.2",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -17965,16 +17099,16 @@
       }
     },
     "@aws-sdk/client-secrets-manager": {
-      "version": "3.238.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.238.0.tgz",
-      "integrity": "sha512-J3lmceh2txILEh8tWf4ldp8ThAh2WJBSa1t8oJhW58KuE+1a7cwOpgWO6MsSvOrGtp7qzTr8GMBUf7KLdv7wOg==",
+      "version": "3.250.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.250.0.tgz",
+      "integrity": "sha512-CB4OcFJPpAuW3rRXBxgOtF9RXHBixEvJSDkh8RsCAamt37Fw61+e+CsdXixSWA4rzQA+3PQuts7zlwhcxobbJg==",
       "dev": true,
       "requires": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.238.0",
+        "@aws-sdk/client-sts": "3.245.0",
         "@aws-sdk/config-resolver": "3.234.0",
-        "@aws-sdk/credential-provider-node": "3.238.0",
+        "@aws-sdk/credential-provider-node": "3.245.0",
         "@aws-sdk/fetch-http-handler": "3.226.0",
         "@aws-sdk/hash-node": "3.226.0",
         "@aws-sdk/invalid-dependency": "3.226.0",
@@ -17999,7 +17133,7 @@
         "@aws-sdk/util-body-length-node": "3.208.0",
         "@aws-sdk/util-defaults-mode-browser": "3.234.0",
         "@aws-sdk/util-defaults-mode-node": "3.234.0",
-        "@aws-sdk/util-endpoints": "3.226.0",
+        "@aws-sdk/util-endpoints": "3.245.0",
         "@aws-sdk/util-retry": "3.229.0",
         "@aws-sdk/util-user-agent-browser": "3.226.0",
         "@aws-sdk/util-user-agent-node": "3.226.0",
@@ -18009,219 +17143,6 @@
         "uuid": "^8.3.2"
       },
       "dependencies": {
-        "@aws-sdk/client-sso": {
-          "version": "3.238.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.238.0.tgz",
-          "integrity": "sha512-KHJJWP7hBDa9KLYiU5+hOb+3AAba93PhWebXkpKyQ/Bs+e7ECCreyLCwuME6uWTV01NDuFDpwZ6zUMpyNIcP6Q==",
-          "dev": true,
-          "requires": {
-            "@aws-crypto/sha256-browser": "2.0.0",
-            "@aws-crypto/sha256-js": "2.0.0",
-            "@aws-sdk/config-resolver": "3.234.0",
-            "@aws-sdk/fetch-http-handler": "3.226.0",
-            "@aws-sdk/hash-node": "3.226.0",
-            "@aws-sdk/invalid-dependency": "3.226.0",
-            "@aws-sdk/middleware-content-length": "3.226.0",
-            "@aws-sdk/middleware-endpoint": "3.226.0",
-            "@aws-sdk/middleware-host-header": "3.226.0",
-            "@aws-sdk/middleware-logger": "3.226.0",
-            "@aws-sdk/middleware-recursion-detection": "3.226.0",
-            "@aws-sdk/middleware-retry": "3.235.0",
-            "@aws-sdk/middleware-serde": "3.226.0",
-            "@aws-sdk/middleware-stack": "3.226.0",
-            "@aws-sdk/middleware-user-agent": "3.226.0",
-            "@aws-sdk/node-config-provider": "3.226.0",
-            "@aws-sdk/node-http-handler": "3.226.0",
-            "@aws-sdk/protocol-http": "3.226.0",
-            "@aws-sdk/smithy-client": "3.234.0",
-            "@aws-sdk/types": "3.226.0",
-            "@aws-sdk/url-parser": "3.226.0",
-            "@aws-sdk/util-base64": "3.208.0",
-            "@aws-sdk/util-body-length-browser": "3.188.0",
-            "@aws-sdk/util-body-length-node": "3.208.0",
-            "@aws-sdk/util-defaults-mode-browser": "3.234.0",
-            "@aws-sdk/util-defaults-mode-node": "3.234.0",
-            "@aws-sdk/util-endpoints": "3.226.0",
-            "@aws-sdk/util-retry": "3.229.0",
-            "@aws-sdk/util-user-agent-browser": "3.226.0",
-            "@aws-sdk/util-user-agent-node": "3.226.0",
-            "@aws-sdk/util-utf8-browser": "3.188.0",
-            "@aws-sdk/util-utf8-node": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/client-sso-oidc": {
-          "version": "3.238.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.238.0.tgz",
-          "integrity": "sha512-kazcA2Kp+cXQRtaZi5/T5YFfU9J3nzu1tXJsh0xAm+J3S9LS1ertY1bSX6KBed2xuxx2mfum8JRqli0TJad/pA==",
-          "dev": true,
-          "requires": {
-            "@aws-crypto/sha256-browser": "2.0.0",
-            "@aws-crypto/sha256-js": "2.0.0",
-            "@aws-sdk/config-resolver": "3.234.0",
-            "@aws-sdk/fetch-http-handler": "3.226.0",
-            "@aws-sdk/hash-node": "3.226.0",
-            "@aws-sdk/invalid-dependency": "3.226.0",
-            "@aws-sdk/middleware-content-length": "3.226.0",
-            "@aws-sdk/middleware-endpoint": "3.226.0",
-            "@aws-sdk/middleware-host-header": "3.226.0",
-            "@aws-sdk/middleware-logger": "3.226.0",
-            "@aws-sdk/middleware-recursion-detection": "3.226.0",
-            "@aws-sdk/middleware-retry": "3.235.0",
-            "@aws-sdk/middleware-serde": "3.226.0",
-            "@aws-sdk/middleware-stack": "3.226.0",
-            "@aws-sdk/middleware-user-agent": "3.226.0",
-            "@aws-sdk/node-config-provider": "3.226.0",
-            "@aws-sdk/node-http-handler": "3.226.0",
-            "@aws-sdk/protocol-http": "3.226.0",
-            "@aws-sdk/smithy-client": "3.234.0",
-            "@aws-sdk/types": "3.226.0",
-            "@aws-sdk/url-parser": "3.226.0",
-            "@aws-sdk/util-base64": "3.208.0",
-            "@aws-sdk/util-body-length-browser": "3.188.0",
-            "@aws-sdk/util-body-length-node": "3.208.0",
-            "@aws-sdk/util-defaults-mode-browser": "3.234.0",
-            "@aws-sdk/util-defaults-mode-node": "3.234.0",
-            "@aws-sdk/util-endpoints": "3.226.0",
-            "@aws-sdk/util-retry": "3.229.0",
-            "@aws-sdk/util-user-agent-browser": "3.226.0",
-            "@aws-sdk/util-user-agent-node": "3.226.0",
-            "@aws-sdk/util-utf8-browser": "3.188.0",
-            "@aws-sdk/util-utf8-node": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/client-sts": {
-          "version": "3.238.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.238.0.tgz",
-          "integrity": "sha512-jQNwHqxWUGvWCN4o8KUFYQES8r41Oobu7x1KZOMrPhPxy27FUcDjBq/h85VoD2/AZlETSCZLiCnKV3KBh5pT5w==",
-          "dev": true,
-          "requires": {
-            "@aws-crypto/sha256-browser": "2.0.0",
-            "@aws-crypto/sha256-js": "2.0.0",
-            "@aws-sdk/config-resolver": "3.234.0",
-            "@aws-sdk/credential-provider-node": "3.238.0",
-            "@aws-sdk/fetch-http-handler": "3.226.0",
-            "@aws-sdk/hash-node": "3.226.0",
-            "@aws-sdk/invalid-dependency": "3.226.0",
-            "@aws-sdk/middleware-content-length": "3.226.0",
-            "@aws-sdk/middleware-endpoint": "3.226.0",
-            "@aws-sdk/middleware-host-header": "3.226.0",
-            "@aws-sdk/middleware-logger": "3.226.0",
-            "@aws-sdk/middleware-recursion-detection": "3.226.0",
-            "@aws-sdk/middleware-retry": "3.235.0",
-            "@aws-sdk/middleware-sdk-sts": "3.226.0",
-            "@aws-sdk/middleware-serde": "3.226.0",
-            "@aws-sdk/middleware-signing": "3.226.0",
-            "@aws-sdk/middleware-stack": "3.226.0",
-            "@aws-sdk/middleware-user-agent": "3.226.0",
-            "@aws-sdk/node-config-provider": "3.226.0",
-            "@aws-sdk/node-http-handler": "3.226.0",
-            "@aws-sdk/protocol-http": "3.226.0",
-            "@aws-sdk/smithy-client": "3.234.0",
-            "@aws-sdk/types": "3.226.0",
-            "@aws-sdk/url-parser": "3.226.0",
-            "@aws-sdk/util-base64": "3.208.0",
-            "@aws-sdk/util-body-length-browser": "3.188.0",
-            "@aws-sdk/util-body-length-node": "3.208.0",
-            "@aws-sdk/util-defaults-mode-browser": "3.234.0",
-            "@aws-sdk/util-defaults-mode-node": "3.234.0",
-            "@aws-sdk/util-endpoints": "3.226.0",
-            "@aws-sdk/util-retry": "3.229.0",
-            "@aws-sdk/util-user-agent-browser": "3.226.0",
-            "@aws-sdk/util-user-agent-node": "3.226.0",
-            "@aws-sdk/util-utf8-browser": "3.188.0",
-            "@aws-sdk/util-utf8-node": "3.208.0",
-            "fast-xml-parser": "4.0.11",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/config-resolver": {
-          "version": "3.234.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.234.0.tgz",
-          "integrity": "sha512-uZxy4wzllfvgCQxVc+Iqhde0NGAnfmV2hWR6ejadJaAFTuYNvQiRg9IqJy3pkyDPqXySiJ8Bom5PoJfgn55J/A==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/signature-v4": "3.226.0",
-            "@aws-sdk/types": "3.226.0",
-            "@aws-sdk/util-config-provider": "3.208.0",
-            "@aws-sdk/util-middleware": "3.226.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/credential-provider-ini": {
-          "version": "3.238.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.238.0.tgz",
-          "integrity": "sha512-WmPNtIYyUasjV7VQxvPNq7ihmx0vFsiKAtjNjjakdrt5TPoma4nUYb9tIG9SuG+kcp4DJIgRLJAgZtXbCcVimg==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/credential-provider-env": "3.226.0",
-            "@aws-sdk/credential-provider-imds": "3.226.0",
-            "@aws-sdk/credential-provider-process": "3.226.0",
-            "@aws-sdk/credential-provider-sso": "3.238.0",
-            "@aws-sdk/credential-provider-web-identity": "3.226.0",
-            "@aws-sdk/property-provider": "3.226.0",
-            "@aws-sdk/shared-ini-file-loader": "3.226.0",
-            "@aws-sdk/types": "3.226.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/credential-provider-node": {
-          "version": "3.238.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.238.0.tgz",
-          "integrity": "sha512-/RN5EyGfgdIIJdFzv+O0nSaHX1/F3anQjTIBeVg8GJ+82m+bDxMdALsG+NzkYnLilN9Uhc1lSNjLBCoPa5DSEg==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/credential-provider-env": "3.226.0",
-            "@aws-sdk/credential-provider-imds": "3.226.0",
-            "@aws-sdk/credential-provider-ini": "3.238.0",
-            "@aws-sdk/credential-provider-process": "3.226.0",
-            "@aws-sdk/credential-provider-sso": "3.238.0",
-            "@aws-sdk/credential-provider-web-identity": "3.226.0",
-            "@aws-sdk/property-provider": "3.226.0",
-            "@aws-sdk/shared-ini-file-loader": "3.226.0",
-            "@aws-sdk/types": "3.226.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/credential-provider-sso": {
-          "version": "3.238.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.238.0.tgz",
-          "integrity": "sha512-i70V4bFlCVYey3QARJ6XxKEg/4YuoFRnePV2oK37UHOGpEn49uXKwVZqLjzJgFHln7BPlC06cWDqrHUQIMvYrQ==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/client-sso": "3.238.0",
-            "@aws-sdk/property-provider": "3.226.0",
-            "@aws-sdk/shared-ini-file-loader": "3.226.0",
-            "@aws-sdk/token-providers": "3.238.0",
-            "@aws-sdk/types": "3.226.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/smithy-client": {
-          "version": "3.234.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.234.0.tgz",
-          "integrity": "sha512-8AtR/k4vsFvjXeQbIzq/Wy7Nbk48Ou0wUEeVYPHWHPSU8QamFWORkOwmKtKMfHAyZvmqiAPeQqHFkq+UJhWyyQ==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/middleware-stack": "3.226.0",
-            "@aws-sdk/types": "3.226.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/token-providers": {
-          "version": "3.238.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.238.0.tgz",
-          "integrity": "sha512-vYUwmy0kTzA99mJCVvad+/5RDlWve/xxnppT8DJK3JIdAgskp+rULY+joVnq2NSl489UAioUnFGs57vUxi8Pog==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/client-sso-oidc": "3.238.0",
-            "@aws-sdk/property-provider": "3.226.0",
-            "@aws-sdk/shared-ini-file-loader": "3.226.0",
-            "@aws-sdk/types": "3.226.0",
-            "tslib": "^2.3.1"
-          }
-        },
         "uuid": {
           "version": "8.3.2",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -18276,16 +17197,6 @@
         "uuid": "^8.3.2"
       },
       "dependencies": {
-        "@aws-sdk/util-endpoints": {
-          "version": "3.245.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.245.0.tgz",
-          "integrity": "sha512-UNOFquB1tKx+8RT8n82Zb5tIwDyZHVPBg/m0LB0RsLETjr6krien5ASpqWezsXKIR1hftN9uaxN4bvf2dZrWHg==",
-          "dev": true,
-          "requires": {
-            "@aws-sdk/types": "3.226.0",
-            "tslib": "^2.3.1"
-          }
-        },
         "uuid": {
           "version": "8.3.2",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -18332,17 +17243,6 @@
         "@aws-sdk/util-utf8-browser": "3.188.0",
         "@aws-sdk/util-utf8-node": "3.208.0",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "@aws-sdk/util-endpoints": {
-          "version": "3.245.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.245.0.tgz",
-          "integrity": "sha512-UNOFquB1tKx+8RT8n82Zb5tIwDyZHVPBg/m0LB0RsLETjr6krien5ASpqWezsXKIR1hftN9uaxN4bvf2dZrWHg==",
-          "requires": {
-            "@aws-sdk/types": "3.226.0",
-            "tslib": "^2.3.1"
-          }
-        }
       }
     },
     "@aws-sdk/client-sso-oidc": {
@@ -18383,17 +17283,6 @@
         "@aws-sdk/util-utf8-browser": "3.188.0",
         "@aws-sdk/util-utf8-node": "3.208.0",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "@aws-sdk/util-endpoints": {
-          "version": "3.245.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.245.0.tgz",
-          "integrity": "sha512-UNOFquB1tKx+8RT8n82Zb5tIwDyZHVPBg/m0LB0RsLETjr6krien5ASpqWezsXKIR1hftN9uaxN4bvf2dZrWHg==",
-          "requires": {
-            "@aws-sdk/types": "3.226.0",
-            "tslib": "^2.3.1"
-          }
-        }
       }
     },
     "@aws-sdk/client-sts": {
@@ -18438,17 +17327,6 @@
         "@aws-sdk/util-utf8-node": "3.208.0",
         "fast-xml-parser": "4.0.11",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "@aws-sdk/util-endpoints": {
-          "version": "3.245.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.245.0.tgz",
-          "integrity": "sha512-UNOFquB1tKx+8RT8n82Zb5tIwDyZHVPBg/m0LB0RsLETjr6krien5ASpqWezsXKIR1hftN9uaxN4bvf2dZrWHg==",
-          "requires": {
-            "@aws-sdk/types": "3.226.0",
-            "tslib": "^2.3.1"
-          }
-        }
       }
     },
     "@aws-sdk/config-resolver": {
@@ -18960,10 +17838,9 @@
       }
     },
     "@aws-sdk/util-endpoints": {
-      "version": "3.226.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.226.0.tgz",
-      "integrity": "sha512-iqOkac/zLmyPBUJd7SLN0PeZMkOmlGgD5PHmmekTClOkce2eUjK9SNX1PzL73aXPoPTyhg9QGLH8uEZEQ8YUzg==",
-      "dev": true,
+      "version": "3.245.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.245.0.tgz",
+      "integrity": "sha512-UNOFquB1tKx+8RT8n82Zb5tIwDyZHVPBg/m0LB0RsLETjr6krien5ASpqWezsXKIR1hftN9uaxN4bvf2dZrWHg==",
       "requires": {
         "@aws-sdk/types": "3.226.0",
         "tslib": "^2.3.1"
@@ -24390,6 +23267,27 @@
       "dev": true,
       "requires": {
         "path-type": "^4.0.0"
+      }
+    },
+    "docs": {
+      "version": "file:docs/snippets",
+      "requires": {
+        "@aws-sdk/client-appconfigdata": "^3.241.0",
+        "@aws-sdk/client-dynamodb": "^3.245.0",
+        "@aws-sdk/client-secrets-manager": "^3.238.0",
+        "@aws-sdk/client-ssm": "^3.244.0",
+        "@aws-sdk/util-dynamodb": "^3.245.0"
+      },
+      "dependencies": {
+        "@aws-sdk/util-dynamodb": {
+          "version": "3.245.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-dynamodb/-/util-dynamodb-3.245.0.tgz",
+          "integrity": "sha512-Wx06Ey92DRRSQTFfpQs1DkHSoajcwVu2TLWTg07yHXgGxdi6EveJPNqh111ot5yzHGmzPIHas/IPZe3hDttzcw==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        }
       }
     },
     "doctrine": {

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
     "build": "npm run build -ws",
     "postversion": "git push && git push --tags",
     "docs-website-build-run": "npm run docs-buildDockerImage && npm run docs-runLocalDocker",
-    "docs-buildDockerImage": "docker build -t powertool-typescript/docs ./docs/",
-    "docs-runLocalDocker": "docker run --rm -it -p 8000:8000 -v ${PWD}:/docs powertool-typescript/docs",
+    "docs-buildDockerImage": "docker build -t powertools-typescript/docs ./docs/",
+    "docs-runLocalDocker": "docker run --rm -it -p 8000:8000 -v ${PWD}:/docs powertools-typescript/docs",
     "docs-api-build-run": "npm run docs-generateApiDoc && npx live-server api",
     "docs-generateApiDoc": "typedoc .",
     "docs-runLocalApiDoc": "npx live-server api"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "packages/metrics",
     "packages/tracer",
     "packages/parameters",
-    "packages/idempotency"
+    "packages/idempotency",
+    "docs/snippets"
   ],
   "scripts": {
     "init-environment": "husky install",


### PR DESCRIPTION
## Description of your changes

As part of the efforts described in #729 we are extracting the code snippets present in the docs in their own files, so that we can apply linting as part of our CI.

In order to do that, these code snippets need to:
- have access to external dependencies (i.e. `@middy/core`, `@aws-sdk/client-dynamodb`, etc.)
- have access to the current version of the `@aws-lambda-powertools/*` packages, which might be still not available on npm
- share the same `.eslintrc.js` file as the rest of the monorepo (for best practices)

To comply with these three points, we have decided to add the `docs/snippets` folder to the npm workspace that contains the rest of the utilities (and soon the `layer-publisher` folder too).

This PR does the following:
- initializes a new npm project under `docs/snippets` and makes it part of the wider npm workspace
- adds most (if not all) the `devDependencies` used by the code snippets (more might be added once linting is applied)
- adds a new mkdocs plugin that allows to exclude the `docs/snippets/node_modules` directory from the docs

Closes #1250.

### How to verify this change

N/A

### Related issues, RFCs

<!--- Add here the number (i.e. #42) to the Github Issue or RFC that is related to this PR. -->
<!--- If no issue is present the PR might get blocked and not be reviewed. -->
**Issue number:** #1250

### PR status

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-typescript/#tenets)
- [x] I have performed a *self-review* of my own code
- [ ] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [x] I have made corresponding changes to the *documentation*
- [ ] I have made corresponding changes to the *examples*
- [x] My changes generate *no new warnings*
- [ ] The *code coverage* hasn't decreased
- [ ] I have *added tests* that prove my change is effective and works
- [x] New and existing *unit tests pass* locally and in Github Actions
- [ ] Any *dependent changes have been merged and published*
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

- [ ] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
