### PR TITLE
refactor(tracer): log warning instead of throwing when segment is not found

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5815,9 +5815,9 @@
       }
     },
     "node_modules/aws-xray-sdk-core": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/aws-xray-sdk-core/-/aws-xray-sdk-core-3.4.0.tgz",
-      "integrity": "sha512-PH3jqjUp8fTIaRa0i6fjJxXJSR9yDwldH1Qw7nMDNAouL7txsrSM6BhrQEjcaZ2mwfU0PNx8tsFQ+2/nfNdR1w==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/aws-xray-sdk-core/-/aws-xray-sdk-core-3.4.1.tgz",
+      "integrity": "sha512-HPQ+9GMF+yhDDXNKPp6HGAIv2yVapKTI7WRs2aN3TT+RxQkbmgO+3JlcMvRL2/lu0RqTVWoYCIhmF9/H/zRL1A==",
       "dependencies": {
         "@aws-sdk/service-error-classification": "^3.4.1",
         "@aws-sdk/types": "^3.4.1",
@@ -16792,7 +16792,7 @@
       "license": "MIT-0",
       "dependencies": {
         "@aws-lambda-powertools/commons": "^1.6.0",
-        "aws-xray-sdk-core": "^3.4.0"
+        "aws-xray-sdk-core": "^3.4.1"
       },
       "devDependencies": {
         "@aws-sdk/client-dynamodb": "^3.231.0",
@@ -17081,7 +17081,7 @@
         "@aws-sdk/client-dynamodb": "^3.231.0",
         "@types/promise-retry": "^1.1.3",
         "aws-sdk": "^2.1276.0",
-        "aws-xray-sdk-core": "^3.4.0",
+        "aws-xray-sdk-core": "3.4.1",
         "axios": "^1.2.1",
         "promise-retry": "^2.0.1"
       }
@@ -21326,9 +21326,9 @@
       "dev": true
     },
     "aws-xray-sdk-core": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/aws-xray-sdk-core/-/aws-xray-sdk-core-3.4.0.tgz",
