### PR TITLE
fix(parameters): handle base64/binaries in transformer

### DIFF
--- a/packages/parameters/src/BaseProvider.ts
+++ b/packages/parameters/src/BaseProvider.ts
@@ -131,6 +131,11 @@ abstract class BaseProvider implements BaseProviderInterface {
 const transformValue = (value: string | Uint8Array | undefined, transform: TransformOptions, throwOnTransformError: boolean, key: string): string | Record<string, unknown> | undefined => {
   try {
     const normalizedTransform = transform.toLowerCase();
+
+    if (value instanceof Uint8Array) {
+      value = new TextDecoder('utf-8').decode(value);
+    }
+
     if (
       (normalizedTransform === TRANSFORM_METHOD_JSON ||
         (normalizedTransform === 'auto' && key.toLowerCase().endsWith(`.${TRANSFORM_METHOD_JSON}`))) &&
@@ -139,15 +144,12 @@ const transformValue = (value: string | Uint8Array | undefined, transform: Trans
       return JSON.parse(value) as Record<string, unknown>;
     } else if (
       (normalizedTransform === TRANSFORM_METHOD_BINARY ||
-        (normalizedTransform === 'auto' && key.toLowerCase().endsWith(`.${TRANSFORM_METHOD_BINARY}`)))
+        (normalizedTransform === 'auto' && key.toLowerCase().endsWith(`.${TRANSFORM_METHOD_BINARY}`))) &&
+      typeof value === 'string'
     ) {
-      if (typeof value === 'string') {
-        return new TextDecoder('utf-8').decode(fromBase64(value));
-      } else {
-        return new TextDecoder('utf-8').decode(value);
-      }
+      return new TextDecoder('utf-8').decode(fromBase64(value));
     } else {
-      return value as string;
+      return value;
     }
   } catch (error) {
     if (throwOnTransformError)

--- a/packages/parameters/tests/e2e/appConfigProvider.class.test.functionCode.ts
+++ b/packages/parameters/tests/e2e/appConfigProvider.class.test.functionCode.ts
@@ -16,8 +16,7 @@ const application = process.env.APPLICATION_NAME || 'my-app';
 const environment = process.env.ENVIRONMENT_NAME || 'my-env';
 const freeFormJsonName = process.env.FREEFORM_JSON_NAME || 'freeform-json';
 const freeFormYamlName = process.env.FREEFORM_YAML_NAME || 'freeform-yaml';
-const freeFormPlainTextNameA = process.env.FREEFORM_PLAIN_TEXT_NAME_A || 'freeform-plain-text';
-const freeFormPlainTextNameB = process.env.FREEFORM_PLAIN_TEXT_NAME_B || 'freeform-plain-text';
+const freeFormBase64encodedPlainText = process.env.FREEFORM_BASE64_ENCODED_PLAIN_TEXT_NAME || 'freeform-plain-text';
 const featureFlagName = process.env.FEATURE_FLAG_NAME || 'feature-flag';
 
 const defaultProvider = new AppConfigProvider({
@@ -65,28 +64,25 @@ const _call_get = async (
 };
 
 export const handler = async (_event: unknown, _context: Context): Promise<void> => {
-  // Test 1 - get a single parameter as-is (no transformation)
-  await _call_get(freeFormPlainTextNameA, 'get');
+  // Test 1 - get a single parameter as-is (no transformation - should return an Uint8Array)
+  await _call_get(freeFormYamlName, 'get');
 
-  // Test 2 - get a free-form JSON and apply binary transformation (should return a stringified JSON)
-  await _call_get(freeFormJsonName, 'get-freeform-json-binary', { transform: 'binary' });
+  // Test 2 - get a free-form JSON and apply json transformation (should return an object)
+  await _call_get(freeFormJsonName, 'get-freeform-json-binary', { transform: 'json' });
 
-  // Test 3 - get a free-form YAML and apply binary transformation (should return a string-encoded YAML)
-  await _call_get(freeFormYamlName, 'get-freeform-yaml-binary', { transform: 'binary' });
+  // Test 3 - get a free-form base64-encoded plain text and apply binary transformation (should return a decoded string)
+  await _call_get(freeFormBase64encodedPlainText, 'get-freeform-base64-plaintext-binary', { transform: 'binary' });
 
-  // Test 4 - get a free-form plain text and apply binary transformation (should return a string)
-  await _call_get(freeFormPlainTextNameB, 'get-freeform-plain-text-binary', { transform: 'binary' });
-
-  // Test 5 - get a feature flag and apply binary transformation (should return a stringified JSON)
-  await _call_get(featureFlagName, 'get-feature-flag-binary', { transform: 'binary' });
+  // Test 5 - get a feature flag and apply json transformation (should return an object)
+  await _call_get(featureFlagName, 'get-feature-flag-binary', { transform: 'json' });
 
   // Test 6
   // get parameter twice with middleware, which counts the number of requests, we check later if we only called AppConfig API once
   try {
     providerWithMiddleware.clearCache();
     middleware.counter = 0;
-    await providerWithMiddleware.get(freeFormPlainTextNameA);
-    await providerWithMiddleware.get(freeFormPlainTextNameA);
+    await providerWithMiddleware.get(freeFormBase64encodedPlainText);
+    await providerWithMiddleware.get(freeFormBase64encodedPlainText);
     logger.log({
       test: 'get-cached',
       value: middleware.counter // should be 1
@@ -103,8 +99,8 @@ export const handler = async (_event: unknown, _context: Context): Promise<void>
   try {
     providerWithMiddleware.clearCache();
     middleware.counter = 0;
-    await providerWithMiddleware.get(freeFormPlainTextNameA);
-    await providerWithMiddleware.get(freeFormPlainTextNameA, { forceFetch: true });
+    await providerWithMiddleware.get(freeFormBase64encodedPlainText);
+    await providerWithMiddleware.get(freeFormBase64encodedPlainText, { forceFetch: true });
     logger.log({
       test: 'get-forced',
       value: middleware.counter // should be 2

--- a/packages/parameters/tests/unit/BaseProvider.test.ts
+++ b/packages/parameters/tests/unit/BaseProvider.test.ts
@@ -206,19 +206,15 @@ describe('Class: BaseProvider', () => {
 
     });
     
-    test('when called with a binary transform, and the value is a valid binary, it returns the decoded value', async () => {
+    test('when called with a binary transform, and the value is a valid binary but NOT base64 encoded, it throws', async () => {
 
       // Prepare
       const mockData = encoder.encode('my-value');
       const provider = new TestProvider();
       jest.spyOn(provider, '_get').mockImplementation(() => new Promise((resolve, _reject) => resolve(mockData as unknown as string)));
 
-      // Act
-      const value = await provider.get('my-parameter', { transform: 'binary' });
-
-      // Assess
-      expect(typeof value).toBe('string');
-      expect(value).toEqual('my-value');
+      // Act & Assess
+      await expect(provider.get('my-parameter', { transform: 'binary' })).rejects.toThrowError(TransformParameterError);
 
     });
     

--- a/packages/parameters/tests/unit/getAppConfig.test.ts
+++ b/packages/parameters/tests/unit/getAppConfig.test.ts
@@ -16,11 +16,11 @@ import {
 import { mockClient } from 'aws-sdk-client-mock';
 import 'aws-sdk-client-mock-jest';
 import type { GetAppConfigCombinedInterface } from '../../src/types/AppConfigProvider';
+import { toBase64 } from '@aws-sdk/util-base64-node';
 
 describe('Function: getAppConfig', () => {
   const client = mockClient(AppConfigDataClient);
   const encoder = new TextEncoder();
-  const decoder = new TextDecoder();
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -103,8 +103,8 @@ describe('Function: getAppConfig', () => {
       'AYADeNgfsRxdKiJ37A12OZ9vN2cAXwABABVhd3MtY3J5cHRvLXB1YmxpYy1rZXkAREF1RzlLMTg1Tkx2Wjk4OGV2UXkyQ1';
     const mockNextToken =
       'ImRmyljpZnxt7FfxeEOE5H8xQF1SfOlWZFnHujbzJmIvNeSAAA8/qA9ivK0ElRMwpvx96damGxt125XtMkmYf6a0OWSqnBw==';
-    const mockData = encoder.encode('myAppConfiguration');
-    const decodedData = decoder.decode(mockData);
+    const expectedValue = 'my-value';
+    const mockData = encoder.encode(toBase64(encoder.encode(expectedValue)));
 
     client
       .on(StartConfigurationSessionCommand)
@@ -121,6 +121,6 @@ describe('Function: getAppConfig', () => {
     const result = await getAppConfig(name, options);
 
     // Assess
-    expect(result).toBe(decodedData);
+    expect(result).toBe(expectedValue);
   });
 });


### PR DESCRIPTION
<!--- 1. Make sure you follow our Contributing Guidelines: https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/CONTRIBUTING.md -->
<!--- 2. Please follow the template, and do not remove any section in the template. If something is not applicable leave it empty, but leave it in the PR. -->

## Description of your changes

As described in #1325, the current implementation of the transformer in the Parameters utility was not handling correctly values returned by AppConfig, which are always of type `Uint8Array`.

The linked issue has a more in-depth explanation, but essentially this PR updates the transformer so that both `json` and `binary` (aka base64) transforms can be used correctly with the provider.

Once merged this PR will close #1325.

### How to verify this change

See checks below the PR as well as successful integration tests run [here](https://github.com/awslabs/aws-lambda-powertools-typescript/actions/runs/4244943927).

### Related issues, RFCs

<!--- Add here the number (i.e. #42) to the Github Issue or RFC that is related to this PR. -->
<!--- If no issue is present the PR might get blocked and not be reviewed. -->
**Issue number:** #1325

### PR status

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-typescript/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [ ] I have made corresponding changes to the *documentation*
- [ ] I have made corresponding changes to the *examples*
- [x] My changes generate *no new warnings*
- [x] The *code coverage* hasn't decreased
- [x] I have *added tests* that prove my change is effective and works
- [x] New and existing *unit tests pass* locally and in Github Actions
- [ ] Any *dependent changes have been merged and published*
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

- [ ] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
