### PR TITLE
fix(logger): fix a bug when child logger didn't get all the parent's attributes

### DIFF
--- a/packages/logger/src/Logger.ts
+++ b/packages/logger/src/Logger.ts
@@ -203,8 +203,13 @@ class Logger extends Utility implements ClassThatLogs {
    * @returns {Logger}
    */
   public createChild(options: ConstructorOptions = {}): Logger {
+    const parentsOptions = {
+      logLevel: this.getLogLevel(),
+      customConfigService: this.getCustomConfigService(),
+      logFormatter: this.getLogFormatter(),
+    };
     const parentsPowertoolsLogData = this.getPowertoolLogData();
-    const childLogger = new Logger(merge({}, parentsPowertoolsLogData, options));
+    const childLogger = new Logger(merge({}, parentsOptions, parentsPowertoolsLogData, options));
     
     const parentsPersistentLogAttributes = this.getPersistentLogAttributes();
     childLogger.addPersistentLogAttributes(parentsPersistentLogAttributes);

--- a/packages/logger/tests/unit/Logger.test.ts
+++ b/packages/logger/tests/unit/Logger.test.ts
@@ -8,7 +8,7 @@ import { ContextExamples as dummyContext, Events as dummyEvent, LambdaInterface 
 import { createLogger, Logger } from '../../src';
 import { EnvironmentVariablesService } from '../../src/config';
 import { PowertoolLogFormatter } from '../../src/formatter';
-import { ClassThatLogs, LogJsonIndent } from '../../src/types';
+import { ClassThatLogs, LogJsonIndent, ConstructorOptions } from '../../src/types';
 import { Context } from 'aws-lambda';
 import { Console } from 'console';
 
@@ -1297,7 +1297,7 @@ describe('Class: Logger', () => {
 
   describe('Method: createChild', () => {
 
-    test('Child and grandchild loggers should have all ancestor\'s options', () => {
+    test('child and grandchild loggers should have all ancestor\'s options', () => {
       // Prepare
       const INDENTATION = LogJsonIndent.COMPACT;
       const loggerOptions = {
@@ -1398,7 +1398,7 @@ describe('Class: Logger', () => {
 
     });
 
-    test('when called, it returns a DISTINCT clone of the logger instance', () => {
+    test('child logger should be a DISTINCT clone of the logger instance', () => {
 
       // Prepare
       const INDENTATION = LogJsonIndent.COMPACT;
@@ -1715,6 +1715,93 @@ describe('Class: Logger', () => {
           serviceName: 'hello-world',
         },
       });
+    });
+
+    test('child logger should have parent\'s logFormatter', () => {
+
+      // Prepare
+      class MyCustomLogFormatter extends PowertoolLogFormatter {}
+      const parentLogger = new Logger({
+        logFormatter: new MyCustomLogFormatter()
+      });
+
+      // Act
+      const childLoggerWithParentLogFormatter = parentLogger.createChild();
+
+      // Assess
+      expect(childLoggerWithParentLogFormatter).toEqual(
+        expect.objectContaining({
+          logFormatter: expect.any(MyCustomLogFormatter),
+        })
+      );
+    });
+
+    test('child logger with custom logFormatter in options should have provided logFormatter', () => {
+
+      // Prepare
+      class MyCustomLogFormatter extends PowertoolLogFormatter {}
+      const parentLogger = new Logger();
+
+      // Act
+      const childLoggerWithCustomLogFormatter = parentLogger.createChild({
+        logFormatter: new MyCustomLogFormatter()
+      });
+
+      // Assess
+      expect(parentLogger).toEqual(
+        expect.objectContaining({
+          logFormatter: expect.any(PowertoolLogFormatter),
+        })
+      );
+
+      expect(childLoggerWithCustomLogFormatter).toEqual(
+        expect.objectContaining({
+          logFormatter: expect.any(MyCustomLogFormatter),
+        })
+      );
+    });
+
+    test('child logger should have exact same attributes as the parent logger created with all non-default options', () => {
+
+      // Prepare
+      class MyCustomLogFormatter extends PowertoolLogFormatter {}
+      class MyCustomEnvironmentVariablesService extends EnvironmentVariablesService {}
+
+      const options: ConstructorOptions = {
+        logLevel: 'ERROR',
+        serviceName: 'test-service-name',
+        sampleRateValue: 0.77,
+        logFormatter: new MyCustomLogFormatter(),
+        customConfigService: new MyCustomEnvironmentVariablesService(),
+        persistentLogAttributes: {
+          aws_account_id: '1234567890',
+          aws_region: 'eu-west-1',
+        },
+        environment: 'local'
+      };
+      const parentLogger = new Logger(options);
+
+      // Act
+      const childLogger = parentLogger.createChild();
+
+      // Assess
+      expect(childLogger).toEqual({
+        ...parentLogger,
+        console: expect.any(Console),
+      });
+
+      expect(childLogger).toEqual(
+        expect.objectContaining({
+          logFormatter: expect.any(MyCustomLogFormatter),
+        })
+      );
+
+      expect(childLogger).toEqual(
+        expect.objectContaining({
+          customConfigService: expect.any(MyCustomEnvironmentVariablesService),
+        })
+      );
+      
     });
     
   });


### PR DESCRIPTION
When `createChild` used without option it didn't inherit parents attributes.

Attributes affected:
- `logLevel`
- `customConfigService`
- `logFormatter`

Example:

```
// With this logger, all the INFO logs will be printed
const logger = new Logger({
    logLevel: 'INFO'
});

// With this logger, we expect INFO logs too
const childLogger = parentLogger.createChild();
```

But it will be `DEBUG` since it is the default value:

```
-   "logLevel": "INFO",
+   "logLevel": "DEBUG",
```

<!--- 1. Make sure you follow our Contributing Guidelines: https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/CONTRIBUTING.md -->
<!--- 2. Please follow the template, and do not remove any section in the template. If something is not applicable leave it empty, but leave it in the PR. -->

## Description of your changes

<!--- Include here a summary of the change. -->
Missing parent's attributes are added to `options` before merging with child `options` that suppose to overwrite them.

It was missed because existing tests compare attributes against default values. I added a test with all possible parent's `options` with non-default values and found all the affected attributes.

<!--- Please include also relevant motivation and context. -->

<!--- List any dependencies that are required for this change. -->

<!--- If this PR is part of a sequence of related PRs or TODOs, list the high level TODO items. -->

### How to verify this change

<!--- Add any applicable config, projects, screenshots or other resources -->
<!--- that can help us verify your changes. -->

<!--- Examples: -->
<!--- Screenshots, cloud configuration, anything helping us evaluate better. -->

### Related issues, RFCs

<!--- Add here the number (i.e. #42) to the Github Issue or RFC that is related to this PR. -->
<!--- If no issue is present the PR might get blocked and not be reviewed. -->
**Issue number:** #1264 
### PR status

***Is this ready for review?:*** YES 
***Is it a breaking change?:*** NO

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-typescript/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [ ] I have made corresponding changes to the *documentation*
- [ ] I have made corresponding changes to the *examples*
- [x] My changes generate *no new warnings*
- [x] The *code coverage* hasn't decreased
- [x] I have *added tests* that prove my change is effective and works
- [x] New and existing *unit tests pass* locally and in Github Actions
- [x] Any *dependent changes have been merged and published*
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

- [ ] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
