### PR TITLE
chore(ci): narrow down stale issue filtering

### DIFF
--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -23,13 +23,13 @@ jobs:
           close-issue-reason: not_planned
           # Exempt any issue that hasn't been triaged yet, or that is clearly labeled
           exempt-issue-labels: triage,status/confirmed,status/blocked,status/on-hold,status/completed
-          # Include only issues where any of these labels are present (aka only issues that need more info from the customer)
-          # that are either under discussion, but no info/answer has been provided in 2 weeks, or that were already marked
-          # as stale 
-          any-of-issue-labels: need-more-information,status/discussing,status/pending-close-response-required
+          # Include only issues that were labeled as `need-more-information` (aka only issues that need more info from the customer)
+          only-issue-labels: need-more-information
           # Settings specific to issues
           days-before-issue-stale: 14
           days-before-issue-close: 7
           # Set to ignore PRs
           days-before-pr-stale: -1
           days-before-pr-close: -1
+          # Operations
+          operations-per-run: 60

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -268,7 +268,7 @@ In other cases, you may have constrained capacity. Use `help=wanted` label when 
 
 When in doubt, use `need-more-information` or `need-customer-feedback` labels to signal more context and feedback are necessary before proceeding. You can also use `status/on-hold` label when you expect it might take a while to gather enough information before you can decide.
 
-Note that issues marked as `need-more-information` and `status/discussing` will be automatically closed after 3 weeks of inactivity.
+Note that issues marked as `need-more-information` will be automatically closed after 3 weeks of inactivity.
 
 ### Crediting contributions
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -102,7 +102,7 @@ These are the most common labels used by maintainers to triage issues, pull requ
 | good-first-issue                       | Something that is suitable for those who want to start contributing                            |                                                    |
 | help-wanted                            | Tasks you want help from anyone to move forward                                                | Bandwidth, complex topics, etc.                    |
 | need-customer-feedback                 | Tasks that need more feedback before proceeding                                                | 80/20% rule, uncertain, etc.                       |
-| need-more-information                  | Missing information before making any calls                                                    |                                                    |
+| need-more-information                  | Missing information before making any calls                                                    | Triggers stale automation after 2 weeks            |
 | need-issue                             | PR is missing a related issue for tracking change                                              |                                                    |
 
 ## Maintainer Responsibilities


### PR DESCRIPTION
## Description of your changes

As discussed in the linked issue, the stale issue automation that was set up in #1341 had filter that was too broad and that closed issues that shouldn't be closed.

This PR changes the filter to now include only the label `need-more-information` which should solve the issue.

The PR also increases the number of operations allowed to the workflow from 30 to 60.

Resolves #1345

### How to verify this change

Check output of next run tomorrow.

### Related issues, RFCs

<!--- Add here the number (i.e. #42) to the Github Issue or RFC that is related to this PR. -->
<!--- If no issue is present the PR might get blocked and not be reviewed. -->
**Issue number:** #1345

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-typescript/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [x] I have made corresponding changes to the *documentation*
- [ ] I have made corresponding changes to the *examples*
- [x] My changes generate *no new warnings*
- [x] The *code coverage* hasn't decreased
- [ ] I have *added tests* that prove my change is effective and works
- [x] New and existing *unit tests pass* locally and in Github Actions
- [ ] Any *dependent changes have been merged and published*
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

***Is it a breaking change?:*** NO

- [ ] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
