### PR TITLE
refactor(tracer): allow streaming threshold configuration

### DIFF
--- a/docs/core/tracer.md
+++ b/docs/core/tracer.md
@@ -249,6 +249,16 @@ You can opt-out from this feature by setting the **`POWERTOOLS_TRACER_CAPTURE_HT
 
 ## Advanced
 
+### Configure streaming threshold
+
+By default, the SDK is configured to have a threshold of 100 subsegments per segment. This is because the UDP packet maximum size is ~65 kb, and larger segments might trigger the 'Segment too large to send' error.
+
+To remedy this, the SDK automatically sends the completed subsegments to the daemon when the threshold is breached. Additionally, subsegments that complete when over the threshold automatically send themselves. If a subsegment is sent out of band, it is pruned from the segment object. The full segment is reconstructed on the service side. You can change the threshold as needed.
+
+`tracer.setStreamingThreshold(10)`
+
+Subsegments can be marked as in_progress when sent to the daemon. The SDK is telling the service to anticipate the asynchronous subsegment to be received out of band when it has completed. When received, the in_progress subsegment is discarded in favor of the completed subsegment.
+
 ### Disabling response auto-capture
 
 Use **`POWERTOOLS_TRACER_CAPTURE_RESPONSE=false`** environment variable to instruct Tracer **not** to serialize function responses as metadata.

--- a/packages/tracer/src/provider/ProviderService.ts
+++ b/packages/tracer/src/provider/ProviderService.ts
@@ -1,10 +1,10 @@
 import { ContextMissingStrategy } from 'aws-xray-sdk-core/dist/lib/context_utils';
 import { Namespace } from 'cls-hooked';
 import { ProviderServiceInterface } from '.';
-import { captureAWS, captureAWSClient, captureAWSv3Client, captureAsyncFunc, captureFunc, captureHTTPsGlobal, getNamespace, getSegment, setSegment, Segment, Subsegment, setContextMissingStrategy, setDaemonAddress, setLogger, Logger } from 'aws-xray-sdk-core';
+import { captureAWS, captureAWSClient, captureAWSv3Client, captureAsyncFunc, captureFunc, captureHTTPsGlobal, getNamespace, getSegment, setSegment, Segment, Subsegment, setContextMissingStrategy, setStreamingThreshold, setDaemonAddress, setLogger, Logger } from 'aws-xray-sdk-core';
 
 class ProviderService implements ProviderServiceInterface {
-  
+
   public captureAWS<T>(awssdk: T): T {
     return captureAWS(awssdk);
   }
@@ -45,7 +45,7 @@ class ProviderService implements ProviderServiceInterface {
   public setContextMissingStrategy(strategy: unknown): void {
     setContextMissingStrategy(strategy as ContextMissingStrategy);
   }
-
+  
   public setDaemonAddress(address: string): void {
     setDaemonAddress(address);
   }
@@ -56,6 +56,10 @@ class ProviderService implements ProviderServiceInterface {
   
   public setSegment(segment: Segment | Subsegment): void {
     setSegment(segment);
+  }
+
+  public setStreamingThreshold(threshold: number): void {
+    setStreamingThreshold(threshold);
   }
 
 }

--- a/packages/tracer/src/provider/ProviderServiceInterface.ts
+++ b/packages/tracer/src/provider/ProviderServiceInterface.ts
@@ -14,6 +14,8 @@ interface ProviderServiceInterface {
 
   setContextMissingStrategy(strategy: unknown): void
 
+  setStreamingThreshold(threshold: number): void
+
   captureAWS<T>(awsservice: T): T
 
   captureAWSClient<T>(awsservice: T): T

--- a/packages/tracer/tests/unit/ProviderService.test.ts
+++ b/packages/tracer/tests/unit/ProviderService.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { ProviderService } from '../../src/provider';
-import { captureAWS, captureAWSClient, captureAWSv3Client, captureAsyncFunc, captureHTTPsGlobal, captureFunc, getNamespace, getSegment, setContextMissingStrategy, setDaemonAddress, setLogger, setSegment, Subsegment } from 'aws-xray-sdk-core';
+import { captureAWS, captureAWSClient, captureAWSv3Client, captureAsyncFunc, captureHTTPsGlobal, captureFunc, getNamespace, getSegment, setContextMissingStrategy, setDaemonAddress, setLogger, setSegment, Subsegment, setStreamingThreshold } from 'aws-xray-sdk-core';
 import http from 'http';
 import https from 'https';
 
@@ -21,7 +21,8 @@ jest.mock('aws-xray-sdk-core', () => ({
   setContextMissingStrategy: jest.fn(),
   setDaemonAddress: jest.fn(),
   setLogger: jest.fn(),
-  setSegment: jest.fn()
+  setSegment: jest.fn(),
+  setStreamingThreshold: jest.fn()
 }));
 
 describe('Class: ProviderService', () => {
@@ -263,6 +264,24 @@ describe('Class: ProviderService', () => {
     
     });
     
+  });
+
+  describe('Method: setStreamingThreshold', () => {
+
+    test('when called, it forwards the correct parameter, and call the correct function', () => {
+
+      // Prepare
+      const provider: ProviderService = new ProviderService();
+
+      // Act
+      provider.setStreamingThreshold(0);
+
+      // Assess
+      expect(setStreamingThreshold).toHaveBeenCalledTimes(1);
+      expect(setStreamingThreshold).toHaveBeenCalledWith(0);
+
+    });
+
   });
 
 });


### PR DESCRIPTION
<!--- 1. Make sure you follow our Contributing Guidelines: https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/CONTRIBUTING.md -->
<!--- 2. Please follow the template, and do not remove any section in the template. If something is not applicable leave it empty, but leave it in the PR. -->

## Description of your changes

<!--- Include here a summary of the change. -->
- Add setStreamingThreshold method to `ProviderServiceInterface.ts` 
- Implement setStreamingThreshold method 
- Add unit-tests
<!--- Please include also relevant motivation and context. -->

Initially the `setStreamingThreshold` method was not exposed.
Having encountered a Segment too large issue (with a lot of requests to DynamoDB), the only way to bypass the issue was to set the Streaming Threshold to a value of 0. 
This is possible when using `aws-xray-sdk-node` directly but not `aws-lambda-powertools-typescript` because the setStreamingThreshold method was not exposed.

<!--- List any dependencies that are required for this change. -->

<!--- If this PR is part of a sequence of related PRs or TODOs, list the high level TODO items. -->

### How to verify this change

<!--- Add any applicable config, projects, screenshots or other resources -->
<!--- that can help us verify your changes. -->

<!--- Examples: -->
<!--- Screenshots, cloud configuration, anything helping us evaluate better. -->

### Related issues, RFCs

<!--- Add here the number (i.e. #42) to the Github Issue or RFC that is related to this PR. -->
<!--- If no issue is present the PR might get blocked and not be reviewed. -->
**Issue number:** 

### PR status

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-typescript/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [x] I have made corresponding changes to the *documentation*
- [ ] I have made corresponding changes to the *examples*
- [x] My changes generate *no new warnings*
- [x] The *code coverage* hasn't decreased
- [x] I have *added tests* that prove my change is effective and works
- [x] New and existing *unit tests pass* locally and in Github Actions
- [x] Any *dependent changes have been merged and published*
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

- [ ] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
