### PR TITLE
feat(parameters): ability to set `maxAge` and `decrypt` via environment variables

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -293,20 +293,22 @@ Core utilities such as Tracing, Logging, and Metrics will be available across al
 ???+ info
 	Explicit parameters take precedence over environment variables
 
-| Environment variable                         | Description                                                                                                   | Utility                   | Default             |
-| -------------------------------------------- | ------------------------------------------------------------------------------------------------------------- | ------------------------- | ------------------- |
-| **POWERTOOLS_SERVICE_NAME**                  | Sets service name used for tracing namespace, metrics dimension and structured logging                        | All                       | `service_undefined` |
-| **POWERTOOLS_METRICS_NAMESPACE**             | Sets namespace used for metrics                                                                               | [Metrics](./core/metrics) | `default_namespace` |
-| **POWERTOOLS_TRACE_ENABLED**                 | Explicitly disables tracing                                                                                   | [Tracer](./core/tracer)   | `true`              |
-| **POWERTOOLS_TRACER_CAPTURE_RESPONSE**       | Captures Lambda or method return as metadata.                                                                 | [Tracer](./core/tracer)   | `true`              |
-| **POWERTOOLS_TRACER_CAPTURE_ERROR**          | Captures Lambda or method exception as metadata.                                                              | [Tracer](./core/tracer)   | `true`              |
-| **POWERTOOLS_TRACER_CAPTURE_HTTPS_REQUESTS** | Captures HTTP(s) requests as segments.                                                                        | [Tracer](./core/tracer)   | `true`              |
-| **POWERTOOLS_LOGGER_LOG_EVENT**              | Logs incoming event                                                                                           | [Logger](./core/logger)   | `false`             |
-| **POWERTOOLS_LOGGER_SAMPLE_RATE**            | Debug log sampling                                                                                            | [Logger](./core/logger)   | `0`                 |
-| **POWERTOOLS_DEV**                           | Increase JSON indentation to ease debugging when running functions locally or in a non-production environment | [Logger](./core/logger)   | `false`             |
-| **LOG_LEVEL**                                | Sets logging level                                                                                            | [Logger](./core/logger)   | `INFO`              |
+| Environment variable                         | Description                                                                                                   | Utility                              | Default             |
+| -------------------------------------------- | ------------------------------------------------------------------------------------------------------------- | ------------------------------------ | ------------------- |
+| **POWERTOOLS_SERVICE_NAME**                  | Sets service name used for tracing namespace, metrics dimension and structured logging                        | All                                  | `service_undefined` |
+| **POWERTOOLS_METRICS_NAMESPACE**             | Sets namespace used for metrics                                                                               | [Metrics](./core/metrics)            | `default_namespace` |
+| **POWERTOOLS_TRACE_ENABLED**                 | Explicitly disables tracing                                                                                   | [Tracer](./core/tracer)              | `true`              |
+| **POWERTOOLS_TRACER_CAPTURE_RESPONSE**       | Captures Lambda or method return as metadata.                                                                 | [Tracer](./core/tracer)              | `true`              |
+| **POWERTOOLS_TRACER_CAPTURE_ERROR**          | Captures Lambda or method exception as metadata.                                                              | [Tracer](./core/tracer)              | `true`              |
+| **POWERTOOLS_TRACER_CAPTURE_HTTPS_REQUESTS** | Captures HTTP(s) requests as segments.                                                                        | [Tracer](./core/tracer)              | `true`              |
+| **POWERTOOLS_LOGGER_LOG_EVENT**              | Logs incoming event                                                                                           | [Logger](./core/logger)              | `false`             |
+| **POWERTOOLS_LOGGER_SAMPLE_RATE**            | Debug log sampling                                                                                            | [Logger](./core/logger)              | `0`                 |
+| **POWERTOOLS_DEV**                           | Increase JSON indentation to ease debugging when running functions locally or in a non-production environment | [Logger](./core/logger)              | `false`             |
+| **LOG_LEVEL**                                | Sets logging level                                                                                            | [Logger](./core/logger)              | `INFO`              |
+| **POWERTOOLS_PARAMETERS_MAX_AGE**            | Adjust how long values are kept in cache (in seconds)                                                         | [Parameters](./utilities/parameters) | `5`                 |
+| **POWERTOOLS_PARAMETERS_SSM_DECRYPT**        | Sets whether to decrypt or not values retrieved from AWS Systems Manager Parameters Store                     | [Parameters](./utilities/parameters) | `false`             |
 
