### PR TITLE
chore(tests): standardize env setup for tests

### DIFF
--- a/packages/commons/jest.config.js
+++ b/packages/commons/jest.config.js
@@ -1,4 +1,8 @@
 module.exports = {
+  displayName: {
+    name: 'AWS Lambda Powertools utility: COMMONS',
+    color: 'red',
+  },
   'preset': 'ts-jest',
   'transform': {
     '^.+\\.ts?$': 'ts-jest',

--- a/packages/idempotency/jest.config.js
+++ b/packages/idempotency/jest.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   displayName: {
     name: 'AWS Lambda Powertools utility: IDEMPOTENCY',
-    color: 'blue',
+    color: 'yellow',
   },
   'runner': 'groups',
   'preset': 'ts-jest',

--- a/packages/logger/tests/helpers/populateEnvironmentVariables.ts
+++ b/packages/logger/tests/helpers/populateEnvironmentVariables.ts
@@ -2,7 +2,9 @@
 process.env._X_AMZN_TRACE_ID = 'Root=1-5759e988-bd862e3fe1be46a994272793;Parent=557abcec3ee5a047;Sampled=1';
 process.env.AWS_LAMBDA_FUNCTION_NAME = 'my-lambda-function';
 process.env.AWS_LAMBDA_FUNCTION_MEMORY_SIZE = '128';
-process.env.AWS_REGION = 'eu-west-1';
+if (process.env.AWS_REGION === undefined && process.env.CDK_DEFAULT_REGION === undefined) {
+  process.env.AWS_REGION = 'eu-west-1';
+}
 
 // Powertools variables
 process.env.LOG_LEVEL = 'DEBUG';

--- a/packages/metrics/jest.config.js
+++ b/packages/metrics/jest.config.js
@@ -1,4 +1,8 @@
 module.exports = {
+  displayName: {
+    name: 'AWS Lambda Powertools utility: METRICS',
+    color: 'green',
+  },
   'runner': 'groups',
   'preset': 'ts-jest',
   'transform': {
@@ -33,4 +37,7 @@ module.exports = {
     'json-summary',
     'text',
     'lcov' ],
+  'setupFiles': [
+    '<rootDir>/tests/helpers/populateEnvironmentVariables.ts'
+  ]
 };

--- a/packages/metrics/tests/helpers/populate-environment-variables.ts
+++ b/packages/metrics/tests/helpers/populate-environment-variables.ts
@@ -1,9 +1,0 @@
-const populateEnvironmentVariables = (): void => {
-
-  process.env.POWERTOOLS_METRICS_NAMESPACE = 'hello-world';
-
-};
-
-export {
-  populateEnvironmentVariables,
-};

--- a/packages/metrics/tests/helpers/populateEnvironmentVariables.ts
+++ b/packages/metrics/tests/helpers/populateEnvironmentVariables.ts
@@ -1,9 +1,10 @@
 // Reserved variables
-process.env._X_AMZN_TRACE_ID = '1-abcdef12-3456abcdef123456abcdef12';
+process.env._X_AMZN_TRACE_ID = 'Root=1-5759e988-bd862e3fe1be46a994272793;Parent=557abcec3ee5a047;Sampled=1';
 process.env.AWS_LAMBDA_FUNCTION_NAME = 'my-lambda-function';
-process.env.AWS_EXECUTION_ENV = 'nodejs16.x';
 process.env.AWS_LAMBDA_FUNCTION_MEMORY_SIZE = '128';
 if (process.env.AWS_REGION === undefined && process.env.CDK_DEFAULT_REGION === undefined) {
   process.env.AWS_REGION = 'eu-west-1';
 }
-process.env._HANDLER = 'index.handler';
+
+// Powertools variables
+process.env.POWERTOOLS_METRICS_NAMESPACE = 'hello-world';

--- a/packages/metrics/tests/unit/Metrics.test.ts
+++ b/packages/metrics/tests/unit/Metrics.test.ts
@@ -7,7 +7,6 @@
 import { ContextExamples as dummyContext, Events as dummyEvent, LambdaInterface } from '@aws-lambda-powertools/commons';
 import { Context, Callback } from 'aws-lambda';
 import { Metrics, MetricUnits } from '../../src/';
-import { populateEnvironmentVariables } from '../helpers';
 
 const MAX_METRICS_SIZE = 100;
 const MAX_DIMENSION_COUNT = 29;
@@ -20,7 +19,7 @@ interface LooseObject {
 }
 
 describe('Class: Metrics', () => {
-  const originalEnvironmentVariables = process.env;
+  const ENVIRONMENT_VARIABLES = process.env;
   const context = dummyContext.helloworldContext;
   const event = dummyEvent.Custom.CustomEvent;
 
@@ -29,12 +28,7 @@ describe('Class: Metrics', () => {
   });
 
   beforeAll(() => {
-    populateEnvironmentVariables();
-  });
-
-  afterEach(() => {
-    process.env = originalEnvironmentVariables;
-    delete process.env.POWERTOOLS_SERVICE_NAME;
+    process.env = { ...ENVIRONMENT_VARIABLES };
   });
 
   describe('Feature: Dimensions logging', () => {

--- a/packages/parameters/tests/helpers/populateEnvironmentVariables.ts
+++ b/packages/parameters/tests/helpers/populateEnvironmentVariables.ts
@@ -2,8 +2,6 @@
 process.env._X_AMZN_TRACE_ID = 'Root=1-5759e988-bd862e3fe1be46a994272793;Parent=557abcec3ee5a047;Sampled=1';
 process.env.AWS_LAMBDA_FUNCTION_NAME = 'my-lambda-function';
 process.env.AWS_LAMBDA_FUNCTION_MEMORY_SIZE = '128';
-process.env.AWS_REGION = 'eu-west-1';
-
-// Powertools variables
-process.env.LOG_LEVEL = 'DEBUG';
-process.env.POWERTOOLS_SERVICE_NAME = 'hello-world';
+if (process.env.AWS_REGION === undefined && process.env.CDK_DEFAULT_REGION === undefined) {
+  process.env.AWS_REGION = 'eu-west-1';
+}

--- a/packages/tracer/jest.config.js
+++ b/packages/tracer/jest.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   displayName: {
     name: 'AWS Lambda Powertools utility: TRACER',
-    color: 'cyan',
+    color: 'white',
   },
   'runner': 'groups',
   'preset': 'ts-jest',

--- a/packages/tracer/tests/helpers/populateEnvironmentVariables.ts
+++ b/packages/tracer/tests/helpers/populateEnvironmentVariables.ts
@@ -3,7 +3,9 @@ process.env._X_AMZN_TRACE_ID = '1-abcdef12-3456abcdef123456abcdef12';
 process.env.AWS_LAMBDA_FUNCTION_NAME = 'my-lambda-function';
 process.env.AWS_EXECUTION_ENV = 'nodejs16.x';
 process.env.AWS_LAMBDA_FUNCTION_MEMORY_SIZE = '128';
-process.env.AWS_REGION = 'eu-west-1';
+if (process.env.AWS_REGION === undefined && process.env.CDK_DEFAULT_REGION === undefined) {
+  process.env.AWS_REGION = 'eu-west-1';
+}
 process.env._HANDLER = 'index.handler';
 
 // Powertools variables


### PR DESCRIPTION
## Description of your changes

This maintenance PR fixes an issue highlighted in #1083 by standardizing the setup phase of all the Jest tests in the workspace. This PR makes the AWS Region in which integration tests are run configurable by the user while also setting a default in case no preference is specified.

### Details

This PR makes sure the all packages in the monorepo are using the now standard `packages/*/tests/helpers/populateEnvironmentVariables.ts` file which is referenced in the `jest.config.js` file and sets a number of standard environment variables throughout all tests.

One of these variables is the `AWS_REGION` one. Before this PR, some packages (Tracer and Logger) were always setting it while others (Metrics) weren't. This caused some tests to always run in an AWS Region regardless of user explicit settings while others stayed configurable.

The `populateEnvironmentVariables.ts` now checks if the user running the test has explicitly set the variable, if the variable is set it uses the value specified by the user, if it's not set is uses a default one (`eu-west-1`).

```ts
if (process.env.AWS_REGION === undefined && process.env.CDK_DEFAULT_REGION === undefined) {
  process.env.AWS_REGION = 'eu-west-1';
}
```

### Other changes in this PR

Additionally, the PR also makes a small change to the `jest.config.js` files of each package to standardize the name & color shown in the console (housekeeping), i.e.:
![Screenshot 2023-01-18 at 11 37 09](https://user-images.githubusercontent.com/7353869/213149990-78242782-207e-412f-afea-f8f4e477d21a.png)
![image](https://user-images.githubusercontent.com/7353869/213150094-2e01193c-1397-4fb8-823f-c4a9ca6dc101.png)

Once merged, this PR fixes #1083. 

### How to verify this change

See results of automated checks below the PR, or successful run of the integration tests [here](https://github.com/awslabs/aws-lambda-powertools-typescript/actions/runs/3947906906).

Additionally, you can optionally run any of the integration tests locally using the command below & verify that they are in fact run in the AWS Region you specify:

`AWS_REGION=eu-central-1 npm run test:e2e:nodejs18x -w packages/metrics`

### Related issues, RFCs

<!--- Add here the number (i.e. #42) to the Github Issue or RFC that is related to this PR. -->
<!--- If no issue is present the PR might get blocked and not be reviewed. -->
**Issue number:** #1083 

### PR status

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-typescript/#tenets)
- [x] I have performed a *self-review* of my own code
- [ ] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [ ] I have made corresponding changes to the *documentation*
- [ ] I have made corresponding changes to the *examples*
- [x] My changes generate *no new warnings*
- [x] The *code coverage* hasn't decreased
- [ ] I have *added tests* that prove my change is effective and works
- [x] New and existing *unit tests pass* locally and in Github Actions
- [ ] Any *dependent changes have been merged and published*
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

- [ ] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
