### PR TITLE
fix(logger): middleware stores initial persistent attributes correctly

### DIFF
--- a/packages/logger/src/middleware/middy.ts
+++ b/packages/logger/src/middleware/middy.ts
@@ -35,9 +35,9 @@ const injectLambdaContext = (target: Logger | Logger[], options?: HandlerOptions
   const persistentAttributes: LogAttributes[] = [];
 
   const injectLambdaContextBefore = async (request: MiddyLikeRequest): Promise<void> => {
-    loggers.forEach((logger: Logger) => {
+    loggers.forEach((logger: Logger, index: number) => {
       if (options && options.clearState === true) {
-        persistentAttributes.push({ ...logger.getPersistentLogAttributes() });
+        persistentAttributes[index] = ({ ...logger.getPersistentLogAttributes() });
       }
       Logger.injectLambdaContextBefore(logger, request.event, request.context, options);
     });

--- a/packages/logger/tests/unit/Logger.test.ts
+++ b/packages/logger/tests/unit/Logger.test.ts
@@ -1247,7 +1247,7 @@ describe('Class: Logger', () => {
         @logger.injectLambdaContext()
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
-        public async handler<TResult>(_event: unknown, _context: Context, _callback: Callback<TResult>): void | Promise<TResult> {
+        public async handler(_event: unknown, _context: unknown): Promise<unknown> {
           await this.dummyMethod();
           logger.info('This is a DEBUG log');
 
@@ -1258,11 +1258,11 @@ describe('Class: Logger', () => {
           return;
         }
       }
-
-      // Act
       const lambda = new LambdaFunction();
       const handler = lambda.handler.bind(lambda);
-      await handler({}, context, () => console.log('Lambda invoked!'));
+
+      // Act
+      await handler({}, context);
 
       // Assess
       expect(consoleSpy).toBeCalledTimes(1);


### PR DESCRIPTION
<!--- 1. Make sure you follow our Contributing Guidelines: https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/CONTRIBUTING.md -->
<!--- 2. Please follow the template, and do not remove any section in the template. If something is not applicable leave it empty, but leave it in the PR. -->

## Description of your changes

In #1328 it was reported that the Logger middleware `injectLambdaContext` was not clearing correctly the state and potentially leaking attributes set during an execution in the subsequent one.

Prior to this PR the middleware was improperly storing the initial persistent attributes of each logger instance passed to the middleware. This caused issues when clearing the state after each invocation, since the initial persistent attributes were now unusable.

This PR fixes the issue and adds new unit tests. Once merged this PR will close #1328.

<longer explanation coming soon>

Once merged, this PR closes #1328.

### How to verify this change

See checks under the PR as well as integration [test run here](https://github.com/awslabs/aws-lambda-powertools-typescript/actions/runs/4272607387). New unit tests were added to demonstrate the fix & avoid future regressions.

### Related issues, RFCs

<!--- Add here the number (i.e. #42) to the Github Issue or RFC that is related to this PR. -->
<!--- If no issue is present the PR might get blocked and not be reviewed. -->
**Issue number:** #1328

### PR status

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-typescript/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [ ] I have made corresponding changes to the *documentation*
- [ ] I have made corresponding changes to the *examples*
- [x] My changes generate *no new warnings*
- [x] The *code coverage* hasn't decreased
- [x] I have *added tests* that prove my change is effective and works
- [x] New and existing *unit tests pass* locally and in Github Actions
- [ ] Any *dependent changes have been merged and published*
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

- [ ] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