-Each Utility page provides information on example values and allowed values
+Each Utility page provides information on example values and allowed values.
 
 ## Tenets
 

--- a/docs/snippets/parameters/adjustingCacheTTL.ts
+++ b/docs/snippets/parameters/adjustingCacheTTL.ts
@@ -3,12 +3,12 @@ import { SSMProvider } from '@aws-lambda-powertools/parameters/ssm';
 const parametersProvider = new SSMProvider();
 
 export const handler = async (): Promise<void> => {
-  // Retrieve a single parameter
-  const parameter = await parametersProvider.get('/my/parameter', { maxAge: 60 }); // 1 minute
+  // Retrieve a single parameter and cache it for 1 minute
+  const parameter = await parametersProvider.get('/my/parameter', { maxAge: 60 }); // (1)
   console.log(parameter);
 
-  // Retrieve multiple parameters from a path prefix
-  const parameters = await parametersProvider.getMultiple('/my/path/prefix', { maxAge: 120 }); // 2 minutes
+  // Retrieve multiple parameters from a path prefix and cache them for 2 minutes
+  const parameters = await parametersProvider.getMultiple('/my/path/prefix', { maxAge: 120 });
   for (const [ key, value ] of Object.entries(parameters || {})) {
     console.log(`${key}: ${value}`);
   }

--- a/docs/snippets/parameters/ssmProviderDecryptAndRecursive.ts
+++ b/docs/snippets/parameters/ssmProviderDecryptAndRecursive.ts
@@ -3,7 +3,7 @@ import { SSMProvider } from '@aws-lambda-powertools/parameters/ssm';
 const parametersProvider = new SSMProvider();
 
 export const handler = async (): Promise<void> => {
-  const decryptedValue = await parametersProvider.get('/my/encrypted/parameter', { decrypt: true });
+  const decryptedValue = await parametersProvider.get('/my/encrypted/parameter', { decrypt: true }); // (1)
   console.log(decryptedValue);
 
   const noRecursiveValues = await parametersProvider.getMultiple('/my/path/prefix', { recursive: false });

--- a/docs/utilities/parameters.md
+++ b/docs/utilities/parameters.md
@@ -127,16 +127,21 @@ The following will retrieve the latest version and store it in the cache.
 
 ### Adjusting cache TTL
 
-???+ tip
-	`maxAge` parameter is also available in high level functions like `getParameter`, `getSecret`, etc.
-
 By default, the provider will cache parameters retrieved in-memory for 5 seconds.
 
 You can adjust how long values should be kept in cache by using the param `maxAge`, when using  `get()` or `getMultiple()` methods across all providers.
 
+???+ tip
+	If you want to set the same TTL for all parameters, you can set the `POWERTOOLS_PARAMETERS_MAX_AGE` environment variable. **This will override the default TTL of 5 seconds but can be overridden by the `maxAge` parameter**.
+
 ```typescript hl_lines="7 11" title="Caching parameters values in memory for longer than 5 seconds"
 --8<-- "docs/snippets/parameters/adjustingCacheTTL.ts"
 ```
+
+1.  Options passed to `get()`, `getMultiple()`, and `getParametersByName()` will override the values set in `POWERTOOLS_PARAMETERS_MAX_AGE` environment variable.
+
+???+ info
+	The `maxAge` parameter is also available in high level functions like `getParameter`, `getSecret`, etc.
 
 ### Always fetching the latest
 
@@ -166,9 +171,14 @@ The AWS Systems Manager Parameter Store provider supports two additional argumen
 | **decrypt**   | `false` | Will automatically decrypt the parameter (see required [IAM Permissions](#iam-permissions)).  |
 | **recursive** | `true`  | For `getMultiple()` only, will fetch all parameter values recursively based on a path prefix. |
 
+???+ tip
+	If you want to always decrypt parameters, you can set the `POWERTOOLS_PARAMETERS_SSM_DECRYPT=true` environment variable. **This will override the default value of `false` but can be overridden by the `decrypt` parameter**.
+
 ```typescript hl_lines="6 9" title="Example with get() and getMultiple()"
 --8<-- "docs/snippets/parameters/ssmProviderDecryptAndRecursive.ts"
 ```
+
+1.  Options passed to `get()`, `getMultiple()`, and `getParametersByName()` will override the values set in `POWERTOOLS_PARAMETERS_SSM_DECRYPT` environment variable.
 
 #### SecretsProvider
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16764,6 +16764,7 @@
       "version": "1.7.0",
       "license": "MIT-0",
       "dependencies": {
+        "@aws-lambda-powertools/commons": "^1.7.0",
         "@aws-sdk/util-base64-node": "^3.209.0"
       },
       "devDependencies": {
@@ -17055,6 +17056,7 @@
     "@aws-lambda-powertools/parameters": {
       "version": "file:packages/parameters",
       "requires": {
+        "@aws-lambda-powertools/commons": "*",
         "@aws-sdk/client-appconfigdata": "^3.241.0",
         "@aws-sdk/client-dynamodb": "^3.245.0",
         "@aws-sdk/client-secrets-manager": "^3.238.0",

--- a/packages/commons/src/config/ConfigService.ts
+++ b/packages/commons/src/config/ConfigService.ts
@@ -24,6 +24,25 @@ abstract class ConfigService {
    */
   public abstract getServiceName(): string;
 
+  /**
+   * It returns the value of the _X_AMZN_TRACE_ID environment variable.
+   * 
+   * The AWS X-Ray Trace data available in the environment variable has this format:
+   * `Root=1-5759e988-bd862e3fe1be46a994272793;Parent=557abcec3ee5a047;Sampled=1`,
+   *
+   * The actual Trace ID is: `1-5759e988-bd862e3fe1be46a994272793`.
+   *
+   * @returns {string|undefined}
+   */
+  public abstract getXrayTraceId(): string | undefined;
+
+  /**
+   * It returns true if the string value represents a boolean true value.
+   *
+   * @param {string} value
+   * @returns boolean
+   */
+  public abstract isValueTrue(value: string): boolean;
 }
 
 export {

--- a/packages/commons/src/config/EnvironmentVariablesService.ts
+++ b/packages/commons/src/config/EnvironmentVariablesService.ts
@@ -60,6 +60,18 @@ class EnvironmentVariablesService extends ConfigService {
     return xRayTraceId.split(';')[0].replace('Root=', '');
   }
 
+  /**
+   * It returns true if the string value represents a boolean true value.
+   *
+   * @param {string} value
+   * @returns boolean
+   */
+  public isValueTrue(value: string): boolean {
+    const truthyValues: string[] = [ '1', 'y', 'yes', 't', 'true', 'on' ];
+
+    return truthyValues.includes(value.toLowerCase());
+  }
+
 }
 
 export {

--- a/packages/commons/tests/unit/config/EnvironmentVariablesService.test.ts
+++ b/packages/commons/tests/unit/config/EnvironmentVariablesService.test.ts
@@ -110,4 +110,31 @@ describe('Class: EnvironmentVariablesService', () => {
 
   });
 
+  describe('Method: isValueTrue', () => {
+
+    const valuesToTest: Array<Array<string | boolean>> = [
+      [ '1', true ],
+      [ 'y', true ],
+      [ 'yes', true ],
+      [ 't', true ],
+      [ 'TRUE', true ],
+      [ 'on', true ],
+      [ '', false ],
+      [ 'false', false ],
+      [ 'fasle', false ],
+      [ 'somethingsilly', false ],
+      [ '0', false ]
+    ];
+
+    test.each(valuesToTest)('it takes string "%s" and returns %s', (input, output) => {
+      // Prepare
+      const service = new EnvironmentVariablesService();
+      // Act
+      const value = service.isValueTrue(input as string);
+      // Assess
+      expect(value).toBe(output);
+    });
+    
+  });
+
 });

--- a/packages/logger/src/config/EnvironmentVariablesService.ts
+++ b/packages/logger/src/config/EnvironmentVariablesService.ts
@@ -117,18 +117,6 @@ class EnvironmentVariablesService extends CommonEnvironmentVariablesService impl
     return this.isValueTrue(value);
   }
 
-  /**
-   * It returns true if the string value represents a boolean true value.
-   *
-   * @param {string} value
-   * @returns boolean
-   */
-  public isValueTrue(value: string): boolean {
-    const truthyValues: string[] = [ '1', 'y', 'yes', 't', 'true', 'on' ];
-
-    return truthyValues.includes(value.toLowerCase());
-  }
-
 }
 
 export {

--- a/packages/logger/tests/unit/config/EnvironmentVariablesService.test.ts
+++ b/packages/logger/tests/unit/config/EnvironmentVariablesService.test.ts
@@ -249,31 +249,4 @@ describe('Class: EnvironmentVariablesService', () => {
 
   });
 
-  describe('Method: isValueTrue', () => {
-
-    const valuesToTest: Array<Array<string | boolean>> = [
-      [ '1', true ],
-      [ 'y', true ],
-      [ 'yes', true ],
-      [ 't', true ],
-      [ 'TRUE', true ],
-      [ 'on', true ],
-      [ '', false ],
-      [ 'false', false ],
-      [ 'fasle', false ],
-      [ 'somethingsilly', false ],
-      [ '0', false ]
-    ];
-
-    test.each(valuesToTest)('it takes string "%s" and returns %s', (input, output) => {
-      // Prepare
-      const service = new EnvironmentVariablesService();
-      // Act
-      const value = service.isValueTrue(input as string);
-      // Assess
-      expect(value).toBe(output);
-    });
-    
-  });
-
 });

--- a/packages/parameters/package.json
+++ b/packages/parameters/package.json
@@ -65,6 +65,7 @@
     "aws-sdk-client-mock-jest": "^2.0.1"
   },
   "dependencies": {
+    "@aws-lambda-powertools/commons": "^1.7.0",
     "@aws-sdk/util-base64-node": "^3.209.0"
   }
 }

--- a/packages/parameters/src/GetMultipleOptions.ts
+++ b/packages/parameters/src/GetMultipleOptions.ts
@@ -1,20 +1,21 @@
-import { DEFAULT_MAX_AGE_SECS } from './constants';
-import type { GetMultipleOptionsInterface, TransformOptions } from './types';
+import { GetOptions } from './GetOptions';
+import { EnvironmentVariablesService } from './config/EnvironmentVariablesService';
+import type { GetMultipleOptionsInterface } from './types';
 
 /**
  * Options for the `getMultiple` method.
  * 
- * It merges the default options with the provided options.
+ * Extends the `GetOptions` class and adds the `throwOnTransformError` option.
  */
-class GetMultipleOptions implements GetMultipleOptionsInterface {
-  public forceFetch: boolean = false;
-  public maxAge: number = DEFAULT_MAX_AGE_SECS;
-  public sdkOptions?: unknown;
+class GetMultipleOptions extends GetOptions implements GetMultipleOptionsInterface {
   public throwOnTransformError: boolean = false;
-  public transform?: TransformOptions;
 
-  public constructor(options: GetMultipleOptionsInterface) {
-    Object.assign(this, options);
+  public constructor(options: GetMultipleOptionsInterface = {}, envVarsService: EnvironmentVariablesService) {
+    super(options, envVarsService);
+
+    if (options.throwOnTransformError !== undefined) {
+      this.throwOnTransformError = options.throwOnTransformError;
+    }
   }
 }
 

--- a/packages/parameters/src/GetOptions.ts
+++ b/packages/parameters/src/GetOptions.ts
@@ -1,4 +1,5 @@
 import { DEFAULT_MAX_AGE_SECS } from './constants';
+import { EnvironmentVariablesService } from './config/EnvironmentVariablesService';
 import type { GetOptionsInterface, TransformOptions } from './types';
 
 /**
@@ -8,12 +9,16 @@ import type { GetOptionsInterface, TransformOptions } from './types';
  */
 class GetOptions implements GetOptionsInterface {
   public forceFetch: boolean = false;
-  public maxAge: number = DEFAULT_MAX_AGE_SECS;
+  public maxAge!: number;
   public sdkOptions?: unknown;
   public transform?: TransformOptions;
 
-  public constructor(options: GetOptionsInterface = {}) {
+  public constructor(options: GetOptionsInterface = {}, envVarsService: EnvironmentVariablesService) {
     Object.assign(this, options);
+
+    if (options.maxAge === undefined) {
+      this.maxAge = envVarsService.getParametersMaxAge() ?? DEFAULT_MAX_AGE_SECS;
+    }
   }
 }
 

--- a/packages/parameters/src/appconfig/AppConfigProvider.ts
+++ b/packages/parameters/src/appconfig/AppConfigProvider.ts
@@ -165,8 +165,8 @@ import type {
  */
 class AppConfigProvider extends BaseProvider {
   public client: AppConfigDataClient;
-  protected configurationTokenStore: Map<string, string> = new Map();
-  protected valueStore: Map<string, Uint8Array> = new Map();
+  protected configurationTokenStore = new Map<string, string>();
+  protected valueStore = new Map<string, Uint8Array>();
   private application?: string;
   private environment: string;
   
@@ -187,13 +187,12 @@ class AppConfigProvider extends BaseProvider {
       this.client = new AppConfigDataClient(options.clientConfig || {});
     }
     
-    if (!options?.application && !process.env['POWERTOOLS_SERVICE_NAME']) {
+    this.application = options?.application || this.envVarsService.getServiceName();
+    if (!this.application || this.application.trim().length === 0) {
       throw new Error(
         'Application name is not defined or POWERTOOLS_SERVICE_NAME is not set'
       );
     }
-    this.application =
-      options.application || process.env['POWERTOOLS_SERVICE_NAME'];
     this.environment = options.environment;
   }
 

--- a/packages/parameters/src/config/ConfigServiceInterface.ts
+++ b/packages/parameters/src/config/ConfigServiceInterface.ts
@@ -4,6 +4,10 @@ interface ConfigServiceInterface {
   
   getServiceName(): string
 
+  getParametersMaxAge(): number | undefined
+
+  getSSMDecrypt(): string
+
 }
 
 export {

--- a/packages/parameters/src/config/ConfigServiceInterface.ts
+++ b/packages/parameters/src/config/ConfigServiceInterface.ts
@@ -1,0 +1,11 @@
+interface ConfigServiceInterface {
+
+  get?(name: string): string
+  
+  getServiceName(): string
+
+}
+
+export {
+  ConfigServiceInterface,
+};

--- a/packages/parameters/src/config/EnvironmentVariablesService.ts
+++ b/packages/parameters/src/config/EnvironmentVariablesService.ts
@@ -1,4 +1,5 @@
 import { ConfigServiceInterface } from './ConfigServiceInterface';
+import { DEFAULT_MAX_AGE_SECS } from '../constants';
 import { EnvironmentVariablesService as CommonEnvironmentVariablesService } from '@aws-lambda-powertools/commons';
 
 class EnvironmentVariablesService extends CommonEnvironmentVariablesService implements ConfigServiceInterface {
@@ -12,12 +13,13 @@ class EnvironmentVariablesService extends CommonEnvironmentVariablesService impl
 
     if (maxAge.length === 0) return undefined;
     
-    try {
-      return parseInt(maxAge, 10);
-    } catch (error) {
+    const maxAgeAsNumber = parseInt(maxAge, 10);
+    if (isNaN(maxAgeAsNumber)) {
       console.warn(
-        `Invalid value for ${this.parametersMaxAgeVariable} environment variable: ${maxAge}, using default value of 5 seconds`
+        `Invalid value for ${this.parametersMaxAgeVariable} environment variable: [${maxAge}], using default value of ${DEFAULT_MAX_AGE_SECS} seconds`
       );
+    } else {
+      return maxAgeAsNumber;
     }
   }
 

--- a/packages/parameters/src/config/EnvironmentVariablesService.ts
+++ b/packages/parameters/src/config/EnvironmentVariablesService.ts
@@ -1,0 +1,32 @@
+import { ConfigServiceInterface } from './ConfigServiceInterface';
+import { EnvironmentVariablesService as CommonEnvironmentVariablesService } from '@aws-lambda-powertools/commons';
+
+class EnvironmentVariablesService extends CommonEnvironmentVariablesService implements ConfigServiceInterface {
+
+  // Environment variables
+  private parametersMaxAgeVariable = 'POWERTOOLS_PARAMETERS_MAX_AGE';
+  private ssmDecryptVariable = 'POWERTOOLS_PARAMETERS_SSM_DECRYPT';
+
+  public getParametersMaxAge(): number | undefined {
+    const maxAge = this.get(this.parametersMaxAgeVariable);
+
+    if (maxAge.length === 0) return undefined;
+    
+    try {
+      return parseInt(maxAge, 10);
+    } catch (error) {
+      console.warn(
+        `Invalid value for ${this.parametersMaxAgeVariable} environment variable: ${maxAge}, using default value of 5 seconds`
+      );
+    }
+  }
+
+  public getSSMDecrypt(): string {
+    return this.get(this.ssmDecryptVariable);
+  }
+
+}
+
+export {
+  EnvironmentVariablesService,
+};

--- a/packages/parameters/src/ssm/SSMProvider.ts
+++ b/packages/parameters/src/ssm/SSMProvider.ts
@@ -738,7 +738,7 @@ class SSMProvider extends BaseProvider {
   ): boolean | undefined {
     if (options?.decrypt !== undefined) return options.decrypt;
     if (sdkOptions?.WithDecryption !== undefined) return sdkOptions.WithDecryption;
-    if (this.envVarsService.getSSMDecrypt() !== undefined) {
+    if (this.envVarsService.getSSMDecrypt() !== '') {
       return this.envVarsService.isValueTrue(this.envVarsService.getSSMDecrypt());
     }
 

--- a/packages/parameters/src/ssm/SSMProvider.ts
+++ b/packages/parameters/src/ssm/SSMProvider.ts
@@ -414,7 +414,7 @@ class SSMProvider extends BaseProvider {
     options?: SSMGetParametersByNameOptionsInterface
   ): Promise<Record<string, unknown>> {
     const configs = { ...{
-      decrypt: false,
+      decrypt: this.resolveDecryptionConfigValue({}) || false,
       maxAge: DEFAULT_MAX_AGE_SECS,
       throwOnError: true,
     }, ...options };
@@ -477,8 +477,7 @@ class SSMProvider extends BaseProvider {
       ...(options?.sdkOptions || {}),
       Name: name,
     };
-    sdkOptions.WithDecryption = options?.decrypt !== undefined ?
-      options.decrypt : sdkOptions.WithDecryption;
+    sdkOptions.WithDecryption = this.resolveDecryptionConfigValue(options, sdkOptions);
     const result = await this.client.send(new GetParameterCommand(sdkOptions));
 
     return result.Parameter?.Value;
@@ -501,8 +500,7 @@ class SSMProvider extends BaseProvider {
     const paginationOptions: PaginationConfiguration = {
       client: this.client
     };
-    sdkOptions.WithDecryption = options?.decrypt !== undefined ?
-      options.decrypt : sdkOptions.WithDecryption;
+    sdkOptions.WithDecryption = this.resolveDecryptionConfigValue(options, sdkOptions);
     sdkOptions.Recursive = options?.recursive !== undefined ?
       options.recursive : sdkOptions.Recursive;
     paginationOptions.pageSize = sdkOptions.MaxResults !== undefined ?
@@ -732,6 +730,19 @@ class SSMProvider extends BaseProvider {
     }
 
     return errors;
+  }
+
+  protected resolveDecryptionConfigValue(
+    options: SSMGetOptionsInterface | SSMGetMultipleOptionsInterface = {},
+    sdkOptions?: GetParameterCommandInput | GetParametersByPathCommandInput
+  ): boolean | undefined {
+    if (options?.decrypt !== undefined) return options.decrypt;
+    if (sdkOptions?.WithDecryption !== undefined) return sdkOptions.WithDecryption;
+    if (this.envVarsService.getSSMDecrypt() !== undefined) {
+      return this.envVarsService.isValueTrue(this.envVarsService.getSSMDecrypt());
+    }
+
+    return undefined;
   }
 
   /**

--- a/packages/parameters/tests/unit/config/EnvironmentVariablesService.test.ts
+++ b/packages/parameters/tests/unit/config/EnvironmentVariablesService.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Test Parameters EnvironmentVariablesService class
+ *
+ * @group unit/parameters/config
+ */
+import { EnvironmentVariablesService } from '../../../src/config/EnvironmentVariablesService';
+
+describe('Class: EnvironmentVariablesService', () => {
+
+  const ENVIRONMENT_VARIABLES = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...ENVIRONMENT_VARIABLES };
+  });
+
+  afterAll(() => {
+    process.env = ENVIRONMENT_VARIABLES;
+  });
+
+  describe('Method: getParametersMaxAge', () => {
+
+    test('it returns undefined if the POWERTOOLS_PARAMETERS_MAX_AGE is empty', () => {
+
+      // Prepare
+      const service = new EnvironmentVariablesService();
+
+      // Act
+      const value = service.getParametersMaxAge();
+
+      // Assess
+      expect(value).toEqual(undefined);
+
+    });
+
+    test('it returns a number if the POWERTOOLS_PARAMETERS_MAX_AGE has a numeric value', () => {
+
+      // Prepare
+      process.env.POWERTOOLS_PARAMETERS_MAX_AGE = '36';
+      const service = new EnvironmentVariablesService();
+
+      // Act
+      const value = service.getParametersMaxAge();
+
+      // Assess
+      expect(value).toEqual(36);
+
+    });
+    
+    test('it logs a warning if the POWERTOOLS_PARAMETERS_MAX_AGE has a non-numeric value', () => {
+
+      // Prepare
+      process.env.POWERTOOLS_PARAMETERS_MAX_AGE = 'invalid';
+      const service = new EnvironmentVariablesService();
+      const warnLogspy = jest.spyOn(console, 'warn').mockImplementation();
+
+      // Act
+      const value = service.getParametersMaxAge();
+
+      // Assess
+      expect(value).toEqual(undefined);
+      expect(warnLogspy)
+        .toHaveBeenCalledWith(
+          'Invalid value for POWERTOOLS_PARAMETERS_MAX_AGE environment variable: [invalid], using default value of 5 seconds'
+        );
+
+    });
+
+  });
+
+  describe('Method: getSSMDecrypt', () => {
+
+    test('it returns the value of the environment variable POWERTOOLS_PARAMETERS_SSM_DECRYPT', () => {
+
+      // Prepare
+      process.env.POWERTOOLS_PARAMETERS_SSM_DECRYPT = 'true';
+      const service = new EnvironmentVariablesService();
+
+      // Act
+      const value = service.getSSMDecrypt();
+
+      // Assess
+      expect(value).toEqual('true');
+    });
+
+  });
+
+});


### PR DESCRIPTION
<!--- 1. Make sure you follow our Contributing Guidelines: https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/CONTRIBUTING.md -->
<!--- 2. Please follow the template, and do not remove any section in the template. If something is not applicable leave it empty, but leave it in the PR. -->

## Description of your changes

This PR introduces two new environment variables to configure the behavior of the Parameters utility around caching (`maxAge`) and decryption (for SSM only).

### Problem statement
Today the utility allows customers to configure caching and decryption via arguments passed to the utility functions or class methods. This allows to configure the retrieval and lifecycle of parameter values in a granular way.

Some customers however want to have shared settings that apply to all parameter values. For this reason we are adding two environment variables: `POWERTOOLS_PARAMETERS_MAX_AGE` and `POWERTOOLS_PARAMETERS_SSM_DECRYPT` that once set will apply to all parameter retrievals.

### Additional info on the changes

Prior to this PR the Parameters utility was using environment variables only in one instance and only in the `AppConfigProvider`. With the introduction of these new environment variables this PR adds the `EnvironmentVariablesService` from the `commons` package to this library. With this service the Parameters utility has now access to shared utilities that allow to read and standardize the env vars retrieval.

Once merged this PR will close #1380.

### Related issues, RFCs

<!--- Add here the number (i.e. #42) to the Github Issue or RFC that is related to this PR. -->
<!--- If no issue is present the PR might get blocked and not be reviewed. -->
**Issue number:** #1380

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-typescript/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [x] I have made corresponding changes to the *documentation*
- [ ] I have made corresponding changes to the *examples*
- [x] My changes generate *no new warnings*
- [x] The *code coverage* hasn't decreased
- [x] I have *added tests* that prove my change is effective and works
- [x] New and existing *unit tests pass* locally and in Github Actions
- [x] Any *dependent changes have been merged and published*
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

***Is it a breaking change?:*** NO

- [ ] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.