### PR TITLE
feat(parameters): AppConfigProvider to return the last valid value when the API returns empty value on subsequent calls

### DIFF
--- a/packages/commons/tests/utils/e2eUtils.ts
+++ b/packages/commons/tests/utils/e2eUtils.ts
@@ -5,7 +5,7 @@
  * E2E utils is used by e2e tests. They are helper function that calls either CDK or SDK
  * to interact with services. 
 */
-import { App, CfnOutput, Stack } from 'aws-cdk-lib';
+import { App, CfnOutput, Stack, Duration } from 'aws-cdk-lib';
 import {
   NodejsFunction,
   NodejsFunctionProps
@@ -37,6 +37,7 @@ export type StackWithLambdaFunctionOptions = {
   runtime: string
   bundling?: NodejsFunctionProps['bundling']
   layers?: NodejsFunctionProps['layers']
+  timeout?: Duration
 };
 
 type FunctionPayload = {[key: string]: string | boolean | number};
@@ -55,6 +56,7 @@ export const createStackWithLambdaFunction = (params: StackWithLambdaFunctionOpt
     bundling: params.bundling,
     layers: params.layers,
     logRetention: RetentionDays.ONE_DAY,
+    timeout: params.timeout
   });
 
   if (params.logGroupOutputKey) {

--- a/packages/parameters/src/ExpirableValue.ts
+++ b/packages/parameters/src/ExpirableValue.ts
@@ -4,10 +4,17 @@ class ExpirableValue implements ExpirableValueInterface {
   public ttl: number;
   public value: string | Uint8Array | Record<string, unknown>;
 
+  /**
+   * Creates a new cached value which will expire automatically
+   * @param value Parameter value to be cached
+   * @param maxAge Maximum number of seconds to cache the value for
+   */
   public constructor(value: string | Uint8Array | Record<string, unknown>, maxAge: number) {
     this.value = value;
-    const timeNow = new Date();
-    this.ttl = timeNow.setSeconds(timeNow.getSeconds() + maxAge);
+
+    const maxAgeInMilliseconds = maxAge * 1000;
+    const nowTimestamp = Date.now();
+    this.ttl = nowTimestamp + maxAgeInMilliseconds;
   }
 
   public isExpired(): boolean {

--- a/packages/parameters/src/ExpirableValue.ts
+++ b/packages/parameters/src/ExpirableValue.ts
@@ -4,17 +4,10 @@ class ExpirableValue implements ExpirableValueInterface {
   public ttl: number;
   public value: string | Uint8Array | Record<string, unknown>;
 
-  /**
-   * Creates a new cached value which will expire automatically
-   * @param value Parameter value to be cached
-   * @param maxAge Maximum number of seconds to cache the value for
-   */
   public constructor(value: string | Uint8Array | Record<string, unknown>, maxAge: number) {
     this.value = value;
-
-    const maxAgeInMilliseconds = maxAge * 1000;
-    const nowTimestamp = Date.now();
-    this.ttl = nowTimestamp + maxAgeInMilliseconds;
+    const timeNow = new Date();
+    this.ttl = timeNow.setSeconds(timeNow.getSeconds() + maxAge);
   }
 
   public isExpired(): boolean {

--- a/packages/parameters/tests/e2e/appConfigProvider.class.test.functionCode.ts
+++ b/packages/parameters/tests/e2e/appConfigProvider.class.test.functionCode.ts
@@ -81,8 +81,16 @@ export const handler = async (_event: unknown, _context: Context): Promise<void>
   try {
     providerWithMiddleware.clearCache();
     middleware.counter = 0;
-    await providerWithMiddleware.get(freeFormBase64encodedPlainText);
-    await providerWithMiddleware.get(freeFormBase64encodedPlainText);
+    const result1 = await providerWithMiddleware.get(freeFormBase64encodedPlainText);
+    const result2 = await providerWithMiddleware.get(freeFormBase64encodedPlainText);
+    logger.log({
+      test: 'get-cached-result1',
+      value: result1
+    });
+    logger.log({
+      test: 'get-cached-result2',
+      value: result2
+    });
     logger.log({
       test: 'get-cached',
       value: middleware.counter // should be 1
@@ -108,6 +116,36 @@ export const handler = async (_event: unknown, _context: Context): Promise<void>
   } catch (err) {
     logger.log({
       test: 'get-forced',
+      error: err.message
+    });
+  }
+
+  // Test 8
+  // get parameter twice, but wait long enough that cache expires count SDK calls and return values
+  try {
+    providerWithMiddleware.clearCache();
+    middleware.counter = 0;
+    const expiredResult1 = await providerWithMiddleware.get(freeFormBase64encodedPlainText, { maxAge: 5 });
+
+    // Wait
+    await new Promise(resolve => setTimeout(resolve, 6000));
+
+    const expiredResult2 = await providerWithMiddleware.get(freeFormBase64encodedPlainText, { maxAge: 5 });
+    logger.log({
+      test: 'get-expired-result1',
+      value: expiredResult1
+    });
+    logger.log({
+      test: 'get-expired-result2',
+      value: expiredResult2
+    });
+    logger.log({
+      test: 'get-expired',
+      value: middleware.counter // should be 2
+    });
+  } catch (err) {
+    logger.log({
+      test: 'get-expired',
       error: err.message
     });
   }

--- a/packages/parameters/tests/e2e/appConfigProvider.class.test.functionCode.ts
+++ b/packages/parameters/tests/e2e/appConfigProvider.class.test.functionCode.ts
@@ -73,10 +73,10 @@ export const handler = async (_event: unknown, _context: Context): Promise<void>
   // Test 3 - get a free-form base64-encoded plain text and apply binary transformation (should return a decoded string)
   await _call_get(freeFormBase64encodedPlainText, 'get-freeform-base64-plaintext-binary', { transform: 'binary' });
 
-  // Test 5 - get a feature flag and apply json transformation (should return an object)
+  // Test 4 - get a feature flag and apply json transformation (should return an object)
   await _call_get(featureFlagName, 'get-feature-flag-binary', { transform: 'json' });
 
-  // Test 6
+  // Test 5
   // get parameter twice with middleware, which counts the number of requests, we check later if we only called AppConfig API once
   try {
     providerWithMiddleware.clearCache();
@@ -84,16 +84,10 @@ export const handler = async (_event: unknown, _context: Context): Promise<void>
     const result1 = await providerWithMiddleware.get(freeFormBase64encodedPlainText);
     const result2 = await providerWithMiddleware.get(freeFormBase64encodedPlainText);
     logger.log({
-      test: 'get-cached-result1',
-      value: result1
-    });
-    logger.log({
-      test: 'get-cached-result2',
-      value: result2
-    });
-    logger.log({
       test: 'get-cached',
-      value: middleware.counter // should be 1
+      value: middleware.counter, // should be 1
+      result1: result1,
+      result2: result2
     });
   } catch (err) {
     logger.log({
@@ -102,7 +96,7 @@ export const handler = async (_event: unknown, _context: Context): Promise<void>
     });
   }
 
-  // Test 7
+  // Test 6
   // get parameter twice, but force fetch 2nd time, we count number of SDK requests and check that we made two API calls
   try {
     providerWithMiddleware.clearCache();
@@ -120,28 +114,18 @@ export const handler = async (_event: unknown, _context: Context): Promise<void>
     });
   }
 
-  // Test 8
+  // Test 7
   // get parameter twice, but wait long enough that cache expires count SDK calls and return values
   try {
     providerWithMiddleware.clearCache();
     middleware.counter = 0;
-    const expiredResult1 = await providerWithMiddleware.get(freeFormBase64encodedPlainText, { maxAge: 5 });
-
-    // Wait
-    await new Promise(resolve => setTimeout(resolve, 6000));
-
-    const expiredResult2 = await providerWithMiddleware.get(freeFormBase64encodedPlainText, { maxAge: 5 });
-    logger.log({
-      test: 'get-expired-result1',
-      value: expiredResult1
-    });
-    logger.log({
-      test: 'get-expired-result2',
-      value: expiredResult2
-    });
+    const expiredResult1 = await providerWithMiddleware.get(freeFormBase64encodedPlainText, { maxAge: 0 });
+    const expiredResult2 = await providerWithMiddleware.get(freeFormBase64encodedPlainText, { maxAge: 0 });
     logger.log({
       test: 'get-expired',
-      value: middleware.counter // should be 2
+      value: middleware.counter, // should be 2
+      result1: expiredResult1,
+      result2: expiredResult2
     });
   } catch (err) {
     logger.log({

--- a/packages/parameters/tests/e2e/appConfigProvider.class.test.functionCode.ts
+++ b/packages/parameters/tests/e2e/appConfigProvider.class.test.functionCode.ts
@@ -130,9 +130,11 @@ export const handler = async (_event: unknown, _context: Context): Promise<void>
     );
     logger.log({
       test: 'get-expired',
-      value: middleware.counter, // should be 2
-      result1: expiredResult1,
-      result2: expiredResult2
+      value: {
+        counter: middleware.counter, // should be 2
+        result1: expiredResult1,
+        result2: expiredResult2
+      },
     });
   } catch (err) {
     logger.log({

--- a/packages/parameters/tests/e2e/appConfigProvider.class.test.functionCode.ts
+++ b/packages/parameters/tests/e2e/appConfigProvider.class.test.functionCode.ts
@@ -111,14 +111,23 @@ export const handler = async (_event: unknown, _context: Context): Promise<void>
       error: err.message
     });
   }
-
   // Test 7
-  // get parameter twice, but wait long enough that cache expires count SDK calls and return values
+  // get parameter twice, using maxAge to avoid primary cache, count SDK calls and return values
   try {
     providerWithMiddleware.clearCache();
     middleware.counter = 0;
-    const expiredResult1 = await providerWithMiddleware.get(freeFormBase64encodedPlainText, { maxAge: 0, transform: 'base64' });
-    const expiredResult2 = await providerWithMiddleware.get(freeFormBase64encodedPlainText, { maxAge: 0, transform: 'base64' });
+    const expiredResult1 = await providerWithMiddleware.get(
+      freeFormBase64encodedPlainText, { 
+        maxAge: 0, 
+        transform: 'base64' 
+      }
+    );
+    const expiredResult2 = await providerWithMiddleware.get(
+      freeFormBase64encodedPlainText, { 
+        maxAge: 0, 
+        transform: 'base64' 
+      }
+    );
     logger.log({
       test: 'get-expired',
       value: middleware.counter, // should be 2

--- a/packages/parameters/tests/e2e/appConfigProvider.class.test.functionCode.ts
+++ b/packages/parameters/tests/e2e/appConfigProvider.class.test.functionCode.ts
@@ -81,13 +81,11 @@ export const handler = async (_event: unknown, _context: Context): Promise<void>
   try {
     providerWithMiddleware.clearCache();
     middleware.counter = 0;
-    const result1 = await providerWithMiddleware.get(freeFormBase64encodedPlainText);
-    const result2 = await providerWithMiddleware.get(freeFormBase64encodedPlainText);
+    await providerWithMiddleware.get(freeFormBase64encodedPlainText);
+    await providerWithMiddleware.get(freeFormBase64encodedPlainText);
     logger.log({
       test: 'get-cached',
-      value: middleware.counter, // should be 1
-      result1: result1,
-      result2: result2
+      value: middleware.counter // should be 1
     });
   } catch (err) {
     logger.log({
@@ -119,8 +117,8 @@ export const handler = async (_event: unknown, _context: Context): Promise<void>
   try {
     providerWithMiddleware.clearCache();
     middleware.counter = 0;
-    const expiredResult1 = await providerWithMiddleware.get(freeFormBase64encodedPlainText, { maxAge: 0 });
-    const expiredResult2 = await providerWithMiddleware.get(freeFormBase64encodedPlainText, { maxAge: 0 });
+    const expiredResult1 = await providerWithMiddleware.get(freeFormBase64encodedPlainText, { maxAge: 0, transform: 'base64' });
+    const expiredResult2 = await providerWithMiddleware.get(freeFormBase64encodedPlainText, { maxAge: 0, transform: 'base64' });
     logger.log({
       test: 'get-expired',
       value: middleware.counter, // should be 2

--- a/packages/parameters/tests/e2e/appConfigProvider.class.test.ts
+++ b/packages/parameters/tests/e2e/appConfigProvider.class.test.ts
@@ -332,9 +332,11 @@ describe(`parameters E2E tests (appConfigProvider) for runtime ${runtime}`, () =
 
       expect(testLog).toStrictEqual({
         test: 'get-expired',
-        value: 2,
-        result1: result,
-        result2: result
+        value: {
+          counter: 2,
+          result1: result,
+          result2: result
+        }
       });
 
     }, TEST_CASE_TIMEOUT);

--- a/packages/parameters/tests/e2e/appConfigProvider.class.test.ts
+++ b/packages/parameters/tests/e2e/appConfigProvider.class.test.ts
@@ -147,7 +147,7 @@ describe(`parameters E2E tests (appConfigProvider) for runtime ${runtime}`, () =
         FREEFORM_BASE64_ENCODED_PLAIN_TEXT_NAME: freeFormBase64PlainTextName,
         FEATURE_FLAG_NAME: featureFlagName,
       },
-      runtime
+      runtime,
     });
 
     // Create the base resources for an AppConfig application.

--- a/packages/parameters/tests/e2e/appConfigProvider.class.test.ts
+++ b/packages/parameters/tests/e2e/appConfigProvider.class.test.ts
@@ -4,7 +4,7 @@
   * @group e2e/parameters/appconfig/class
   */
 import path from 'path';
-import { App, Stack, Aspects, Duration } from 'aws-cdk-lib';
+import { App, Stack, Aspects } from 'aws-cdk-lib';
 import { toBase64 } from '@aws-sdk/util-base64-node';
 import { v4 } from 'uuid';
 import { 
@@ -147,8 +147,7 @@ describe(`parameters E2E tests (appConfigProvider) for runtime ${runtime}`, () =
         FREEFORM_BASE64_ENCODED_PLAIN_TEXT_NAME: freeFormBase64PlainTextName,
         FEATURE_FLAG_NAME: featureFlagName,
       },
-      runtime,
-      timeout: Duration.seconds(10),
+      runtime
     });
 
     // Create the base resources for an AppConfig application.

--- a/packages/parameters/tests/e2e/appConfigProvider.class.test.ts
+++ b/packages/parameters/tests/e2e/appConfigProvider.class.test.ts
@@ -115,7 +115,7 @@ let stack: Stack;
  * check that we got matching results
  * 
  * Test 7
- * get parameter twice, wait for expiration betweenn
+ * get parameter twice, using maxAge to avoid primary cache
  * we count number of SDK requests and check that we made two API calls
  * and check that the values match
  * 
@@ -321,7 +321,7 @@ describe(`parameters E2E tests (appConfigProvider) for runtime ${runtime}`, () =
 
     }, TEST_CASE_TIMEOUT);
 
-    // Test 7 - get parameter twice, wait for expiration betweenn
+    // Test 7 - get parameter twice, using maxAge to avoid primary cache
     // we count number of SDK requests and check that we made two API calls
     // and check that the values match
     it('should retrieve single parameter twice, with expiration between and matching values', async () => {

--- a/packages/parameters/tests/e2e/appConfigProvider.class.test.ts
+++ b/packages/parameters/tests/e2e/appConfigProvider.class.test.ts
@@ -299,13 +299,10 @@ describe(`parameters E2E tests (appConfigProvider) for runtime ${runtime}`, () =
 
       const logs = invocationLogs[0].getFunctionLogs();
       const testLog = InvocationLogs.parseFunctionLog(logs[4]);
-      const result = freeFormBase64PlainTextValue;
 
       expect(testLog).toStrictEqual({
         test: 'get-cached',
-        value: 1,
-        result1: result,
-        result2: result
+        value: 1
       });
 
     }, TEST_CASE_TIMEOUT);

--- a/packages/parameters/tests/unit/AppConfigProvider.test.ts
+++ b/packages/parameters/tests/unit/AppConfigProvider.test.ts
@@ -4,6 +4,7 @@
  * @group unit/parameters/AppConfigProvider/class
  */
 import { AppConfigProvider } from '../../src/appconfig/index';
+import { ExpirableValue } from '../../src/ExpirableValue';
 import { AppConfigProviderOptions } from '../../src/types/AppConfigProvider';
 import {
   AppConfigDataClient,
@@ -286,5 +287,50 @@ describe('Class: AppConfigProvider', () => {
       // Act & Assess
       await expect(provider.getMultiple(path)).rejects.toThrow(errorMessage);
     });
+  });
+});
+
+describe('Class: ExpirableValue', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('Method: constructor', () => {
+    test('when created, it has ttl set to at least maxAge seconds from test start', () => {
+      // Prepare
+      const seconds = 10;
+      const nowTimestamp = Date.now();
+      const futureTimestampSeconds = nowTimestamp/1000+(seconds);
+
+      // Act
+      const expirableValue = new ExpirableValue('foo', seconds);
+
+      // Assess
+      expect(expirableValue.ttl).toBeGreaterThan(futureTimestampSeconds);
+    });
+  });
+
+  describe('Method: isExpired', () => {
+    test('when called, it returns true when maxAge is in the future', () => {
+      // Prepare
+      const seconds = 60;
+
+      // Act
+      const expirableValue = new ExpirableValue('foo', seconds);
+
+      // Assess
+      expect(expirableValue.isExpired()).toBeFalsy();
+    }); 
+
+    test('when called, it returns false when maxAge is in the past', () => {
+      // Prepare
+      const seconds = -60;
+
+      // Act
+      const expirableValue = new ExpirableValue('foo', seconds);
+
+      // Assess
+      expect(expirableValue.isExpired()).toBeTruthy();
+    }); 
   });
 });

--- a/packages/parameters/tests/unit/AppConfigProvider.test.ts
+++ b/packages/parameters/tests/unit/AppConfigProvider.test.ts
@@ -233,8 +233,6 @@ describe('Class: AppConfigProvider', () => {
 
     test('when session returns an empty configuration on the second call, it returns the last value', async () => {
 
-      client.reset();
-
       // Prepare
       const options: AppConfigProviderOptions = {
         application: 'MyApp',

--- a/packages/parameters/tests/unit/AppConfigProvider.test.ts
+++ b/packages/parameters/tests/unit/AppConfigProvider.test.ts
@@ -22,6 +22,10 @@ describe('Class: AppConfigProvider', () => {
     jest.clearAllMocks();
   });
 
+  afterEach(() => {
+    client.reset();
+  });
+
   describe('Method: constructor', () => {
     test('when the class instantiates without SDK client and client config it has default options', async () => {
       // Prepare


### PR DESCRIPTION
<!--- 1. Make sure you follow our Contributing Guidelines: https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/CONTRIBUTING.md -->
<!--- 2. Please follow the template, and do not remove any section in the template. If something is not applicable leave it empty, but leave it in the PR. -->

## Description of your changes

<!--- Include here a summary of the change. -->

<!--- Please include also relevant motivation and context. -->

<!--- List any dependencies that are required for this change. -->

<!--- If this PR is part of a sequence of related PRs or TODOs, list the high level TODO items. -->

Fixes #1363 

When AppConfig parameters were requested beyond the cache expiration, they were returning empty. This was due to AppConfig `GetLatestConfiguration` returning an empty response if the active session already has the latest value.

This change introduces a local cache inside the `AppConfigProvider` that returns the most recent non-empty value in this scenario, matching the behavior of the [Python PowerTools Repository](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/aws_lambda_powertools/utilities/parameters/appconfig.py#L121).

### How to verify this change

<!--- Add any applicable config, projects, screenshots or other resources -->
<!--- that can help us verify your changes. -->

<!--- Examples: -->
<!--- Screenshots, cloud configuration, anything helping us evaluate better. -->

I added unit and e2e tests that cover this scenario. The simplest way is to develop a Lambda that uses the Parameters library with the AppConfig Provider, then invoke it a series of times, waiting beyond the `maxAge` of the configured provider. Confirm that you get the same return value in cold start, within `maxAge`, and beyond `maxAge` scenarios.

### Related issues, RFCs

<!--- Add here the number (i.e. #42) to the Github Issue or RFC that is related to this PR. -->
<!--- If no issue is present the PR might get blocked and not be reviewed. -->
**Issue number:** 
#1363

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-typescript/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [x] I have made corresponding changes to the *documentation*
- [x] I have made corresponding changes to the *examples*
- [x] My changes generate *no new warnings*
- [x] The *code coverage* hasn't decreased
- [x] I have *added tests* that prove my change is effective and works
- [x] New and existing *unit tests pass* locally and in Github Actions
- [x] Any *dependent changes have been merged and published*
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

***Is it a breaking change?:*** NO

- [ ] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.