### PR TITLE
chore(ci): fix typo in doc publishing workflow

### DIFF
--- a/.github/workflows/on_doc_merge.yml
+++ b/.github/workflows/on_doc_merge.yml
@@ -7,7 +7,6 @@ on:
     paths:
       - "docs/**"
       - "mkdocs.yml"
-      - "examples/**"
 
 jobs:
   release-docs:

--- a/.github/workflows/reusable-publish-docs.yml
+++ b/.github/workflows/reusable-publish-docs.yml
@@ -4,7 +4,6 @@ env:
   BRANCH: main
   ORIGIN: awslabs/aws-lambda-powertools-typescript
 
-
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/reusable-publish-docs.yml
+++ b/.github/workflows/reusable-publish-docs.yml
@@ -111,7 +111,7 @@ jobs:
           keep_files: true
           destination_dir: ${{ env.VERSION }}/api
       - name: Release API docs to latest
-        if: ${{ input.alias == 'latest' }}
+        if: ${{ inputs.alias == 'latest' }}
         uses: peaceiris/actions-gh-pages@bd8c6b06eba6b3d25d72b7a1767993c0aeee42e7
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!--- 1. Make sure you follow our Contributing Guidelines: https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/CONTRIBUTING.md -->
<!--- 2. Please follow the template, and do not remove any section in the template. If something is not applicable leave it empty, but leave it in the PR. -->

## Description of your changes

This PR fixes an issue in the workflow that publishes the docs after a PR that changes files related to them has been merged. As described in #1348, the workflow had a typo that caused it to fail immediately on startup.

The PR corrects the typo and also removes some extra lines, as well as one of the paths that can trigger the workflow (`examples/**`). This path was present in the workflow because in the Python repository the code snippets are under that path. In this repo however the snippets that are placed in the docs are under the `docs` path, so the extra path is unnecessary.

Once merged the PR closes #1348.

### How to verify this change

Check the next workflow run.

### Related issues, RFCs

<!--- Add here the number (i.e. #42) to the Github Issue or RFC that is related to this PR. -->
<!--- If no issue is present the PR might get blocked and not be reviewed. -->
**Issue number:** #1348

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-typescript/#tenets)
- [x] I have performed a *self-review* of my own code
- [ ] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [ ] I have made corresponding changes to the *documentation*
- [ ] I have made corresponding changes to the *examples*
- [x] My changes generate *no new warnings*
- [x] The *code coverage* hasn't decreased
- [ ] I have *added tests* that prove my change is effective and works
- [x] New and existing *unit tests pass* locally and in Github Actions
- [x] Any *dependent changes have been merged and published*
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

***Is it a breaking change?:*** NO

- [ ] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
