### PR TITLE
chore: updated `homepage` field in `package.json` files

### DIFF
--- a/packages/commons/package.json
+++ b/packages/commons/package.json
@@ -23,7 +23,7 @@
     "prepare": "npm run build",
     "postversion": "git push --tags"
   },
-  "homepage": "https://github.com/awslabs/aws-lambda-powertools-typescript/tree/master/packages/metrics#readme",
+  "homepage": "https://github.com/awslabs/aws-lambda-powertools-typescript/tree/main/packages/metrics#readme",
   "license": "MIT-0",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/packages/idempotency/package.json
+++ b/packages/idempotency/package.json
@@ -26,7 +26,7 @@
     "prepare": "npm run build",
     "postversion": "echo \"Not implemented\""
   },
-  "homepage": "https://github.com/awslabs/aws-lambda-powertools-typescript/tree/master/packages/idempotency#readme",
+  "homepage": "https://github.com/awslabs/aws-lambda-powertools-typescript/tree/main/packages/idempotency#readme",
   "license": "MIT",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -26,7 +26,7 @@
     "prepare": "npm run build",
     "postversion": "git push --tags"
   },
-  "homepage": "https://github.com/awslabs/aws-lambda-powertools-typescript/tree/master/packages/logging#readme",
+  "homepage": "https://github.com/awslabs/aws-lambda-powertools-typescript/tree/main/packages/logging#readme",
   "license": "MIT",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/packages/metrics/package.json
+++ b/packages/metrics/package.json
@@ -26,7 +26,7 @@
     "prepare": "npm run build",
     "postversion": "git push --tags"
   },
-  "homepage": "https://github.com/awslabs/aws-lambda-powertools-typescript/tree/master/packages/metrics#readme",
+  "homepage": "https://github.com/awslabs/aws-lambda-powertools-typescript/tree/main/packages/metrics#readme",
   "license": "MIT-0",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/packages/tracer/package.json
+++ b/packages/tracer/package.json
@@ -26,7 +26,7 @@
     "prepare": "npm run build",
     "postversion": "git push --tags"
   },
-  "homepage": "https://github.com/awslabs/aws-lambda-powertools-typescript/tree/master/packages/tracer#readme",
+  "homepage": "https://github.com/awslabs/aws-lambda-powertools-typescript/tree/main/packages/tracer#readme",
   "license": "MIT-0",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",


### PR DESCRIPTION
<!--- 1. Make sure you follow our Contributing Guidelines: https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/CONTRIBUTING.md -->
<!--- 2. Please follow the template, and do not remove any section in the template. If something is not applicable leave it empty, but leave it in the PR. -->

## Description of your changes

As discussed in the linked issue, the `package.json` files of most all the utilities except Parameters had a wrong value in the `homepage` field which caused a 404 when users clicked on the rendered link on npm.

This PR fixes the url pointing it to the correct branch and resolves #1337.

### How to verify this change

Check the diff. The new link will be available on npm on the next release.

### Related issues, RFCs

<!--- Add here the number (i.e. #42) to the Github Issue or RFC that is related to this PR. -->
<!--- If no issue is present the PR might get blocked and not be reviewed. -->
**Issue number:** #1337

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-typescript/#tenets)
- [ ] I have performed a *self-review* of my own code
- [ ] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [ ] I have made corresponding changes to the *documentation*
- [ ] I have made corresponding changes to the *examples*
- [x] My changes generate *no new warnings*
- [x] The *code coverage* hasn't decreased
- [ ] I have *added tests* that prove my change is effective and works
- [ ] New and existing *unit tests pass* locally and in Github Actions
- [ ] Any *dependent changes have been merged and published*
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

***Is it a breaking change?:*** NO

- [ ] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
