### PR TITLE
feat(metrics): type concept support high resolution metrics

### DIFF
--- a/packages/metrics/src/Metrics.ts
+++ b/packages/metrics/src/Metrics.ts
@@ -11,11 +11,13 @@ import {
   ExtraOptions,
   MetricUnit,
   MetricUnits,
+  MetricResolution
 } from './types';
 
 const MAX_METRICS_SIZE = 100;
 const MAX_DIMENSION_COUNT = 29;
 const DEFAULT_NAMESPACE = 'default_namespace';
+const DEFAULT_METRIC_RESOLUTION = MetricResolution.Standard; 
 
 /**
  * ## Intro
@@ -169,8 +171,9 @@ class Metrics extends Utility implements MetricsInterface {
    * @param unit
    * @param value
    */
-  public addMetric(name: string, unit: MetricUnit, value: number): void {
-    this.storeMetric(name, unit, value);
+
+  public addMetric(name: string, unit: MetricUnit, value: number, resolution?: MetricResolution): void {
+    this.storeMetric(name, unit, value, resolution ?? DEFAULT_METRIC_RESOLUTION );
     if (this.isSingleMetric) this.publishStoredMetrics();
   }
 
@@ -322,6 +325,7 @@ class Metrics extends Utility implements MetricsInterface {
     const metricDefinitions = Object.values(this.storedMetrics).map((metricDefinition) => ({
       Name: metricDefinition.name,
       Unit: metricDefinition.unit,
+      StorageResolution: metricDefinition.resolution
     }));
     if (metricDefinitions.length === 0 && this.shouldThrowOnEmptyMetrics) {
       throw new RangeError('The number of metrics recorded must be higher than zero');
@@ -479,7 +483,7 @@ class Metrics extends Utility implements MetricsInterface {
     }
   }
 
-  private storeMetric(name: string, unit: MetricUnit, value: number): void {
+  private storeMetric(name: string, unit: MetricUnit, value: number, resolution: MetricResolution): void {
     if (Object.keys(this.storedMetrics).length >= MAX_METRICS_SIZE) {
       this.publishStoredMetrics();
     }
@@ -489,6 +493,7 @@ class Metrics extends Utility implements MetricsInterface {
         unit,
         value,
         name,
+        resolution
       };
     } else {
       const storedMetric = this.storedMetrics[name];
@@ -501,4 +506,4 @@ class Metrics extends Utility implements MetricsInterface {
 
 }
 
-export { Metrics, MetricUnits };
+export { Metrics, MetricUnits, MetricResolution };

--- a/packages/metrics/src/MetricsInterface.ts
+++ b/packages/metrics/src/MetricsInterface.ts
@@ -1,11 +1,11 @@
 import { Metrics } from './Metrics';
-import { MetricUnit, EmfOutput, HandlerMethodDecorator, Dimensions, MetricsOptions } from './types';
+import { MetricUnit, MetricResolution, EmfOutput, HandlerMethodDecorator, Dimensions, MetricsOptions } from './types';
 
 interface MetricsInterface {
   addDimension(name: string, value: string): void
   addDimensions(dimensions: {[key: string]: string}): void
   addMetadata(key: string, value: string): void
-  addMetric(name: string, unit:MetricUnit, value:number): void
+  addMetric(name: string, unit:MetricUnit, value:number, resolution?: MetricResolution): void
   clearDimensions(): void
   clearMetadata(): void
   clearMetrics(): void

--- a/packages/metrics/src/types/MetricResolution.ts
+++ b/packages/metrics/src/types/MetricResolution.ts
@@ -1,0 +1,8 @@
+const MetricResolution = {
+  Standard: 60,
+  High: 1,
+} as const;
+
+type MetricResolution = typeof MetricResolution[keyof typeof MetricResolution];
+
+export { MetricResolution };

--- a/packages/metrics/src/types/Metrics.ts
+++ b/packages/metrics/src/types/Metrics.ts
@@ -2,6 +2,7 @@ import { Handler } from 'aws-lambda';
 import { LambdaInterface, AsyncHandler, SyncHandler } from '@aws-lambda-powertools/commons';
 import { ConfigServiceInterface } from '../config';
 import { MetricUnit } from './MetricUnit';
+import { MetricResolution } from './MetricResolution';
 
 type Dimensions = { [key: string]: string };
 
@@ -19,8 +20,8 @@ type EmfOutput = {
     Timestamp: number
     CloudWatchMetrics: {
       Namespace: string
-      Dimensions: [string[]]
-      Metrics: { Name: string; Unit: MetricUnit }[]
+      Dimensions: [string[]]   
+      Metrics: { Name: string; Unit: MetricUnit; StorageResolution: MetricResolution }[]
     }[]
   }
 };
@@ -60,6 +61,7 @@ type StoredMetric = {
   name: string
   unit: MetricUnit
   value: number | number[]
+  resolution: MetricResolution
 };
 
 type StoredMetrics = {

--- a/packages/metrics/src/types/index.ts
+++ b/packages/metrics/src/types/index.ts
@@ -1,2 +1,3 @@
 export * from './Metrics';
 export * from './MetricUnit';
+export * from './MetricResolution';

--- a/packages/metrics/tests/unit/middleware/middy.test.ts
+++ b/packages/metrics/tests/unit/middleware/middy.test.ts
@@ -4,7 +4,7 @@
  * @group unit/metrics/middleware
  */
 
-import { Metrics, MetricUnits, logMetrics } from '../../../../metrics/src';
+import { Metrics, MetricUnits, logMetrics, MetricResolution } from '../../../../metrics/src';
 import middy from '@middy/core';
 import { ExtraOptions } from '../../../src/types';
 
@@ -178,7 +178,7 @@ describe('Middy middleware', () => {
               {
                 Namespace: 'serverlessAirline',
                 Dimensions: [['service']],
-                Metrics: [{ Name: 'successfulBooking', Unit: 'Count' }],
+                Metrics: [{ Name: 'successfulBooking', Unit: 'Count', StorageResolution: MetricResolution.Standard }],
               },
             ],
           },
@@ -215,7 +215,7 @@ describe('Middy middleware', () => {
               {
                 Namespace: 'serverlessAirline',
                 Dimensions: [[ 'service', 'environment', 'aws_region', 'function_name' ]],
-                Metrics: [{ Name: 'ColdStart', Unit: 'Count' }],
+                Metrics: [{ Name: 'ColdStart', Unit: 'Count', StorageResolution: MetricResolution.Standard }],
               },
             ],
           },
@@ -235,7 +235,7 @@ describe('Middy middleware', () => {
               {
                 Namespace: 'serverlessAirline',
                 Dimensions: [[ 'service', 'environment', 'aws_region' ]],
-                Metrics: [{ Name: 'successfulBooking', Unit: 'Count' }],
+                Metrics: [{ Name: 'successfulBooking', Unit: 'Count', StorageResolution: MetricResolution.Standard }],
               },
             ],
           },
@@ -270,7 +270,7 @@ describe('Middy middleware', () => {
               {
                 Namespace: 'serverlessAirline',
                 Dimensions: [['service']],
-                Metrics: [{ Name: 'successfulBooking', Unit: 'Count' }],
+                Metrics: [{ Name: 'successfulBooking', Unit: 'Count', StorageResolution: MetricResolution.Standard }],
               },
             ],
           },
@@ -305,7 +305,7 @@ describe('Middy middleware', () => {
               {
                 Namespace: 'serverlessAirline',
                 Dimensions: [['service']],
-                Metrics: [{ Name: 'successfulBooking', Unit: 'Count' }],
+                Metrics: [{ Name: 'successfulBooking', Unit: 'Count', StorageResolution: MetricResolution.Standard }],
               },
             ],
           },


### PR DESCRIPTION
<!--- 1. Make sure you follow our Contributing Guidelines: https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/CONTRIBUTING.md -->
<!--- 2. Please follow the template, and do not remove any section in the template. If something is not applicable leave it empty, but leave it in the PR. -->

## Description of your changes

introduction of type `MetricResolution` for `Metrics` . 
to the type `MetricResolution` are assignable only the values 1 and 60, which mean High and Standard , respecting the EMF Documentation. 
addMetrics signature guides the developer to use the resolution of Metric as an optional parameter.
default metric resolution value is 60 , which means 1 minute.  
developer is guided at compile time and only the values 1 and 60 can be applied to the metric resolution type.
serialized metrics include the `StorageResolution` as key , respecting the EMF Documentation. 
stored metrics include the resolution of metric as part of the metric definition name, unit, resolution, respecting the EMF Documentation. 

<!--- Include here a summary of the change. -->

<!--- Please include also relevant motivation and context. -->

<!--- List any dependencies that are required for this change. -->

<!--- If this PR is part of a sequence of related PRs or TODOs, list the high level TODO items. -->

### How to verify this change

<!--- Add any applicable config, projects, screenshots or other resources -->
<!--- that can help us verify your changes. -->

a new test is written in Metrics.test.ts that exercises the type of Metric Resolution 
a concept test is also written to compare the DX,  type of metric resolution as const vs as enum .  
failing tests extended to include the `StorageResolution` as key , respecting the EMF Documentation. 
 
<!--- Examples: -->
<!--- Screenshots, cloud configuration, anything helping us evaluate better. -->

### Related issues, RFCs

<!--- Add here the number (i.e. #42) to the Github Issue or RFC that is related to this PR. -->
<!--- If no issue is present the PR might get blocked and not be reviewed. -->
**Issue number:** #1277

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-typescript/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [ ] I have made corresponding changes to the *documentation*
- [ ] I have made corresponding changes to the *examples*
- [x] My changes generate *no new warnings*
- [x] The *code coverage* hasn't decreased
- [x] I have *added tests* that prove my change is effective and works
- [x] New and existing *unit tests pass* locally and in Github Actions
- [ ] Any *dependent changes have been merged and published*
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

***Is it a breaking change?:*** NO

- [ ] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.