### PR TITLE
docs(logger): update child logger docs section and snippets

### DIFF
--- a/docs/core/logger.md
+++ b/docs/core/logger.md
@@ -392,7 +392,7 @@ The error will be logged with default key name `error`, but you can also pass yo
 
 The `createChild` method allows you to create a child instance of the Logger, which inherits all of the attributes from its parent. You have the option to override any of the settings and attributes from the parent logger, including [its settings](#utility-settings), any [persistent attributes](#appending-persistent-additional-log-keys-and-values), and [the log formatter](#custom-log-formatter-bring-your-own-formatter). Once a child logger is created, the logger and its parent will act as separate instances of the Logger class, and as such any change to one won't be applied to the other. 
 
-The following example shows how to activate multiple Loggers and inherit the service name and persistent attributes while specifying different logging levels within a single Lambda invocation. As the result, only ERROR logs with all the inherited attributes will be displayed in CloudWatch Logs from the child logger.
+ The following example shows how to create multiple Loggers that share service name and persistent attributes while specifying different logging levels within a single Lambda invocation. As the result, only ERROR logs with all the inherited attributes will be displayed in CloudWatch Logs from the child logger, but all logs emitted will have the same service name and persistent attributes.
 
 === "handler.ts"
 

--- a/docs/core/logger.md
+++ b/docs/core/logger.md
@@ -408,7 +408,8 @@ The following example shows how to activate multiple Loggers and inherit the ser
         "message": "This is an INFO log, from the parent logger",
         "service": "serverlessAirline",
         "timestamp": "2021-12-12T22:32:54.667Z",
-        "aws_account_id":"123456789012","aws_region":"eu-west-1",
+        "aws_account_id":"123456789012",
+        "aws_region":"eu-west-1",
         "xray_trace_id": "abcdef123456abcdef123456abcdef123456"
     }
     {
@@ -416,7 +417,8 @@ The following example shows how to activate multiple Loggers and inherit the ser
         "message": "This is an ERROR log, from the parent logger",
         "service": "serverlessAirline",
         "timestamp": "2021-12-12T22:32:54.670Z",
-        "aws_account_id":"123456789012","aws_region":"eu-west-1",
+        "aws_account_id":"123456789012",
+        "aws_region":"eu-west-1",
         "xray_trace_id": "abcdef123456abcdef123456abcdef123456"
     }
     {
@@ -424,7 +426,8 @@ The following example shows how to activate multiple Loggers and inherit the ser
         "message": "This is an ERROR log, from the child logger",
         "service": "serverlessAirline",
         "timestamp": "2021-12-12T22:32:54.670Z",
-        "aws_account_id":"123456789012","aws_region":"eu-west-1",
+        "aws_account_id":"123456789012",
+        "aws_region":"eu-west-1",
         "xray_trace_id": "abcdef123456abcdef123456abcdef123456"
     }
     ```

--- a/docs/core/logger.md
+++ b/docs/core/logger.md
@@ -390,7 +390,7 @@ The error will be logged with default key name `error`, but you can also pass yo
 
 ### Using multiple Logger instances across your code
 
-The `createChild` method of the Logger allows you to create a child instance of the Logger, which inherits all of the attributes from its parent. You have the option to override any of the settings that can be set through the constructor, including [the default settings](#utility-settings), any [persistent attributes](#appending-persistent-additional-log-keys-and-values), and [the log formatter](#custom-log-formatter-bring-your-own-formatter).
+The `createChild` method allows you to create a child instance of the Logger, which inherits all of the attributes from its parent. You have the option to override any of the settings and attributes from the parent logger, including [its settings](#utility-settings), any [persistent attributes](#appending-persistent-additional-log-keys-and-values), and [the log formatter](#custom-log-formatter-bring-your-own-formatter). Once a child logger is created, the logger and its parent will act as separate instances of the Logger class, and as such any change to one won't be applied to the other. 
 
 The following example shows how to activate multiple Loggers and inherit the service name and persistent attributes while specifying different logging levels within a single Lambda invocation. As the result, only ERROR logs with all the inherited attributes will be displayed in CloudWatch Logs from the child logger.
 

--- a/docs/core/logger.md
+++ b/docs/core/logger.md
@@ -390,8 +390,9 @@ The error will be logged with default key name `error`, but you can also pass yo
 
 ### Using multiple Logger instances across your code
 
-Logger supports quick instance cloning via the `createChild` method.
-This can be useful for example if you want to enable multiple Loggers with different logging levels in the same Lambda invocation.
+The `createChild` method of the Logger allows you to create a child instance of the Logger, which inherits all of the attributes from its parent. You have the option to override any of the settings that can be set through the constructor, including [the default settings](#utility-settings), any [persistent attributes](#appending-persistent-additional-log-keys-and-values), and [the log formatter](#custom-log-formatter-bring-your-own-formatter).
+
+The following example shows how to activate multiple Loggers and inherit the service name and persistent attributes while specifying different logging levels within a single Lambda invocation. As the result, only ERROR logs with all the inherited attributes will be displayed in CloudWatch Logs from the child logger.
 
 === "handler.ts"
 
@@ -407,6 +408,7 @@ This can be useful for example if you want to enable multiple Loggers with diffe
         "message": "This is an INFO log, from the parent logger",
         "service": "serverlessAirline",
         "timestamp": "2021-12-12T22:32:54.667Z",
+        "aws_account_id":"123456789012","aws_region":"eu-west-1",
         "xray_trace_id": "abcdef123456abcdef123456abcdef123456"
     }
     {
@@ -414,6 +416,7 @@ This can be useful for example if you want to enable multiple Loggers with diffe
         "message": "This is an ERROR log, from the parent logger",
         "service": "serverlessAirline",
         "timestamp": "2021-12-12T22:32:54.670Z",
+        "aws_account_id":"123456789012","aws_region":"eu-west-1",
         "xray_trace_id": "abcdef123456abcdef123456abcdef123456"
     }
     {
@@ -421,6 +424,7 @@ This can be useful for example if you want to enable multiple Loggers with diffe
         "message": "This is an ERROR log, from the child logger",
         "service": "serverlessAirline",
         "timestamp": "2021-12-12T22:32:54.670Z",
+        "aws_account_id":"123456789012","aws_region":"eu-west-1",
         "xray_trace_id": "abcdef123456abcdef123456abcdef123456"
     }
     ```
