### PR TITLE
tests(parameters): integration tests for `AppConfigProvider`

### DIFF
--- a/packages/parameters/tests/e2e/appConfigProvider.class.test.functionCode.ts
+++ b/packages/parameters/tests/e2e/appConfigProvider.class.test.functionCode.ts
@@ -16,8 +16,9 @@ const application = process.env.APPLICATION_NAME || 'my-app';
 const environment = process.env.ENVIRONMENT_NAME || 'my-env';
 const freeFormJsonName = process.env.FREEFORM_JSON_NAME || 'freeform-json';
 const freeFormYamlName = process.env.FREEFORM_YAML_NAME || 'freeform-yaml';
-const freeFormPlainTextName = process.env.FREEFORM_PLAIN_TEXT_NAME || 'freeform-plain-text';
-const featureFlagJsonName = process.env.FEATURE_FLAG_JSON_NAME || 'feature-flag-json';
+const freeFormPlainTextNameA = process.env.FREEFORM_PLAIN_TEXT_NAME_A || 'freeform-plain-text';
+const freeFormPlainTextNameB = process.env.FREEFORM_PLAIN_TEXT_NAME_B || 'freeform-plain-text';
+const featureFlagName = process.env.FEATURE_FLAG_NAME || 'feature-flag';
 
 const defaultProvider = new AppConfigProvider({
   application,
@@ -65,7 +66,7 @@ const _call_get = async (
 
 export const handler = async (_event: unknown, _context: Context): Promise<void> => {
   // Test 1 - get a single parameter as-is (no transformation)
-  await _call_get(freeFormPlainTextName, 'get');
+  await _call_get(freeFormPlainTextNameA, 'get');
 
   // Test 2 - get a free-form JSON and apply binary transformation (should return a stringified JSON)
   await _call_get(freeFormJsonName, 'get-freeform-json-binary', { transform: 'binary' });
@@ -74,18 +75,18 @@ export const handler = async (_event: unknown, _context: Context): Promise<void>
   await _call_get(freeFormYamlName, 'get-freeform-yaml-binary', { transform: 'binary' });
 
   // Test 4 - get a free-form plain text and apply binary transformation (should return a string)
-  await _call_get(freeFormPlainTextName, 'get-freeform-plain-text-binary', { transform: 'binary' });
+  await _call_get(freeFormPlainTextNameB, 'get-freeform-plain-text-binary', { transform: 'binary' });
 
-  // Test 5 - get a feature flag JSON and apply binary transformation (should return a stringified JSON)
-  await _call_get(featureFlagJsonName, 'get-feature-flag-json-binary', { transform: 'binary' });
+  // Test 5 - get a feature flag and apply binary transformation (should return a stringified JSON)
+  await _call_get(featureFlagName, 'get-feature-flag-binary', { transform: 'binary' });
 
   // Test 6
   // get parameter twice with middleware, which counts the number of requests, we check later if we only called AppConfig API once
   try {
     providerWithMiddleware.clearCache();
     middleware.counter = 0;
-    await providerWithMiddleware.get(freeFormPlainTextName);
-    await providerWithMiddleware.get(freeFormPlainTextName);
+    await providerWithMiddleware.get(freeFormPlainTextNameA);
+    await providerWithMiddleware.get(freeFormPlainTextNameA);
     logger.log({
       test: 'get-cached',
       value: middleware.counter // should be 1
@@ -102,8 +103,8 @@ export const handler = async (_event: unknown, _context: Context): Promise<void>
   try {
     providerWithMiddleware.clearCache();
     middleware.counter = 0;
-    await providerWithMiddleware.get(freeFormPlainTextName);
-    await providerWithMiddleware.get(freeFormPlainTextName, { forceFetch: true });
+    await providerWithMiddleware.get(freeFormPlainTextNameA);
+    await providerWithMiddleware.get(freeFormPlainTextNameA, { forceFetch: true });
     logger.log({
       test: 'get-forced',
       value: middleware.counter // should be 2

--- a/packages/parameters/tests/e2e/appConfigProvider.class.test.functionCode.ts
+++ b/packages/parameters/tests/e2e/appConfigProvider.class.test.functionCode.ts
@@ -1,0 +1,117 @@
+import { Context } from 'aws-lambda';
+import {
+  AppConfigProvider,
+} from '../../src/appconfig';
+import {
+  AppConfigGetOptionsInterface,
+} from '../../src/types';
+import { TinyLogger } from '../helpers/tinyLogger';
+import { middleware } from '../helpers/sdkMiddlewareRequestCounter';
+import { AppConfigDataClient } from '@aws-sdk/client-appconfigdata';
+
+// We use a custom logger to log pure JSON objects to stdout
+const logger = new TinyLogger();
+
+const application = process.env.APPLICATION_NAME || 'my-app';
+const environment = process.env.ENVIRONMENT_NAME || 'my-env';
+const freeFormJsonName = process.env.FREEFORM_JSON_NAME || 'freeform-json';
+const freeFormYamlName = process.env.FREEFORM_YAML_NAME || 'freeform-yaml';
+const freeFormPlainTextName = process.env.FREEFORM_PLAIN_TEXT_NAME || 'freeform-plain-text';
+const featureFlagJsonName = process.env.FEATURE_FLAG_JSON_NAME || 'feature-flag-json';
+
+const defaultProvider = new AppConfigProvider({
+  application,
+  environment,
+});
+// Provider test 
+const customClient = new AppConfigDataClient({});
+customClient.middlewareStack.use(middleware);
+const providerWithMiddleware = new AppConfigProvider({
+  awsSdkV3Client: customClient,
+  application,
+  environment,
+});
+
+// Use provider specified, or default to main one & return it with cache cleared
+const resolveProvider = (provider?: AppConfigProvider): AppConfigProvider => {
+  const resolvedProvider = provider ? provider : defaultProvider;
+  resolvedProvider.clearCache();
+
+  return resolvedProvider;
+};
+
+// Helper function to call get() and log the result
+const _call_get = async (
+  paramName: string,
+  testName: string,
+  options?: AppConfigGetOptionsInterface,
+  provider?: AppConfigProvider,
+): Promise<void> => {
+  try {
+    const currentProvider = resolveProvider(provider);
+
+    const parameterValue = await currentProvider.get(paramName, options);
+    logger.log({
+      test: testName,
+      value: parameterValue
+    });
+  } catch (err) {
+    logger.log({
+      test: testName,
+      error: err.message
+    });
+  }
+};
+
+export const handler = async (_event: unknown, _context: Context): Promise<void> => {
+  // Test 1 - get a single parameter as-is (no transformation)
+  await _call_get(freeFormPlainTextName, 'get');
+
+  // Test 2 - get a free-form JSON and apply binary transformation (should return a stringified JSON)
+  await _call_get(freeFormJsonName, 'get-freeform-json-binary', { transform: 'binary' });
+
+  // Test 3 - get a free-form YAML and apply binary transformation (should return a string-encoded YAML)
+  await _call_get(freeFormYamlName, 'get-freeform-yaml-binary', { transform: 'binary' });
+
+  // Test 4 - get a free-form plain text and apply binary transformation (should return a string)
+  await _call_get(freeFormPlainTextName, 'get-freeform-plain-text-binary', { transform: 'binary' });
+
+  // Test 5 - get a feature flag JSON and apply binary transformation (should return a stringified JSON)
+  await _call_get(featureFlagJsonName, 'get-feature-flag-json-binary', { transform: 'binary' });
+
+  // Test 6
+  // get parameter twice with middleware, which counts the number of requests, we check later if we only called AppConfig API once
+  try {
+    providerWithMiddleware.clearCache();
+    middleware.counter = 0;
+    await providerWithMiddleware.get(freeFormPlainTextName);
+    await providerWithMiddleware.get(freeFormPlainTextName);
+    logger.log({
+      test: 'get-cached',
+      value: middleware.counter // should be 1
+    });
+  } catch (err) {
+    logger.log({
+      test: 'get-cached',
+      error: err.message
+    });
+  }
+
+  // Test 7
+  // get parameter twice, but force fetch 2nd time, we count number of SDK requests and check that we made two API calls
+  try {
+    providerWithMiddleware.clearCache();
+    middleware.counter = 0;
+    await providerWithMiddleware.get(freeFormPlainTextName);
+    await providerWithMiddleware.get(freeFormPlainTextName, { forceFetch: true });
+    logger.log({
+      test: 'get-forced',
+      value: middleware.counter // should be 2
+    });
+  } catch (err) {
+    logger.log({
+      test: 'get-forced',
+      error: err.message
+    });
+  }
+};

--- a/packages/parameters/tests/e2e/appConfigProvider.class.test.ts
+++ b/packages/parameters/tests/e2e/appConfigProvider.class.test.ts
@@ -114,6 +114,11 @@ let stack: Stack;
  * Test 7
  * get parameter twice, but force fetch 2nd time, we count number of SDK requests and
  * check that we made two API calls
+ * 
+ * Note: To avoid race conditions, we add a dependency between each pair of configuration profiles.
+ * This allows us to influence the order of creation and ensure that each configuration profile
+ * is created after the previous one. This is necessary because we share the same AppConfig
+ * application and environment for all tests.
  */
 describe(`parameters E2E tests (appConfigProvider) for runtime ${runtime}`, () => {
 

--- a/packages/parameters/tests/helpers/cdkAspectGrantAccess.ts
+++ b/packages/parameters/tests/helpers/cdkAspectGrantAccess.ts
@@ -56,7 +56,7 @@ export class ResourceAccessGranter implements IAspect {
               ],
               resources: [
                 resource.parameterArn.split(':').slice(0, -1).join(':'),
-                ],
+              ],
             }),
           );
         } else if (resource instanceof CfnDeployment) {

--- a/packages/parameters/tests/helpers/cdkAspectGrantAccess.ts
+++ b/packages/parameters/tests/helpers/cdkAspectGrantAccess.ts
@@ -2,7 +2,7 @@ import { IAspect, Stack } from 'aws-cdk-lib';
 import { IConstruct } from 'constructs';
 import { NodejsFunction } from 'aws-cdk-lib/aws-lambda-nodejs';
 import { Table } from 'aws-cdk-lib/aws-dynamodb';
-import { PolicyStatement } from 'aws-cdk-lib/aws-iam';
+import { PolicyStatement, Effect } from 'aws-cdk-lib/aws-iam';
 import { Secret } from 'aws-cdk-lib/aws-secretsmanager';
 import { CfnDeployment } from 'aws-cdk-lib/aws-appconfig';
 
@@ -46,6 +46,7 @@ export class ResourceAccessGranter implements IAspect {
 
           node.addToRolePolicy(
             new PolicyStatement({
+              effect: Effect.ALLOW,
               actions: [
                 'appconfig:StartConfigurationSession',
                 'appconfig:GetLatestConfiguration',

--- a/packages/parameters/tests/helpers/parametersUtils.ts
+++ b/packages/parameters/tests/helpers/parametersUtils.ts
@@ -131,7 +131,7 @@ const createAppConfigConfigurationProfile = (options: CreateAppConfigConfigurati
     deploymentStrategyId: deploymentStrategy.ref,
     environmentId: environment.ref,
   });
-}
+};
 
 export type CreateSecureStringProviderOptions = {
   stack: Stack

--- a/packages/parameters/tests/helpers/parametersUtils.ts
+++ b/packages/parameters/tests/helpers/parametersUtils.ts
@@ -1,5 +1,13 @@
 import { Stack, RemovalPolicy } from 'aws-cdk-lib';
 import { Table, TableProps, BillingMode } from 'aws-cdk-lib/aws-dynamodb';
+import {
+  CfnApplication,
+  CfnConfigurationProfile,
+  CfnDeployment,
+  CfnDeploymentStrategy,
+  CfnEnvironment,
+  CfnHostedConfigurationVersion,
+} from 'aws-cdk-lib/aws-appconfig';
 
 export type CreateDynamoDBTableOptions = {
   stack: Stack
@@ -17,6 +25,110 @@ const createDynamoDBTable = (options: CreateDynamoDBTableOptions): Table => {
   return new Table(stack, id, props);
 };
 
+export type AppConfigResourcesOptions = {
+  stack: Stack
+  applicationName: string
+  environmentName: string
+  deploymentStrategyName: string
+};
+
+type AppConfigResourcesOutput = {
+  application: CfnApplication
+  environment: CfnEnvironment
+  deploymentStrategy: CfnDeploymentStrategy
+};
+
+/**
+ * Utility function to create the base resources for an AppConfig application.
+ */
+const createBaseAppConfigResources = (options: AppConfigResourcesOptions): AppConfigResourcesOutput => {
+  const {
+    stack,
+    applicationName,
+    environmentName,
+    deploymentStrategyName,
+  } = options;
+
+  // create a new app config application.
+  const application = new CfnApplication(
+    stack,
+    'application',
+    {
+      name: applicationName,
+    }
+  );
+
+  const environment = new CfnEnvironment(stack, 'environment', {
+    name: environmentName,
+    applicationId: application.ref,
+  });
+
+  const deploymentStrategy = new CfnDeploymentStrategy(stack, 'deploymentStrategy', {
+    name: deploymentStrategyName,
+    deploymentDurationInMinutes: 0,
+    growthFactor: 100,
+    replicateTo: 'NONE',
+    finalBakeTimeInMinutes: 0,
+  });
+
+  return {
+    application,
+    environment,
+    deploymentStrategy,
+  };
+};
+
+export type CreateAppConfigConfigurationProfileOptions = {
+  stack: Stack
+  name: string
+  application: CfnApplication
+  environment: CfnEnvironment
+  deploymentStrategy: CfnDeploymentStrategy
+  type: 'AWS.Freeform' | 'AWS.AppConfig.FeatureFlags'
+  content: {
+    contentType: 'application/json' | 'application/x-yaml' | 'text/plain'
+    content: string
+  }
+};
+
+/**
+ * Utility function to create an AppConfig configuration profile and deployment.
+ */
+const createAppConfigConfigurationProfile = (options: CreateAppConfigConfigurationProfileOptions): CfnDeployment => {
+  const {
+    stack,
+    name,
+    application,
+    environment,
+    deploymentStrategy,
+    type,
+    content,
+  } = options;
+  
+  const configProfile = new CfnConfigurationProfile(stack, `${name}-configProfile`, {
+    name,
+    applicationId: application.ref,
+    locationUri: 'hosted',
+    type,
+  });
+
+  const configVersion = new CfnHostedConfigurationVersion(stack, `${name}-configVersion`, {
+    applicationId: application.ref,
+    configurationProfileId: configProfile.ref,
+    ...content
+  });
+
+  return new CfnDeployment(stack, `${name}-deployment`, {
+    applicationId: application.ref,
+    configurationProfileId: configProfile.ref,
+    configurationVersion: configVersion.ref,
+    deploymentStrategyId: deploymentStrategy.ref,
+    environmentId: environment.ref,
+  });
+};
+
 export {
-  createDynamoDBTable
+  createDynamoDBTable,
+  createBaseAppConfigResources,
+  createAppConfigConfigurationProfile,
 };

--- a/packages/parameters/tests/helpers/sdkMiddlewareRequestCounter.ts
+++ b/packages/parameters/tests/helpers/sdkMiddlewareRequestCounter.ts
@@ -17,9 +17,16 @@ export const middleware = {
   applyToStack: (stack) => {
     // Middleware added to mark start and end of an complete API call.
     stack.add(
-      (next, _context) => async (args) => {
-        // Increment counter
-        middleware.counter++;
+      (next, context) => async (args) => {
+        // We only want to count API calls to retrieve data,
+        // not the StartConfigurationSessionCommand
+        if (
+          context.clientName !== 'AppConfigDataClient' ||
+          context.commandName !== 'StartConfigurationSessionCommand'
+        ) {
+          // Increment counter
+          middleware.counter++;
+        }
 
         // Call next middleware
         return await next(args);


### PR DESCRIPTION
## Description of your changes

This PR introduces the test suite that runs integration tests on the `SSMProvider` which is part of the upcoming Parameters utility. The PR also extends the `ResourceAccessGranter` helper to add compatibility for SSM.

### Test suite

This test suite deploys a CDK stack with a Lambda function and a number of AppConfig parameters. The function code uses the Parameters utility to retrieve the parameters. It then logs the values to CloudWatch Logs as JSON objects.

Once the stack is deployed, the Lambda function is invoked and the CloudWatch Logs are retrieved. The logs are then parsed and the values are checked against the expected values for each test case.

The stack creates an AppConfig application and environment, and then creates a number configuration profiles, each with a different type of parameter.

This test suite deploys a CDK stack with a Lambda function and a number of SSM parameters. The function code uses the Parameters utility to retrieve the SSM parameters. It then logs the values to CloudWatch Logs as JSON objects.

Once the stack is deployed, the Lambda function is invoked and the CloudWatch Logs are retrieved. The logs are then parsed and the values are checked against the expected values for each test case.

### The parameters created are:

- Free-form JSON
- Free-form YAML
- 2x Free-form plain text
- Feature flag JSON

These parameters allow to retrieve the values and test some transformations.

### The tests are:

#### Test 1
get a single parameter by name with default options

#### Test 2
get multiple parameters by path with default options

#### Test 3
get multiple parameters by path recursively (aka. get all parameters under a path recursively) i.e. given /param, retrieve /param/get/a and /param/get/b (note path depth)

#### Test 4
get multiple parameters by path with decrypt

#### Test 5
get multiple parameters by name with default options

#### Test 6
get parameter twice with middleware, which counts the number of requests, we check later if we only called AppConfig API once

#### Test 7
get parameter twice, but force fetch 2nd time, we count number of SDK requests and check that we made two API calls

### How to verify this change

Given that the integration tests are not yet hooked up to the GitHub workflow that runs them on GitHub, at the moment the only way to test this is to checkout the repo locally and then run: npm run test:e2e:nodejs18x -w packages/parameters.

The command above will run the tests on your currently logged in AWS account and use the Node.js 18 runtime.

Below a screenshot of the result as run on my machine:
![image](https://user-images.githubusercontent.com/7353869/219333576-a757bdb9-0ddc-496f-a77a-b7c74f5c9bcf.png)

### Related issues, RFCs

<!--- Add here the number (i.e. #42) to the Github Issue or RFC that is related to this PR. -->
<!--- If no issue is present the PR might get blocked and not be reviewed. -->
**Issue number:** #1242

### PR status

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-typescript/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [ ] I have made corresponding changes to the *documentation*
- [ ] I have made corresponding changes to the *examples*
- [x] My changes generate *no new warnings*
- [x] The *code coverage* hasn't decreased
- [x] I have *added tests* that prove my change is effective and works
- [x] New and existing *unit tests pass* locally and in Github Actions
- [ ] Any *dependent changes have been merged and published*
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

- [ ] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
