### PR TITLE
feat(parameters): add support for custom AWS SDK v3 clients for providers

### DIFF
--- a/packages/parameters/src/appconfig/AppConfigProvider.ts
+++ b/packages/parameters/src/appconfig/AppConfigProvider.ts
@@ -23,7 +23,16 @@ class AppConfigProvider extends BaseProvider {
    */
   public constructor(options: AppConfigProviderOptions) {
     super();
-    this.client = new AppConfigDataClient(options.clientConfig || {});
+    if (options?.awsSdkV3Client) {
+      if (options?.awsSdkV3Client instanceof AppConfigDataClient) {
+        this.client = options.awsSdkV3Client;
+      } else {
+        throw Error('Not a valid AppConfigDataClient provided');
+      }
+    } else {
+      this.client = new AppConfigDataClient(options.clientConfig || {});
+    }
+    
     if (!options?.application && !process.env['POWERTOOLS_SERVICE_NAME']) {
       throw new Error(
         'Application name is not defined or POWERTOOLS_SERVICE_NAME is not set'

--- a/packages/parameters/src/dynamodb/DynamoDBProvider.ts
+++ b/packages/parameters/src/dynamodb/DynamoDBProvider.ts
@@ -19,8 +19,17 @@ class DynamoDBProvider extends BaseProvider {
   public constructor(config: DynamoDBProviderOptions) {
     super();
 
-    const clientConfig = config.clientConfig || {};
-    this.client = new DynamoDBClient(clientConfig);
+    if (config?.awsSdkV3Client) {
+      if (config?.awsSdkV3Client instanceof DynamoDBClient) {
+        this.client = config.awsSdkV3Client;
+      } else {
+        throw Error('Not a valid DynamoDBClient provided');
+      }
+    } else {
+      const clientConfig = config?.clientConfig || {};
+      this.client = new DynamoDBClient(clientConfig);
+    }
+
     this.tableName = config.tableName;
     if (config.keyAttr) this.keyAttr = config.keyAttr;
     if (config.sortAttr) this.sortAttr = config.sortAttr;

--- a/packages/parameters/src/secrets/SecretsProvider.ts
+++ b/packages/parameters/src/secrets/SecretsProvider.ts
@@ -15,8 +15,17 @@ class SecretsProvider extends BaseProvider {
   public constructor (config?: SecretsProviderOptions) {
     super();
 
-    const clientConfig = config?.clientConfig || {};
-    this.client = new SecretsManagerClient(clientConfig);
+    if (config?.awsSdkV3Client) {
+      if (config?.awsSdkV3Client instanceof SecretsManagerClient) {
+        this.client = config.awsSdkV3Client;
+      } else {
+        throw Error('Not a valid SecretsManagerClient provided');
+      }
+    } else {
+      const clientConfig = config?.clientConfig || {};
+      this.client = new SecretsManagerClient(clientConfig);
+    }
+    
   }
 
   public async get(

--- a/packages/parameters/src/ssm/SSMProvider.ts
+++ b/packages/parameters/src/ssm/SSMProvider.ts
@@ -14,7 +14,7 @@ import type {
   GetParametersCommandOutput,
 } from '@aws-sdk/client-ssm';
 import type {
-  SSMProviderOptionsInterface,
+  SSMProviderOptions,
   SSMGetMultipleOptionsInterface,
   SSMGetOptionsInterface,
   SSMGetParametersByNameOutputInterface,
@@ -29,9 +29,19 @@ class SSMProvider extends BaseProvider {
   protected errorsKey = '_errors';
   protected maxGetParametersItems = 10;
 
-  public constructor(config?: SSMProviderOptionsInterface) {
+  public constructor(config?: SSMProviderOptions) {
     super();
-    this.client = new SSMClient(config?.clientConfig || {});
+
+    if (config?.awsSdkV3Client) {
+      if (config?.awsSdkV3Client instanceof SSMClient) {
+        this.client = config.awsSdkV3Client;
+      } else {
+        throw Error('Not a valid SSMClient provided');
+      }
+    } else {
+      const clientConfig = config?.clientConfig || {};
+      this.client = new SSMClient(clientConfig);
+    }
   }
 
   public async get(

--- a/packages/parameters/src/types/AppConfigProvider.ts
+++ b/packages/parameters/src/types/AppConfigProvider.ts
@@ -1,22 +1,58 @@
 import type {
+  AppConfigDataClient,
   AppConfigDataClientConfig,
   StartConfigurationSessionCommandInput,
 } from '@aws-sdk/client-appconfigdata';
 import type { GetOptionsInterface } from 'types/BaseProvider';
 
 /**
- * Options for the AppConfigProvider class constructor.
+ * Base interface for AppConfigProviderOptions.
  *
- *  @interface AppConfigProviderOptions
+ *  @interface
  *  @property {string} environment - The environment ID or the environment name.
  *  @property {string} [application] - The application ID or the application name.
- *  @property {AppConfigDataClientConfig} [clientConfig] - Optional configuration to pass during client initialization, e.g. AWS region.
  */
-interface AppConfigProviderOptions {
+interface AppConfigProviderOptionsBaseInterface {
   environment: string
   application?: string
-  clientConfig?: AppConfigDataClientConfig
 }
+
+/**
+ * Interface for AppConfigProviderOptions with clientConfig property.
+ *
+ *  @interface
+ *  @extends AppConfigProviderOptionsBaseInterface
+ *  @property {AppConfigDataClientConfig} [clientConfig] - Optional configuration to pass during client initialization, e.g. AWS region.
+ *  @property {never} [awsSdkV3Client] - This property should never be passed.
+ */
+interface AppConfigProviderOptionsWithClientConfig extends AppConfigProviderOptionsBaseInterface {
+  clientConfig?: AppConfigDataClientConfig
+  awsSdkV3Client?: never
+}
+
+/**
+ * Interface for AppConfigProviderOptions with awsSdkV3Client property.
+ *
+ * @interface
+ * @extends AppConfigProviderOptionsBaseInterface
+ * @property {AppConfigDataClient} [awsSdkV3Client] - Optional AWS SDK v3 client to pass during AppConfigProvider class instantiation
+ * @property {never} [clientConfig] - This property should never be passed.
+ */
+interface AppConfigProviderOptionsWithClientInstance extends AppConfigProviderOptionsBaseInterface {
+  awsSdkV3Client?: AppConfigDataClient
+  clientConfig?: never
+}
+
+/**
+ * Options for the AppConfigProvider class constructor.
+ *
+ * @type AppConfigProviderOptions
+ * @property {string} environment - The environment ID or the environment name.
+ * @property {string} [application] - The application ID or the application name.
+ * @property {AppConfigDataClientConfig} [clientConfig] - Optional configuration to pass during client initialization, e.g. AWS region. Mutually exclusive with awsSdkV3Client.
+ * @property {AppConfigDataClient} [awsSdkV3Client] - Optional AWS SDK v3 client to pass during AppConfigProvider class instantiation. Mutually exclusive with clientConfig.
+ */
+type AppConfigProviderOptions = AppConfigProviderOptionsWithClientConfig | AppConfigProviderOptionsWithClientInstance;
 
 /**
  * Options for the AppConfigProvider get method.
@@ -40,7 +76,7 @@ interface AppConfigGetOptionsInterface extends Omit<GetOptionsInterface, 'sdkOpt
  * @extends {AppConfigProviderOptions, AppConfigGetOptionsInterface}
  */
 interface GetAppConfigCombinedInterface
-  extends Omit<AppConfigProviderOptions, 'clientConfig'>,
+  extends Omit<AppConfigProviderOptions, 'clientConfig' | 'awsSdkV3Client'>,
   AppConfigGetOptionsInterface {}
 
 export type {

--- a/packages/parameters/src/types/DynamoDBProvider.ts
+++ b/packages/parameters/src/types/DynamoDBProvider.ts
@@ -1,13 +1,24 @@
 import type { GetOptionsInterface, GetMultipleOptionsInterface } from './BaseProvider';
-import type { GetItemCommandInput, QueryCommandInput, DynamoDBClientConfig } from '@aws-sdk/client-dynamodb';
+import type { DynamoDBClient, GetItemCommandInput, QueryCommandInput, DynamoDBClientConfig } from '@aws-sdk/client-dynamodb';
 
-interface DynamoDBProviderOptions {
+interface DynamoDBProviderOptionsBaseInterface {
   tableName: string
   keyAttr?: string
   sortAttr?: string
   valueAttr?: string
-  clientConfig?: DynamoDBClientConfig
 }
+
+interface DynamoDBProviderOptionsWithClientConfig extends DynamoDBProviderOptionsBaseInterface {
+  clientConfig?: DynamoDBClientConfig
+  awsSdkV3Client?: never
+}
+
+interface DynamoDBProviderOptionsWithClientInstance extends DynamoDBProviderOptionsBaseInterface {
+  awsSdkV3Client?: DynamoDBClient
+  clientConfig?: never
+}
+
+type DynamoDBProviderOptions = DynamoDBProviderOptionsWithClientConfig | DynamoDBProviderOptionsWithClientInstance;
 
 /**
  * Options for the DynamoDBProvider get method.

--- a/packages/parameters/src/types/SSMProvider.ts
+++ b/packages/parameters/src/types/SSMProvider.ts
@@ -1,4 +1,5 @@
 import type {
+  SSMClient,
   SSMClientConfig,
   GetParameterCommandInput,
   GetParametersByPathCommandInput
@@ -9,9 +10,17 @@ import type {
   TransformOptions
 } from './BaseProvider';
 
-interface SSMProviderOptionsInterface {
-  clientConfig: SSMClientConfig
+interface SSMProviderOptionsWithClientConfig {
+  clientConfig?: SSMClientConfig
+  awsSdkV3Client?: never
 }
+
+interface SSMProviderOptionsWithClientInstance {
+  awsSdkV3Client?: SSMClient
+  clientConfig?: never
+}
+
+type SSMProviderOptions = SSMProviderOptionsWithClientConfig | SSMProviderOptionsWithClientInstance;
 
 /**
  * Options for the SSMProvider get method.
@@ -56,7 +65,7 @@ type SSMGetParametersByNameFromCacheOutputType = {
 };
 
 export type {
-  SSMProviderOptionsInterface,
+  SSMProviderOptions,
   SSMGetOptionsInterface,
   SSMGetMultipleOptionsInterface,
   SSMGetParametersByNameOptionsInterface,

--- a/packages/parameters/src/types/SecretsProvider.ts
+++ b/packages/parameters/src/types/SecretsProvider.ts
@@ -1,9 +1,17 @@
 import type { GetOptionsInterface } from './BaseProvider';
-import type { SecretsManagerClientConfig, GetSecretValueCommandInput } from '@aws-sdk/client-secrets-manager';
+import type { SecretsManagerClient, SecretsManagerClientConfig, GetSecretValueCommandInput } from '@aws-sdk/client-secrets-manager';
 
-interface SecretsProviderOptions {
+interface SecretsProviderOptionsWithClientConfig {
   clientConfig?: SecretsManagerClientConfig
+  awsSdkV3Client?: never
 }
+
+interface SecretsProviderOptionsWithClientInstance {
+  awsSdkV3Client?: SecretsManagerClient
+  clientConfig?: never
+}
+
+type SecretsProviderOptions = SecretsProviderOptionsWithClientConfig | SecretsProviderOptionsWithClientInstance;
 
 interface SecretsGetOptionsInterface extends GetOptionsInterface {
   sdkOptions?: Omit<Partial<GetSecretValueCommandInput>, 'SecretId'>

--- a/packages/parameters/tests/unit/AppConfigProvider.test.ts
+++ b/packages/parameters/tests/unit/AppConfigProvider.test.ts
@@ -21,6 +21,85 @@ describe('Class: AppConfigProvider', () => {
     jest.clearAllMocks();
   });
 
+  describe('Method: constructor', () => {
+    test('when the class instantiates without SDK client and client config it has default options', async () => {
+      // Prepare
+      const options: AppConfigProviderOptions = {
+        application: 'MyApp',
+        environment: 'MyAppProdEnv',
+      };
+
+      // Act
+      const provider = new AppConfigProvider(options);
+
+      // Assess
+      expect(provider.client.config).toEqual(
+        expect.objectContaining({
+          serviceId: 'AppConfigData',
+        })
+      );
+    });
+
+    test('when the user provides a client config in the options, the class instantiates a new client with client config options', async () => {
+      // Prepare
+      const options: AppConfigProviderOptions = {
+        application: 'MyApp',
+        environment: 'MyAppProdEnv',
+        clientConfig: {
+          serviceId: 'with-client-config',
+        },
+      };
+
+      // Act
+      const provider = new AppConfigProvider(options);
+
+      // Assess
+      expect(provider.client.config).toEqual(
+        expect.objectContaining({
+          serviceId: 'with-client-config',
+        })
+      );
+    });
+
+    test('when the user provides an SDK client in the options, the class instantiates with it', async () => {
+      // Prepare
+      const awsSdkV3Client = new AppConfigDataClient({
+        serviceId: 'with-custom-sdk-client',
+      });
+
+      const options: AppConfigProviderOptions = {
+        application: 'MyApp',
+        environment: 'MyAppProdEnv',
+        awsSdkV3Client: awsSdkV3Client,
+      };
+
+      // Act
+      const provider = new AppConfigProvider(options);
+
+      // Assess
+      expect(provider.client.config).toEqual(
+        expect.objectContaining({
+          serviceId: 'with-custom-sdk-client',
+        })
+      );
+    });
+
+    test('when the user provides NOT an SDK client in the options, it throws an error', async () => {
+      // Prepare
+      const awsSdkV3Client = {};
+      const options: AppConfigProviderOptions = {
+        application: 'MyApp',
+        environment: 'MyAppProdEnv',
+        awsSdkV3Client: awsSdkV3Client as AppConfigDataClient,
+      };
+
+      // Act & Assess
+      expect(() => {
+        new AppConfigProvider(options);
+      }).toThrow();
+    });
+  });
+
   describe('Method: _get', () => {
     test('when called with name and options, it returns binary configuration', async () => {
       // Prepare

--- a/packages/parameters/tests/unit/DynamoDBProvider.test.ts
+++ b/packages/parameters/tests/unit/DynamoDBProvider.test.ts
@@ -6,6 +6,7 @@
 import { DynamoDBProvider } from '../../src/dynamodb';
 import { DynamoDBClient, GetItemCommand, QueryCommand } from '@aws-sdk/client-dynamodb';
 import type { GetItemCommandInput, QueryCommandInput } from '@aws-sdk/client-dynamodb';
+import type { DynamoDBProviderOptions } from '../../src/types/DynamoDBProvider';
 import { marshall } from '@aws-sdk/util-dynamodb';
 import { mockClient } from 'aws-sdk-client-mock';
 import 'aws-sdk-client-mock-jest';
@@ -14,6 +15,84 @@ describe('Class: DynamoDBProvider', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+  });
+
+  describe('Method: constructor', () => {
+    test('when the class instantiates without SDK client and client config it has default options', async () => {
+      
+      // Prepare
+      const options: DynamoDBProviderOptions = {
+        tableName: 'test-table',
+      };
+
+      // Act
+      const provider = new DynamoDBProvider(options);
+
+      // Assess
+      expect(provider.client.config).toEqual(
+        expect.objectContaining({
+          serviceId: 'DynamoDB',
+        })
+      );
+    });
+
+    test('when the user provides a client config in the options, the class instantiates a new client with client config options', async () => {
+
+      // Prepare
+      const options: DynamoDBProviderOptions = {
+        tableName: 'test-table',
+        clientConfig: {
+          serviceId: 'with-client-config',
+        },
+      };
+
+      // Act
+      const provider = new DynamoDBProvider(options);
+
+      // Assess
+      expect(provider.client.config).toEqual(
+        expect.objectContaining({
+          serviceId: 'with-client-config',
+        })
+      );
+    });
+
+    test('when the user provides an SDK client in the options, the class instantiates with it', async () => {
+      
+      // Prepare
+      const awsSdkV3Client = new DynamoDBClient({
+        serviceId: 'with-custom-sdk-client',
+      });
+
+      const options: DynamoDBProviderOptions = {
+        tableName: 'test-table',
+        awsSdkV3Client: awsSdkV3Client,
+      };
+
+      // Act
+      const provider = new DynamoDBProvider(options);
+
+      // Assess
+      expect(provider.client.config).toEqual(
+        expect.objectContaining({
+          serviceId: 'with-custom-sdk-client',
+        })
+      );
+    });
+
+    test('when the user provides NOT an SDK client in the options, it throws an error', async () => {
+      // Prepare
+      const awsSdkV3Client = {};
+      const options: DynamoDBProviderOptions = {
+        tableName: 'test-table',
+        awsSdkV3Client: awsSdkV3Client as DynamoDBClient,
+      };
+
+      // Act & Assess
+      expect(() => {
+        new DynamoDBProvider(options);
+      }).toThrow();
+    });
   });
 
   describe('Method: _get', () => {

--- a/packages/parameters/tests/unit/SSMProvider.test.ts
+++ b/packages/parameters/tests/unit/SSMProvider.test.ts
@@ -14,6 +14,7 @@ import type { GetParametersCommandOutput } from '@aws-sdk/client-ssm';
 import { mockClient } from 'aws-sdk-client-mock';
 import 'aws-sdk-client-mock-jest';
 import type {
+  SSMProviderOptions,
   SSMGetParametersByNameFromCacheOutputType,
   SSMGetParametersByNameOptionsInterface,
   SSMSplitBatchAndDecryptParametersOutputType,
@@ -28,6 +29,79 @@ describe('Class: SSMProvider', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+  });
+
+  describe('Method: constructor', () => {
+    test('when the class instantiates without SDK client and client config it has default options', async () => {
+      
+      // Prepare
+      const options: SSMProviderOptions = {};
+
+      // Act
+      const provider = new SSMProvider(options);
+
+      // Assess
+      expect(provider.client.config).toEqual(
+        expect.objectContaining({
+          serviceId: 'SSM',
+        })
+      );
+    });
+
+    test('when the user provides a client config in the options, the class instantiates a new client with client config options', async () => {
+
+      // Prepare
+      const options: SSMProviderOptions = {
+        clientConfig: {
+          serviceId: 'with-client-config',
+        },
+      };
+
+      // Act
+      const provider = new SSMProvider(options);
+
+      // Assess
+      expect(provider.client.config).toEqual(
+        expect.objectContaining({
+          serviceId: 'with-client-config',
+        })
+      );
+    });
+
+    test('when the user provides an SDK client in the options, the class instantiates with it', async () => {
+      
+      // Prepare
+      const awsSdkV3Client = new SSMClient({
+        serviceId: 'with-custom-sdk-client',
+      });
+
+      const options: SSMProviderOptions = {
+        awsSdkV3Client: awsSdkV3Client,
+      };
+
+      // Act
+      const provider = new SSMProvider(options);
+
+      // Assess
+      expect(provider.client.config).toEqual(
+        expect.objectContaining({
+          serviceId: 'with-custom-sdk-client',
+        })
+      );
+    });
+
+    test('when the user provides NOT an SDK client in the options, it throws an error', async () => {
+      // Prepare
+      const awsSdkV3Client = {};
+      const options: SSMProviderOptions = {
+        awsSdkV3Client: awsSdkV3Client as SSMClient,
+      };
+
+      // Act & Assess
+      expect(() => {
+        new SSMProvider(options);
+      }).toThrow();
+    });
   });
 
   describe('Method: getParametersByName', () => {

--- a/packages/parameters/tests/unit/SecretsProvider.test.ts
+++ b/packages/parameters/tests/unit/SecretsProvider.test.ts
@@ -6,6 +6,7 @@
 import { SecretsProvider } from '../../src/secrets';
 import { SecretsManagerClient, GetSecretValueCommand } from '@aws-sdk/client-secrets-manager';
 import type { GetSecretValueCommandInput } from '@aws-sdk/client-secrets-manager';
+import type { SecretsProviderOptions } from '../../src/types/SecretsProvider';
 import { mockClient } from 'aws-sdk-client-mock';
 import 'aws-sdk-client-mock-jest';
 
@@ -17,6 +18,79 @@ describe('Class: SecretsProvider', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+  });
+
+  describe('Method: constructor', () => {
+    test('when the class instantiates without SDK client and client config it has default options', async () => {
+      
+      // Prepare
+      const options: SecretsProviderOptions = {};
+
+      // Act
+      const provider = new SecretsProvider(options);
+
+      // Assess
+      expect(provider.client.config).toEqual(
+        expect.objectContaining({
+          serviceId: 'Secrets Manager',
+        })
+      );
+    });
+
+    test('when the user provides a client config in the options, the class instantiates a new client with client config options', async () => {
+
+      // Prepare
+      const options: SecretsProviderOptions = {
+        clientConfig: {
+          serviceId: 'with-client-config',
+        },
+      };
+
+      // Act
+      const provider = new SecretsProvider(options);
+
+      // Assess
+      expect(provider.client.config).toEqual(
+        expect.objectContaining({
+          serviceId: 'with-client-config',
+        })
+      );
+    });
+
+    test('when the user provides an SDK client in the options, the class instantiates with it', async () => {
+      
+      // Prepare
+      const awsSdkV3Client = new SecretsManagerClient({
+        serviceId: 'with-custom-sdk-client',
+      });
+
+      const options: SecretsProviderOptions = {
+        awsSdkV3Client: awsSdkV3Client,
+      };
+
+      // Act
+      const provider = new SecretsProvider(options);
+
+      // Assess
+      expect(provider.client.config).toEqual(
+        expect.objectContaining({
+          serviceId: 'with-custom-sdk-client',
+        })
+      );
+    });
+
+    test('when the user provides NOT an SDK client in the options, it throws an error', async () => {
+      // Prepare
+      const awsSdkV3Client = {};
+      const options: SecretsProviderOptions = {
+        awsSdkV3Client: awsSdkV3Client as SecretsManagerClient,
+      };
+
+      // Act & Assess
+      expect(() => {
+        new SecretsProvider(options);
+      }).toThrow();
+    });
   });
 
   describe('Method: _get', () => {


### PR DESCRIPTION
This PR is intended to add support for custom AWS SDK v3 clients for `providers`

Providers covered:

- [x] `AppConfigProvider`
- [x] `DynamoDBProvider`
- [x] `SecretsProvider`
- [x] `SSMProvider`

<!--- 1. Make sure you follow our Contributing Guidelines: https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/CONTRIBUTING.md -->
<!--- 2. Please follow the template, and do not remove any section in the template. If something is not applicable leave it empty, but leave it in the PR. -->

## Description of your changes

<!--- Include here a summary of the change. -->

<!--- Please include also relevant motivation and context. -->

<!--- List any dependencies that are required for this change. -->

<!--- If this PR is part of a sequence of related PRs or TODOs, list the high level TODO items. -->

### How to verify this change

<!--- Add any applicable config, projects, screenshots or other resources -->
<!--- that can help us verify your changes. -->

<!--- Examples: -->
<!--- Screenshots, cloud configuration, anything helping us evaluate better. -->

### Related issues, RFCs
<!--- Add here the number (i.e. #42) to the Github Issue or RFC that is related to this PR. -->
<!--- If no issue is present the PR might get blocked and not be reviewed. -->
**Issue number:**  #1222 
### PR status

***Is this ready for review?:*** NO  
***Is it a breaking change?:*** NO

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-typescript/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [ ] I have made corresponding changes to the *documentation*
- [ ] I have made corresponding changes to the *examples*
- [x] My changes generate *no new warnings*
- [x] The *code coverage* hasn't decreased
- [x] I have *added tests* that prove my change is effective and works
- [x] New and existing *unit tests pass* locally and in Github Actions
- [x] Any *dependent changes have been merged and published*
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

- [ ] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