@@ -597,6 +601,9 @@ This is how the printed log would look:
             "awsAccountId": "123456789012"
         }
     ```
+
+!!! tip "Custom Log formatter and Child loggers"
+    It is not necessary to pass the `LogFormatter` each time a [child logger](#using-multiple-logger-instances-across-your-code) is created. The parent's LogFormatter will be inherited by the child logger.
 
 ## Testing your code
 

--- a/docs/snippets/logger/createChild.ts
+++ b/docs/snippets/logger/createChild.ts
@@ -1,11 +1,18 @@
 import { Logger } from '@aws-lambda-powertools/logger';
 
-// With this logger, all the INFO logs will be printed
+// This logger has a service name, some persistent attributes
+// and log level set to INFO
 const logger = new Logger({
-  logLevel: 'INFO'
+  serviceName: 'serverlessAirline',
+  logLevel: 'INFO',
+  persistentLogAttributes: { 
+    aws_account_id: '123456789012',
+    aws_region: 'eu-west-1',
+  },
 });
 
-// With this logger, only the ERROR logs will be printed
+// This other logger inherits all the parent's attributes 
+// but the log level, which is now set to ERROR
 const childLogger = logger.createChild({
   logLevel: 'ERROR'
 });


### PR DESCRIPTION
<!--- 1. Make sure you follow our Contributing Guidelines: https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/CONTRIBUTING.md -->
<!--- 2. Please follow the template, and do not remove any section in the template. If something is not applicable leave it empty, but leave it in the PR. -->

## Description of your changes

<!--- Include here a summary of the change. -->
This PR is intended to improve docs for child loggers (`createChild` method). It is the last part of improving the child logger implementation, unit tests, and documentation. In the first PR #1178 child Logger implementation was changed, and new tests were introduced, in this PR #1264 implementation was improved, and new tests were introduced that cover all attributes inherited from a parent logger.
<!--- Please include also relevant motivation and context. -->

<!--- List any dependencies that are required for this change. -->

<!--- If this PR is part of a sequence of related PRs or TODOs, list the high level TODO items. -->

### How to verify this change

<!--- Add any applicable config, projects, screenshots or other resources -->
<!--- that can help us verify your changes. -->

<!--- Examples: -->
<!--- Screenshots, cloud configuration, anything helping us evaluate better. -->

### Related issues, RFCs

<!--- Add here the number (i.e. #42) to the Github Issue or RFC that is related to this PR. -->
<!--- If no issue is present the PR might get blocked and not be reviewed. -->
**Issue number:** #483 

### PR status

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-typescript/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [x] I have made corresponding changes to the *documentation*
- [x] I have made corresponding changes to the *examples*
- [x] My changes generate *no new warnings*
- [x] The *code coverage* hasn't decreased
- [x] I have *added tests* that prove my change is effective and works
- [x] New and existing *unit tests pass* locally and in Github Actions
- [x] Any *dependent changes have been merged and published*
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

- [ ] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
