### PR TITLE
tests(parameters): update package to run as part of e2e tests

### DIFF
--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -19,7 +19,7 @@ jobs:
       contents: read
     strategy:
       matrix:
-        package: [logger, metrics, tracer]
+        package: [logger, metrics, tracer, parameters]
         version: [14, 16, 18]
       fail-fast: false
     steps:

--- a/packages/parameters/package.json
+++ b/packages/parameters/package.json
@@ -16,7 +16,7 @@
     "test:e2e:nodejs14x": "RUNTIME=nodejs14x jest --group=e2e",
     "test:e2e:nodejs16x": "RUNTIME=nodejs16x jest --group=e2e",
     "test:e2e:nodejs18x": "RUNTIME=nodejs18x jest --group=e2e",
-    "test:e2e": "echo \"Not implemented\"",
+    "test:e2e": "jest --group=e2e",
     "watch": "jest --watch",
     "build": "tsc",
     "lint": "eslint --ext .ts --no-error-on-unmatched-pattern src tests",


### PR DESCRIPTION
## Description of your changes

Now that all the integration tests for Parameters have been implemented, the utility can be added to the workflow that runs the e2e tests on GitHub.

This PR makes the changes necessary to run the tests part of this package once the [`run-e2e-tests.yml`](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/workflows/run-e2e-tests.yml) workflow is run and will close #1039 once merged.

### How to verify this change

See integration test run [here](https://github.com/awslabs/aws-lambda-powertools-typescript/actions/runs/4234018154)

### Related issues, RFCs

<!--- Add here the number (i.e. #42) to the Github Issue or RFC that is related to this PR. -->
<!--- If no issue is present the PR might get blocked and not be reviewed. -->
**Issue number:** #1039

### PR status

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-typescript/#tenets)
- [x] I have performed a *self-review* of my own code
- [ ] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [ ] I have made corresponding changes to the *documentation*
- [ ] I have made corresponding changes to the *examples*
- [x] My changes generate *no new warnings*
- [x] The *code coverage* hasn't decreased
- [ ] I have *added tests* that prove my change is effective and works
- [x] New and existing *unit tests pass* locally and in Github Actions
- [x] Any *dependent changes have been merged and published*
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

- [ ] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