-      "integrity": "sha512-PH3jqjUp8fTIaRa0i6fjJxXJSR9yDwldH1Qw7nMDNAouL7txsrSM6BhrQEjcaZ2mwfU0PNx8tsFQ+2/nfNdR1w==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/aws-xray-sdk-core/-/aws-xray-sdk-core-3.4.1.tgz",
+      "integrity": "sha512-HPQ+9GMF+yhDDXNKPp6HGAIv2yVapKTI7WRs2aN3TT+RxQkbmgO+3JlcMvRL2/lu0RqTVWoYCIhmF9/H/zRL1A==",
       "requires": {
         "@aws-sdk/service-error-classification": "^3.4.1",
         "@aws-sdk/types": "^3.4.1",

--- a/packages/tracer/package.json
+++ b/packages/tracer/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@aws-lambda-powertools/commons": "^1.6.0",
-    "aws-xray-sdk-core": "^3.4.0"
+    "aws-xray-sdk-core": "^3.4.1"
   },
   "keywords": [
     "aws",

--- a/packages/tracer/src/Tracer.ts
+++ b/packages/tracer/src/Tracer.ts
@@ -512,7 +512,7 @@ class Tracer extends Utility implements TracerInterface {
   }
   
   /**
-   * Get the active segment or subsegment in the current scope.
+   * Get the active segment or subsegment (if any) in the current scope.
    * 
    * Usually you won't need to call this method unless you are creating custom subsegments or using manual mode.
    *
@@ -531,7 +531,7 @@ class Tracer extends Utility implements TracerInterface {
    * }
    * ```
    * 
-   * @returns segment - The active segment or subsegment in the current scope.
+   * @returns segment - The active segment or subsegment in the current scope. Will log a warning and return `undefined` if no segment is found.
    */
   public getSegment(): Segment | Subsegment | undefined {
     if (!this.isTracingEnabled()) {

--- a/packages/tracer/src/Tracer.ts
+++ b/packages/tracer/src/Tracer.ts
@@ -153,6 +153,7 @@ class Tracer extends Utility implements TracerInterface {
     * @see https://docs.aws.amazon.com/xray/latest/devguide/xray-concepts.html#xray-concepts-errors
     *
     * @param error - Error to serialize as metadata
+    * @param [remote] - Whether the error was thrown by a remote service. Defaults to `false`
     */
   public addErrorAsMetadata(error: Error, remote?: boolean): void {
     if (!this.isTracingEnabled()) {

--- a/packages/tracer/src/Tracer.ts
+++ b/packages/tracer/src/Tracer.ts
@@ -531,7 +531,7 @@ class Tracer extends Utility implements TracerInterface {
    * }
    * ```
    * 
-   * @returns segment - The active segment or subsegment in the current scope. Will log a warning and return `undefined` if no segment is found.
+   * @returns The active segment or subsegment in the current scope. Will log a warning and return `undefined` if no segment is found.
    */
   public getSegment(): Segment | Subsegment | undefined {
     if (!this.isTracingEnabled()) {

--- a/packages/tracer/src/Tracer.ts
+++ b/packages/tracer/src/Tracer.ts
@@ -38,7 +38,7 @@ import { Segment, Subsegment } from 'aws-xray-sdk-core';
  * 
  * const tracer = new Tracer({ serviceName: 'serverlessAirline' });
  * 
-* const lambdaHandler = async (_event: any, _context: any) => {
+ * const lambdaHandler = async (_event: any, _context: any) => {
  *   ...
  * };
  * 
@@ -154,19 +154,24 @@ class Tracer extends Utility implements TracerInterface {
     *
     * @param error - Error to serialize as metadata
     */
-  public addErrorAsMetadata(error: Error): void {
+  public addErrorAsMetadata(error: Error, remote?: boolean): void {
     if (!this.isTracingEnabled()) {
       return;
     }
 
     const subsegment = this.getSegment();
+    if (subsegment === undefined) {
+
+      return;
+    }
+
     if (!this.captureError) {
       subsegment.addErrorFlag();
 
       return;
     }
 
-    subsegment.addError(error, false);
+    subsegment.addError(error, remote || false);
   }
 
   /**
@@ -527,13 +532,15 @@ class Tracer extends Utility implements TracerInterface {
    * 
    * @returns segment - The active segment or subsegment in the current scope.
    */
-  public getSegment(): Segment | Subsegment {
+  public getSegment(): Segment | Subsegment | undefined {
     if (!this.isTracingEnabled()) {
       return new Subsegment('## Dummy segment');
     }
     const segment = this.provider.getSegment();    
     if (segment === undefined) {
-      throw new Error('Failed to get the current sub/segment from the context.');
+      console.warn(
+        'Failed to get the current sub/segment from the context, this is likely because you are not using the Tracer in a Lambda function.'
+      );
     }
  
     return segment;
@@ -573,13 +580,7 @@ class Tracer extends Utility implements TracerInterface {
   public putAnnotation(key: string, value: string | number | boolean): void {
     if (!this.isTracingEnabled()) return;
 
-    const document = this.getSegment();
-    if (document instanceof Segment) {
-      console.warn('You cannot annotate the main segment in a Lambda execution environment');
-      
-      return;
-    }
-    document.addAnnotation(key, value);
+    this.provider.putAnnotation(key, value);
   }
   
   /**
@@ -606,15 +607,7 @@ class Tracer extends Utility implements TracerInterface {
   public putMetadata(key: string, value: unknown, namespace?: string | undefined): void {
     if (!this.isTracingEnabled()) return;
 
-    const document = this.getSegment();
-    if (document instanceof Segment) {
-      console.warn('You cannot add metadata to the main segment in a Lambda execution environment');
-      
-      return;
-    }
-    
-    namespace = namespace || this.serviceName;
-    document.addMetadata(key, value, namespace);
+    this.provider.putMetadata(key, value, namespace || this.serviceName);
   }
   
   /**

--- a/packages/tracer/src/TracerInterface.ts
+++ b/packages/tracer/src/TracerInterface.ts
@@ -2,7 +2,7 @@ import { CaptureLambdaHandlerOptions, CaptureMethodOptions, HandlerMethodDecorat
 import { Segment, Subsegment } from 'aws-xray-sdk-core';
 
 interface TracerInterface {
-  addErrorAsMetadata(error: Error): void
+  addErrorAsMetadata(error: Error, remote?: boolean): void
   addResponseAsMetadata(data?: unknown, methodName?: string): void
   addServiceNameAnnotation(): void
   annotateColdStart(): void
@@ -11,7 +11,7 @@ interface TracerInterface {
   captureAWSClient<T>(service: T): void | T
   captureLambdaHandler(options?: CaptureLambdaHandlerOptions): HandlerMethodDecorator
   captureMethod(options?: CaptureMethodOptions): MethodDecorator
-  getSegment(): Segment | Subsegment
+  getSegment(): Segment | Subsegment | undefined
   getRootXrayTraceId(): string | undefined
   isTracingEnabled(): boolean
   putAnnotation: (key: string, value: string | number | boolean) => void

--- a/packages/tracer/src/provider/ProviderService.ts
+++ b/packages/tracer/src/provider/ProviderService.ts
@@ -1,7 +1,25 @@
-import { ContextMissingStrategy } from 'aws-xray-sdk-core/dist/lib/context_utils';
+import {
+  ContextMissingStrategy
+} from 'aws-xray-sdk-core/dist/lib/context_utils';
 import { Namespace } from 'cls-hooked';
 import { ProviderServiceInterface } from '.';
-import { captureAWS, captureAWSClient, captureAWSv3Client, captureAsyncFunc, captureFunc, captureHTTPsGlobal, getNamespace, getSegment, setSegment, Segment, Subsegment, setContextMissingStrategy, setDaemonAddress, setLogger, Logger } from 'aws-xray-sdk-core';
+import {
+  captureAWS,
+  captureAWSClient,
+  captureAWSv3Client,
+  captureAsyncFunc,
+  captureFunc,
+  captureHTTPsGlobal,
+  getNamespace,
+  getSegment,
+  setSegment,
+  Segment,
+  Subsegment,
+  setContextMissingStrategy,
+  setDaemonAddress,
+  setLogger,
+  Logger
+} from 'aws-xray-sdk-core';
 
 class ProviderService implements ProviderServiceInterface {
   public captureAWS<T>(awssdk: T): T {
@@ -42,7 +60,7 @@ class ProviderService implements ProviderServiceInterface {
   }
 
   public putAnnotation(key: string, value: string | number | boolean): void {
-    const segment = getSegment();
+    const segment = this.getSegment();
     if (segment === undefined) {
       console.warn('No active segment or subsegment found, skipping annotation');
 
@@ -57,7 +75,7 @@ class ProviderService implements ProviderServiceInterface {
   }
 
   public putMetadata(key: string, value: unknown, namespace?: string): void {
-    const segment = getSegment();
+    const segment = this.getSegment();
     if (segment === undefined) {
       console.warn('No active segment or subsegment found, skipping metadata addition');
 

--- a/packages/tracer/src/provider/ProviderService.ts
+++ b/packages/tracer/src/provider/ProviderService.ts
@@ -4,7 +4,6 @@ import { ProviderServiceInterface } from '.';
 import { captureAWS, captureAWSClient, captureAWSv3Client, captureAsyncFunc, captureFunc, captureHTTPsGlobal, getNamespace, getSegment, setSegment, Segment, Subsegment, setContextMissingStrategy, setDaemonAddress, setLogger, Logger } from 'aws-xray-sdk-core';
 
 class ProviderService implements ProviderServiceInterface {
-  
   public captureAWS<T>(awssdk: T): T {
     return captureAWS(awssdk);
   }
@@ -40,6 +39,36 @@ class ProviderService implements ProviderServiceInterface {
 
   public getSegment(): Segment | Subsegment | undefined {
     return getSegment();
+  }
+
+  public putAnnotation(key: string, value: string | number | boolean): void {
+    const segment = getSegment();
+    if (segment === undefined) {
+      console.warn('No active segment or subsegment found, skipping annotation');
+
+      return;
+    }
+    if (segment instanceof Segment) {
+      console.warn('You cannot annotate the main segment in a Lambda execution environment');
+      
+      return;
+    }
+    segment.addAnnotation(key, value);
+  }
+
+  public putMetadata(key: string, value: unknown, namespace?: string): void {
+    const segment = getSegment();
+    if (segment === undefined) {
+      console.warn('No active segment or subsegment found, skipping metadata addition');
+
+      return;
+    }
+    if (segment instanceof Segment) {
+      console.warn('You cannot add metadata to the main segment in a Lambda execution environment');
+      
+      return;
+    }
+    segment.addMetadata(key, value, namespace);
   }
 
   public setContextMissingStrategy(strategy: unknown): void {

--- a/packages/tracer/src/provider/ProviderServiceInterface.ts
+++ b/packages/tracer/src/provider/ProviderServiceInterface.ts
@@ -25,6 +25,10 @@ interface ProviderServiceInterface {
   captureFunc(name: string, fcn: (subsegment?: Subsegment) => unknown, parent?: Segment | Subsegment): unknown
 
   captureHTTPsGlobal(): void
+
+  putAnnotation(key: string, value: string | number | boolean): void
+
+  putMetadata(key: string, value: unknown, namespace?: string): void
 }
 
 export {


### PR DESCRIPTION
<!--- 1. Make sure you follow our Contributing Guidelines: https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/CONTRIBUTING.md -->
<!--- 2. Please follow the template, and do not remove any section in the template. If something is not applicable leave it empty, but leave it in the PR. -->

## Description of your changes

As reported in #1356, the current behavior of the Tracer and corresponding middleware is fairly unforgiving when it comes to handling missing segments. Prior to this PR, when calling the `getSegment` method, if a segment is not found, an error would be thrown.

This can happen either when users try to retrieve the current segment outside of the context of a function invocation or when the trace data is malformed and the X-Ray SDK is not able to derive the current segment.

This behavior, if not handled properly, can cause a function invocation to fail, which might not be desirable given that for many customers tracing is considered best-effort.

This PR:
- aligns the Tracer utility with the X-Ray SDK so that if a segment is not found, a warning is logged instead of throwing
- improves the handling of missing segments in the `captureLambdaHandler` middleware in all stages to be more resilient
- bumps the `aws-xray-sdk-node` dependency to the latest version
- refactor and extracts some of the internal logic around current segment retrieval from the `Tracer` class to the `ProviderService` one

This PR closes #1356.

### How to verify this change

Check the existing tests as well as the newly added ones in the checks under this repo. Check also the results of [this successful integration test](https://github.com/awslabs/aws-lambda-powertools-typescript/actions/runs/4407673701).

### Related issues, RFCs

<!--- Add here the number (i.e. #42) to the Github Issue or RFC that is related to this PR. -->
<!--- If no issue is present the PR might get blocked and not be reviewed. -->
**Issue number:** #1356

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-typescript/#tenets)
- [x] I have performed a *self-review* of my own code
- [ ] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [ ] I have made corresponding changes to the *documentation*
- [ ] I have made corresponding changes to the *examples*
- [ ] My changes generate *no new warnings*
- [x] The *code coverage* hasn't decreased
- [x] I have *added tests* that prove my change is effective and works
- [x] New and existing *unit tests pass* locally and in Github Actions
- [ ] Any *dependent changes have been merged and published*
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

***Is it a breaking change?:*** NO

- [ ] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.