### PR TITLE
feat(parameters): stronger types for SSM getParameter

### DIFF
--- a/packages/parameters/src/ssm/SSMProvider.ts
+++ b/packages/parameters/src/ssm/SSMProvider.ts
@@ -16,7 +16,9 @@ import type {
 import type {
   SSMProviderOptions,
   SSMGetMultipleOptionsInterface,
-  SSMGetOptionsInterface,
+  SSMGetOptions,
+  SSMGetOptionsUnion,
+  SSMGetOutput,
   SSMGetParametersByNameOutputInterface,
   SSMGetParametersByNameOptionsInterface,
   SSMSplitBatchAndDecryptParametersOutputType,
@@ -315,11 +317,11 @@ class SSMProvider extends BaseProvider {
    * @param {SSMGetOptionsInterface} options - Options to configure the provider
    * @see https://awslabs.github.io/aws-lambda-powertools-typescript/latest/utilities/parameters/
    */
-  public async get(
+  public async get<O extends SSMGetOptionsUnion | undefined = undefined>(
     name: string,
-    options?: SSMGetOptionsInterface | undefined
-  ): Promise<string | Record<string, unknown> | undefined> {
-    return super.get(name, options) as Promise<string | Record<string, unknown> | undefined>;
+    options?: O & SSMGetOptions
+  ): Promise<SSMGetOutput<O> | undefined> {
+    return super.get(name, options) as Promise<SSMGetOutput<O> | undefined>;
   }
 
   /**
@@ -471,7 +473,7 @@ class SSMProvider extends BaseProvider {
    */
   protected async _get(
     name: string,
-    options?: SSMGetOptionsInterface
+    options?: SSMGetOptions
   ): Promise<string | undefined> {
     const sdkOptions: GetParameterCommandInput = {
       ...(options?.sdkOptions || {}),

--- a/packages/parameters/src/ssm/SSMProvider.ts
+++ b/packages/parameters/src/ssm/SSMProvider.ts
@@ -15,10 +15,12 @@ import type {
 } from '@aws-sdk/client-ssm';
 import type {
   SSMProviderOptions,
-  SSMGetMultipleOptionsInterface,
   SSMGetOptions,
   SSMGetOptionsUnion,
   SSMGetOutput,
+  SSMGetMultipleOptions,
+  SSMGetMultipleOptionsUnion,
+  SSMGetMultipleOutput,
   SSMGetParametersByNameOutputInterface,
   SSMGetParametersByNameOptionsInterface,
   SSMSplitBatchAndDecryptParametersOutputType,
@@ -314,7 +316,7 @@ class SSMProvider extends BaseProvider {
    * For usage examples check {@link SSMProvider}.
    *
    * @param {string} name - The name of the value to retrieve (i.e. the partition key)
-   * @param {SSMGetOptionsInterface} options - Options to configure the provider
+   * @param {SSMGetOptions} options - Options to configure the provider
    * @see https://awslabs.github.io/aws-lambda-powertools-typescript/latest/utilities/parameters/
    */
   public async get<O extends SSMGetOptionsUnion | undefined = undefined>(
@@ -351,14 +353,14 @@ class SSMProvider extends BaseProvider {
    * For usage examples check {@link SSMProvider}.
    *
    * @param {string} path - The path of the parameters to retrieve
-   * @param {SSMGetMultipleOptionsInterface} options - Options to configure the retrieval
+   * @param {SSMGetMultipleOptions} options - Options to configure the retrieval
    * @see https://awslabs.github.io/aws-lambda-powertools-typescript/latest/utilities/parameters/
    */
-  public async getMultiple(
+  public async getMultiple<O extends SSMGetMultipleOptionsUnion | undefined = undefined>(
     path: string,
-    options?: SSMGetMultipleOptionsInterface | undefined
-  ): Promise<undefined | Record<string, unknown>> {
-    return super.getMultiple(path, options);
+    options?: O & SSMGetMultipleOptions
+  ): Promise<SSMGetMultipleOutput<O> | undefined> {
+    return super.getMultiple(path, options) as Promise<SSMGetMultipleOutput<O> | undefined>;
   }
 
   /**
@@ -469,7 +471,7 @@ class SSMProvider extends BaseProvider {
    * Retrieve a parameter from AWS Systems Manager.
    *
    * @param {string} name - Name of the parameter to retrieve
-   * @param {SSMGetOptionsInterface} options - Options to customize the retrieval
+   * @param {SSMGetOptions} options - Options to customize the retrieval
    */
   protected async _get(
     name: string,
@@ -489,11 +491,11 @@ class SSMProvider extends BaseProvider {
    * Retrieve multiple items from AWS Systems Manager.
    *
    * @param {string} path - The path of the parameters to retrieve
-   * @param {SSMGetMultipleOptionsInterface} options - Options to configure the provider
+   * @param {SSMGetMultipleOptions} options - Options to configure the provider
    */
   protected async _getMultiple(
     path: string,
-    options?: SSMGetMultipleOptionsInterface
+    options?: SSMGetMultipleOptions
   ): Promise<Record<string, string | undefined>> {
     const sdkOptions: GetParametersByPathCommandInput = {
       ...(options?.sdkOptions || {}),

--- a/packages/parameters/src/ssm/SSMProvider.ts
+++ b/packages/parameters/src/ssm/SSMProvider.ts
@@ -737,7 +737,7 @@ class SSMProvider extends BaseProvider {
   }
 
   protected resolveDecryptionConfigValue(
-    options: SSMGetOptionsInterface | SSMGetMultipleOptionsInterface = {},
+    options: SSMGetOptions | SSMGetMultipleOptions = {},
     sdkOptions?: GetParameterCommandInput | GetParametersByPathCommandInput
   ): boolean | undefined {
     if (options?.decrypt !== undefined) return options.decrypt;

--- a/packages/parameters/src/ssm/SSMProvider.ts
+++ b/packages/parameters/src/ssm/SSMProvider.ts
@@ -16,11 +16,11 @@ import type {
 import type {
   SSMProviderOptions,
   SSMGetOptions,
-  SSMGetOptionsUnion,
   SSMGetOutput,
   SSMGetMultipleOptions,
   SSMGetMultipleOptionsUnion,
   SSMGetMultipleOutput,
+  SSMGetParametersByNameOutput,
   SSMGetParametersByNameOutputInterface,
   SSMGetParametersByNameOptionsInterface,
   SSMSplitBatchAndDecryptParametersOutputType,
@@ -319,11 +319,11 @@ class SSMProvider extends BaseProvider {
    * @param {SSMGetOptions} options - Options to configure the provider
    * @see https://awslabs.github.io/aws-lambda-powertools-typescript/latest/utilities/parameters/
    */
-  public async get<O extends SSMGetOptionsUnion | undefined = undefined>(
+  public async get<T = undefined, O extends SSMGetOptions | undefined = SSMGetOptions>(
     name: string,
     options?: O & SSMGetOptions
-  ): Promise<SSMGetOutput<O> | undefined> {
-    return super.get(name, options) as Promise<SSMGetOutput<O> | undefined>;
+  ): Promise<SSMGetOutput<T, O> | undefined> {
+    return super.get(name, options) as Promise<SSMGetOutput<T, O> | undefined>;
   }
 
   /**
@@ -356,11 +356,11 @@ class SSMProvider extends BaseProvider {
    * @param {SSMGetMultipleOptions} options - Options to configure the retrieval
    * @see https://awslabs.github.io/aws-lambda-powertools-typescript/latest/utilities/parameters/
    */
-  public async getMultiple<O extends SSMGetMultipleOptionsUnion | undefined = undefined>(
+  public async getMultiple<T = undefined, O extends SSMGetMultipleOptionsUnion | undefined = undefined>(
     path: string,
     options?: O & SSMGetMultipleOptions
-  ): Promise<SSMGetMultipleOutput<O> | undefined> {
-    return super.getMultiple(path, options) as Promise<SSMGetMultipleOutput<O> | undefined>;
+  ): Promise<SSMGetMultipleOutput<T, O> | undefined> {
+    return super.getMultiple(path, options) as Promise<SSMGetMultipleOutput<T, O> | undefined>;
   }
 
   /**
@@ -413,10 +413,10 @@ class SSMProvider extends BaseProvider {
    * @param {SSMGetParametersByNameOptionsInterface} options - Options to configure the retrieval
    * @see https://awslabs.github.io/aws-lambda-powertools-typescript/latest/utilities/parameters/
    */
-  public async getParametersByName(
+  public async getParametersByName<T = undefined>(
     parameters: Record<string, SSMGetParametersByNameOptionsInterface>,
     options?: SSMGetParametersByNameOptionsInterface
-  ): Promise<Record<string, unknown>> {
+  ): Promise<SSMGetParametersByNameOutput<T>> {
     const configs = { ...{
       decrypt: this.resolveDecryptionConfigValue({}) || false,
       maxAge: DEFAULT_MAX_AGE_SECS,
@@ -464,7 +464,7 @@ class SSMProvider extends BaseProvider {
       }
     }
 
-    return response;
+    return response as unknown as Promise<SSMGetParametersByNameOutput<T>>;
   }
 
   /**

--- a/packages/parameters/src/ssm/getParameter.ts
+++ b/packages/parameters/src/ssm/getParameter.ts
@@ -1,5 +1,9 @@
 import { SSMProvider, DEFAULT_PROVIDERS } from './SSMProvider';
-import type { SSMGetOptionsInterface } from '../types/SSMProvider';
+import type {
+  SSMGetOptions,
+  SSMGetOptionsUnion,
+  SSMGetOutput,
+} from '../types/SSMProvider';
 
 /**
  * ## Intro
@@ -136,15 +140,15 @@ import type { SSMGetOptionsInterface } from '../types/SSMProvider';
  * @param {SSMGetOptionsInterface} options - Options to configure the provider
  * @see https://awslabs.github.io/aws-lambda-powertools-typescript/latest/utilities/parameters/
  */
-const getParameter = (
+const getParameter = <O extends SSMGetOptionsUnion | undefined = undefined>(
   name: string,
-  options?: SSMGetOptionsInterface
-): Promise<undefined | string | Record<string, unknown>> => {
+  options?: O & SSMGetOptions
+): Promise<SSMGetOutput<O> | undefined> => {
   if (!DEFAULT_PROVIDERS.hasOwnProperty('ssm')) {
     DEFAULT_PROVIDERS.ssm = new SSMProvider();
   }
 
-  return (DEFAULT_PROVIDERS.ssm as SSMProvider).get(name, options);
+  return (DEFAULT_PROVIDERS.ssm as SSMProvider).get(name, options) as Promise<SSMGetOutput<O> | undefined>;
 };
 
 export {

--- a/packages/parameters/src/ssm/getParameter.ts
+++ b/packages/parameters/src/ssm/getParameter.ts
@@ -137,7 +137,7 @@ import type {
  * For more usage examples, see [our documentation](https://awslabs.github.io/aws-lambda-powertools-typescript/latest/utilities/parameters/).
  *
  * @param {string} name - The name of the parameter to retrieve
- * @param {SSMGetOptionsInterface} options - Options to configure the provider
+ * @param {SSMGetOptions} options - Options to configure the provider
  * @see https://awslabs.github.io/aws-lambda-powertools-typescript/latest/utilities/parameters/
  */
 const getParameter = <O extends SSMGetOptionsUnion | undefined = undefined>(
@@ -148,7 +148,9 @@ const getParameter = <O extends SSMGetOptionsUnion | undefined = undefined>(
     DEFAULT_PROVIDERS.ssm = new SSMProvider();
   }
 
-  return (DEFAULT_PROVIDERS.ssm as SSMProvider).get(name, options) as Promise<SSMGetOutput<O> | undefined>;
+  return (
+    DEFAULT_PROVIDERS.ssm as SSMProvider
+  ).get(name, options) as Promise<SSMGetOutput<O> | undefined>;
 };
 
 export {

--- a/packages/parameters/src/ssm/getParameter.ts
+++ b/packages/parameters/src/ssm/getParameter.ts
@@ -1,7 +1,6 @@
 import { SSMProvider, DEFAULT_PROVIDERS } from './SSMProvider';
 import type {
   SSMGetOptions,
-  SSMGetOptionsUnion,
   SSMGetOutput,
 } from '../types/SSMProvider';
 
@@ -140,17 +139,17 @@ import type {
  * @param {SSMGetOptions} options - Options to configure the provider
  * @see https://awslabs.github.io/aws-lambda-powertools-typescript/latest/utilities/parameters/
  */
-const getParameter = <O extends SSMGetOptionsUnion | undefined = undefined>(
+const getParameter = <T = undefined, O extends SSMGetOptions | undefined = SSMGetOptions>(
   name: string,
   options?: O & SSMGetOptions
-): Promise<SSMGetOutput<O> | undefined> => {
+): Promise<SSMGetOutput<T, O> | undefined> => {
   if (!DEFAULT_PROVIDERS.hasOwnProperty('ssm')) {
     DEFAULT_PROVIDERS.ssm = new SSMProvider();
   }
 
   return (
     DEFAULT_PROVIDERS.ssm as SSMProvider
-  ).get(name, options) as Promise<SSMGetOutput<O> | undefined>;
+  ).get(name, options) as Promise<SSMGetOutput<T, O> | undefined>;
 };
 
 export {

--- a/packages/parameters/src/ssm/getParameters.ts
+++ b/packages/parameters/src/ssm/getParameters.ts
@@ -1,5 +1,9 @@
 import { SSMProvider, DEFAULT_PROVIDERS } from './SSMProvider';
-import type { SSMGetMultipleOptionsInterface } from '../types/SSMProvider';
+import type {
+  SSMGetMultipleOptions,
+  SSMGetMultipleOptionsUnion,
+  SSMGetMultipleOutput,
+} from '../types/SSMProvider';
 
 /**
  * ## Intro
@@ -134,18 +138,20 @@ import type { SSMGetMultipleOptionsInterface } from '../types/SSMProvider';
  * For more usage examples, see [our documentation](https://awslabs.github.io/aws-lambda-powertools-typescript/latest/utilities/parameters/).
  *
  * @param {string} path - The path of the parameters to retrieve
- * @param {SSMGetMultipleOptionsInterface} options - Options to configure the provider
+ * @param {SSMGetMultipleOptions} options - Options to configure the provider
  * @see https://awslabs.github.io/aws-lambda-powertools-typescript/latest/utilities/parameters/
  */
-const getParameters = (
+const getParameters = <O extends SSMGetMultipleOptionsUnion | undefined = undefined>(
   path: string,
-  options?: SSMGetMultipleOptionsInterface
-): Promise<undefined | Record<string, unknown>> => {
+  options?: O & SSMGetMultipleOptions
+): Promise<SSMGetMultipleOutput<O> | undefined> => {
   if (!DEFAULT_PROVIDERS.hasOwnProperty('ssm')) {
     DEFAULT_PROVIDERS.ssm = new SSMProvider();
   }
 
-  return (DEFAULT_PROVIDERS.ssm as SSMProvider).getMultiple(path, options);
+  return (
+    DEFAULT_PROVIDERS.ssm as SSMProvider
+  ).getMultiple(path, options) as Promise<SSMGetMultipleOutput<O> | undefined>;
 };
 
 export {

--- a/packages/parameters/src/ssm/getParameters.ts
+++ b/packages/parameters/src/ssm/getParameters.ts
@@ -141,17 +141,17 @@ import type {
  * @param {SSMGetMultipleOptions} options - Options to configure the provider
  * @see https://awslabs.github.io/aws-lambda-powertools-typescript/latest/utilities/parameters/
  */
-const getParameters = <O extends SSMGetMultipleOptionsUnion | undefined = undefined>(
+const getParameters = <T = undefined, O extends SSMGetMultipleOptionsUnion | undefined = SSMGetMultipleOptionsUnion>(
   path: string,
   options?: O & SSMGetMultipleOptions
-): Promise<SSMGetMultipleOutput<O> | undefined> => {
+): Promise<SSMGetMultipleOutput<T, O> | undefined> => {
   if (!DEFAULT_PROVIDERS.hasOwnProperty('ssm')) {
     DEFAULT_PROVIDERS.ssm = new SSMProvider();
   }
 
   return (
     DEFAULT_PROVIDERS.ssm as SSMProvider
-  ).getMultiple(path, options) as Promise<SSMGetMultipleOutput<O> | undefined>;
+  ).getMultiple(path, options) as Promise<SSMGetMultipleOutput<T, O> | undefined>;
 };
 
 export {

--- a/packages/parameters/src/ssm/getParametersByName.ts
+++ b/packages/parameters/src/ssm/getParametersByName.ts
@@ -1,6 +1,7 @@
 import { SSMProvider, DEFAULT_PROVIDERS } from './SSMProvider';
 import type {
-  SSMGetParametersByNameOptionsInterface
+  SSMGetParametersByNameOptionsInterface,
+  SSMGetParametersByNameOutput,
 } from '../types/SSMProvider';
 
 /**
@@ -160,15 +161,17 @@ import type {
  * @param {SSMGetParametersByNameOptionsInterface} options - Options to configure the provider
  * @see https://awslabs.github.io/aws-lambda-powertools-typescript/latest/utilities/parameters/
  */
-const getParametersByName = (
+const getParametersByName = <T = undefined>(
   parameters: Record<string, SSMGetParametersByNameOptionsInterface>,
   options?: SSMGetParametersByNameOptionsInterface
-): Promise<Record<string, unknown> & { _errors?: string[] }> => {
+): Promise<SSMGetParametersByNameOutput<T>> => {
   if (!DEFAULT_PROVIDERS.hasOwnProperty('ssm')) {
     DEFAULT_PROVIDERS.ssm = new SSMProvider();
   }
 
-  return (DEFAULT_PROVIDERS.ssm as SSMProvider).getParametersByName(parameters, options);
+  return (
+    DEFAULT_PROVIDERS.ssm as SSMProvider
+  ).getParametersByName(parameters, options) as Promise<SSMGetParametersByNameOutput<T>>;
 };
 
 export {

--- a/packages/parameters/src/types/BaseProvider.ts
+++ b/packages/parameters/src/types/BaseProvider.ts
@@ -25,9 +25,9 @@ interface GetOptionsInterface {
    */
   sdkOptions?: unknown
   /**
-   * Transform to be applied, can be 'json', 'binary', or 'auto'.
+   * Transform to be applied, can be `json` or `binary`.
    */
-  transform?: TransformOptions
+  transform?: Omit<TransformOptions, 'auto'>
 }
 
 /**
@@ -40,6 +40,10 @@ interface GetOptionsInterface {
  * @property {boolean} throwOnTransformError - Whether to throw an error if a value cannot be transformed.
  */
 interface GetMultipleOptionsInterface extends GetOptionsInterface {
+  /**
+   * Transform to be applied, can be `json`, `binary`, or `auto`.
+   */
+  transform?: TransformOptions
   /**
    * Whether to throw an error if a value cannot be transformed.
    */

--- a/packages/parameters/src/types/SSMProvider.ts
+++ b/packages/parameters/src/types/SSMProvider.ts
@@ -63,6 +63,8 @@ interface SSMGetOptions extends GetOptionsInterface {
    * Additional options to pass to the AWS SDK v3 client. Supports all options from `GetParameterCommandInput`.
    */
   sdkOptions?: Partial<GetParameterCommandInput>
+
+  transform?: Exclude<TransformOptions, 'auto'>
 }
 
 interface SSMGetOptionsTransformJson extends SSMGetOptions {
@@ -77,14 +79,16 @@ interface SSMGetOptionsTransformNone extends SSMGetOptions {
   transform?: never
 }
 
-type SSMGetOptionsUnion = SSMGetOptionsTransformJson | SSMGetOptionsTransformBinary | SSMGetOptionsTransformNone | undefined;
-
-type SSMGetOutput<O = undefined> =
+/**
+ * Generic output type for the SSMProvider get method.
+ */
+type SSMGetOutput<T = undefined, O = undefined> =
+  undefined extends T ? 
     undefined extends O ? string :
       O extends SSMGetOptionsTransformNone | SSMGetOptionsTransformBinary ? string :
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        O extends SSMGetOptionsTransformJson ? Record<string, any> :
-          never;
+        O extends SSMGetOptionsTransformJson ? Record<string, unknown> :
+          never
+    : T;
 
 /**
  * Options for the SSMProvider getMultiple method.
@@ -126,18 +130,32 @@ interface SSMGetMultipleOptionsTransformBinary extends SSMGetMultipleOptions {
   transform: 'binary'
 }
 
+interface SSMGetMultipleOptionsTransformAuto extends SSMGetMultipleOptions {
+  transform: 'auto'
+}
+
 interface SSMGetMultipleOptionsTransformNone extends SSMGetMultipleOptions {
   transform?: never
 }
 
-type SSMGetMultipleOptionsUnion = SSMGetMultipleOptionsTransformJson | SSMGetMultipleOptionsTransformBinary | SSMGetMultipleOptionsTransformNone | undefined;
+type SSMGetMultipleOptionsUnion = 
+  SSMGetMultipleOptionsTransformJson |
+  SSMGetMultipleOptionsTransformBinary |
+  SSMGetMultipleOptionsTransformAuto |
+  SSMGetMultipleOptionsTransformNone |
+  undefined;
 
-type SSMGetMultipleOutput<O = undefined> =
+/**
+ * Generic output type for the SSMProvider getMultiple method.
+ */
+type SSMGetMultipleOutput<T = undefined, O = undefined> =
+  undefined extends T ? 
     undefined extends O ? Record<string, string> :
       O extends SSMGetMultipleOptionsTransformNone | SSMGetMultipleOptionsTransformBinary ? Record<string, string> :
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        O extends SSMGetMultipleOptionsTransformJson ? Record<string, Record<string, any>> :
-          never;
+        O extends SSMGetMultipleOptionsTransformAuto ? Record<string, unknown> :
+          O extends SSMGetMultipleOptionsTransformJson ? Record<string, Record<string, unknown>> :
+            never
+    : Record<string, T>;
 
 /**
  * Options for the SSMProvider getParametersByName method.
@@ -152,7 +170,7 @@ interface SSMGetParametersByNameOptionsInterface {
   maxAge?: number
   throwOnError?: boolean
   decrypt?: boolean
-  transform?: TransformOptions
+  transform?: Exclude<TransformOptions, 'auto'>
 }
 
 /**
@@ -179,10 +197,14 @@ type SSMGetParametersByNameFromCacheOutputType = {
   toFetch: Record<string, SSMGetParametersByNameOptionsInterface>
 };
 
+type SSMGetParametersByNameOutput<T = undefined> = 
+  undefined extends T ?
+    Record<string, unknown> & { _errors?: string[] } :
+    Record<string, T> & { _errors?: string[] };
+
 export type {
   SSMProviderOptions,
   SSMGetOptions,
-  SSMGetOptionsUnion,
   SSMGetOutput,
   SSMGetMultipleOptions,
   SSMGetMultipleOptionsUnion,
@@ -191,4 +213,5 @@ export type {
   SSMSplitBatchAndDecryptParametersOutputType,
   SSMGetParametersByNameOutputInterface,
   SSMGetParametersByNameFromCacheOutputType,
+  SSMGetParametersByNameOutput,
 };

--- a/packages/parameters/src/types/SSMProvider.ts
+++ b/packages/parameters/src/types/SSMProvider.ts
@@ -54,10 +54,31 @@ type SSMProviderOptions = SSMProviderOptionsWithClientConfig | SSMProviderOption
  * @property {TransformOptions} transform - Transform to be applied, can be 'json' or 'binary'.
  * @property {boolean} decrypt - If true, the parameter will be decrypted.
  */
-interface SSMGetOptionsInterface extends GetOptionsInterface {
+interface SSMGetOptions extends GetOptionsInterface {
   decrypt?: boolean
   sdkOptions?: Partial<GetParameterCommandInput>
 }
+
+interface SSMGetOptionsTransformJson extends SSMGetOptions {
+  transform: 'json'
+}
+
+interface SSMGetOptionsTransformBinary extends SSMGetOptions {
+  transform: 'binary'
+}
+
+interface SSMGetOptionsTransformNone extends SSMGetOptions {
+  transform?: never
+}
+
+type SSMGetOptionsUnion = SSMGetOptionsTransformJson | SSMGetOptionsTransformBinary | SSMGetOptionsTransformNone | undefined;
+
+type SSMGetOutput<O = undefined> =
+    undefined extends O ? string :
+      O extends SSMGetOptionsTransformNone | SSMGetOptionsTransformBinary ? string :
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        O extends SSMGetOptionsTransformJson ? Record<string, any> :
+          never;
 
 /**
  * Options for the SSMProvider getMultiple method.
@@ -121,7 +142,9 @@ type SSMGetParametersByNameFromCacheOutputType = {
 
 export type {
   SSMProviderOptions,
-  SSMGetOptionsInterface,
+  SSMGetOptions,
+  SSMGetOptionsUnion,
+  SSMGetOutput,
   SSMGetMultipleOptionsInterface,
   SSMGetParametersByNameOptionsInterface,
   SSMSplitBatchAndDecryptParametersOutputType,

--- a/packages/parameters/src/types/SSMProvider.ts
+++ b/packages/parameters/src/types/SSMProvider.ts
@@ -50,12 +50,18 @@ type SSMProviderOptions = SSMProviderOptionsWithClientConfig | SSMProviderOption
  * @extends {GetOptionsInterface}
  * @property {number} maxAge - Maximum age of the value in the cache, in seconds.
  * @property {boolean} forceFetch - Force fetch the value from the parameter store, ignoring the cache.
- * @property {GetItemCommandInput} [sdkOptions] - Additional options to pass to the AWS SDK v3 client.
+ * @property {GetItemCommandInput} [sdkOptions] - Additional options to pass to the AWS SDK v3 client. Supports all options from `GetParameterCommandInput`.
  * @property {TransformOptions} transform - Transform to be applied, can be 'json' or 'binary'.
- * @property {boolean} decrypt - If true, the parameter will be decrypted.
+ * @property {boolean} decrypt - If true, the parameter will be decrypted. Defaults to `false`.
  */
 interface SSMGetOptions extends GetOptionsInterface {
+  /**
+   * If true, the parameter will be decrypted. Defaults to `false`.
+   */
   decrypt?: boolean
+  /**
+   * Additional options to pass to the AWS SDK v3 client. Supports all options from `GetParameterCommandInput`.
+   */
   sdkOptions?: Partial<GetParameterCommandInput>
 }
 
@@ -93,12 +99,45 @@ type SSMGetOutput<O = undefined> =
  * @property {boolean} recursive - If true, the parameter will be fetched recursively.
  * @property {boolean} throwOnTransformError - If true, the method will throw an error if the transform fails.
  */
-interface SSMGetMultipleOptionsInterface extends GetMultipleOptionsInterface {
+interface SSMGetMultipleOptions extends GetMultipleOptionsInterface {
+  /**
+   * Additional options to pass to the AWS SDK v3 client. Supports all options from `GetParametersByPathCommandInput`.
+   */
   sdkOptions?: Partial<GetParametersByPathCommandInput>
+  /**
+   * If true, the parameters will be decrypted. Defaults to `false`.
+   */
   decrypt?: boolean
+  /**
+   * If true, the parameters will be fetched recursively. Defaults to `false`.
+   */
   recursive?: boolean
+  /**
+   * If true, the method will throw an error if the transform fails.
+   */
   throwOnTransformError?: boolean
 }
+
+interface SSMGetMultipleOptionsTransformJson extends SSMGetMultipleOptions {
+  transform: 'json'
+}
+
+interface SSMGetMultipleOptionsTransformBinary extends SSMGetMultipleOptions {
+  transform: 'binary'
+}
+
+interface SSMGetMultipleOptionsTransformNone extends SSMGetMultipleOptions {
+  transform?: never
+}
+
+type SSMGetMultipleOptionsUnion = SSMGetMultipleOptionsTransformJson | SSMGetMultipleOptionsTransformBinary | SSMGetMultipleOptionsTransformNone | undefined;
+
+type SSMGetMultipleOutput<O = undefined> =
+    undefined extends O ? Record<string, string> :
+      O extends SSMGetMultipleOptionsTransformNone | SSMGetMultipleOptionsTransformBinary ? Record<string, string> :
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        O extends SSMGetMultipleOptionsTransformJson ? Record<string, Record<string, any>> :
+          never;
 
 /**
  * Options for the SSMProvider getParametersByName method.
@@ -145,7 +184,9 @@ export type {
   SSMGetOptions,
   SSMGetOptionsUnion,
   SSMGetOutput,
-  SSMGetMultipleOptionsInterface,
+  SSMGetMultipleOptions,
+  SSMGetMultipleOptionsUnion,
+  SSMGetMultipleOutput,
   SSMGetParametersByNameOptionsInterface,
   SSMSplitBatchAndDecryptParametersOutputType,
   SSMGetParametersByNameOutputInterface,

--- a/packages/parameters/tests/unit/getParameter.test.ts
+++ b/packages/parameters/tests/unit/getParameter.test.ts
@@ -9,6 +9,10 @@ import { SSMClient, GetParameterCommand } from '@aws-sdk/client-ssm';
 import { mockClient } from 'aws-sdk-client-mock';
 import 'aws-sdk-client-mock-jest';
 
+/**
+ * Note that the following tests include type annotations on the results of each call. This is to ensure that the
+ * generic types defined in the utility are working as expected. If they are not, the tests will fail to compile.
+ */
 describe('Function: getParameter', () => {
 
   beforeEach(() => {
@@ -27,7 +31,7 @@ describe('Function: getParameter', () => {
     });
 
     // Act
-    const value = await getParameter(parameterName);
+    const value: string | undefined = await getParameter(parameterName);
 
     // Assess
     expect(client).toReceiveCommandWith(GetParameterCommand, {
@@ -36,7 +40,7 @@ describe('Function: getParameter', () => {
     expect(value).toBe(parameterValue);
 
   });
-  
+
   test('when called and a default provider exists, it uses it and returns the value', async () => {
 
     // Prepare
@@ -51,7 +55,7 @@ describe('Function: getParameter', () => {
     });
 
     // Act
-    const value = await getParameter(parameterName);
+    const value: string | undefined = await getParameter(parameterName);
 
     // Assess
     expect(client).toReceiveCommandWith(GetParameterCommand, {
@@ -59,6 +63,54 @@ describe('Function: getParameter', () => {
     });
     expect(value).toBe(parameterValue);
     expect(DEFAULT_PROVIDERS.ssm).toBe(provider);
+
+  });
+
+  test('when called and transform `JSON` is specified, it returns an object with correct type', async () => {
+
+    // Prepare
+    const provider = new SSMProvider();
+    DEFAULT_PROVIDERS.ssm = provider;
+    const parameterName = 'foo';
+    const parameterValue = JSON.stringify({ hello: 'world' });
+    const client = mockClient(SSMClient).on(GetParameterCommand).resolves({
+      Parameter: {
+        Value: parameterValue,
+      },
+    });
+
+    // Act
+    const value: Record<string, unknown> | undefined = await getParameter(parameterName, { transform: 'json' });
+
+    // Assess
+    expect(client).toReceiveCommandWith(GetParameterCommand, {
+      Name: parameterName,
+    });
+    expect(value).toStrictEqual(JSON.parse(parameterValue));
+
+  });
+
+  test('when called and transform `JSON` is specified as well as an explicit `K` type, it returns a result with correct type', async () => {
+
+    // Prepare
+    const provider = new SSMProvider();
+    DEFAULT_PROVIDERS.ssm = provider;
+    const parameterName = 'foo';
+    const parameterValue = JSON.stringify(5);
+    const client = mockClient(SSMClient).on(GetParameterCommand).resolves({
+      Parameter: {
+        Value: parameterValue,
+      },
+    });
+
+    // Act
+    const value: number | undefined = await getParameter<number>(parameterName, { transform: 'json' });
+
+    // Assess
+    expect(client).toReceiveCommandWith(GetParameterCommand, {
+      Name: parameterName,
+    });
+    expect(value).toBe(JSON.parse(parameterValue));
 
   });
 

--- a/packages/parameters/tests/unit/getParameters.test.ts
+++ b/packages/parameters/tests/unit/getParameters.test.ts
@@ -9,6 +9,10 @@ import { SSMClient, GetParametersByPathCommand } from '@aws-sdk/client-ssm';
 import { mockClient } from 'aws-sdk-client-mock';
 import 'aws-sdk-client-mock-jest';
 
+/**
+ * Note that the following tests include type annotations on the results of each call. This is to ensure that the
+ * generic types defined in the utility are working as expected. If they are not, the tests will fail to compile.
+ */
 describe('Function: getParameters', () => {
 
   beforeEach(() => {
@@ -28,7 +32,7 @@ describe('Function: getParameters', () => {
     });
 
     // Act
-    const parameters = await getParameters(parameterPath);
+    const parameters: Record<string, string> | undefined = await getParameters(parameterPath);
 
     // Assess
     expect(client).toReceiveCommandWith(GetParametersByPathCommand, {
@@ -39,7 +43,7 @@ describe('Function: getParameters', () => {
     });
 
   });
-  
+
   test('when called and a default provider exists, it uses it and returns the value', async () => {
 
     // Prepare
@@ -55,13 +59,69 @@ describe('Function: getParameters', () => {
     });
 
     // Act
-    const parameters = await getParameters(parameterPath);
+    const parameters: Record<string, string> | undefined = await getParameters(parameterPath);
 
     // Assess
     expect(client).toReceiveCommandWith(GetParametersByPathCommand, {
       Path: parameterPath,
     });
     expect(parameters).toEqual({
+      'bar': parameterValue,
+    });
+    expect(DEFAULT_PROVIDERS.ssm).toBe(provider);
+
+  });
+
+  test('when called and transform `JSON` is specified, it returns an object with correct type', async () => {
+
+    // Prepare
+    const provider = new SSMProvider();
+    DEFAULT_PROVIDERS.ssm = provider;
+    const parameterPath = '/foo';
+    const parameterValue = JSON.stringify({ hello: 'world' });
+    const client = mockClient(SSMClient).on(GetParametersByPathCommand).resolves({
+      Parameters: [{
+        Name: '/foo/bar',
+        Value: parameterValue,
+      }],
+    });
+
+    // Act
+    const parameters: Record<string, Record<string, unknown>> | undefined = await getParameters(parameterPath);
+
+    // Assess
+    expect(client).toReceiveCommandWith(GetParametersByPathCommand, {
+      Path: parameterPath,
+    });
+    expect(parameters).toStrictEqual({
+      'bar': parameterValue,
+    });
+    expect(DEFAULT_PROVIDERS.ssm).toBe(provider);
+
+  });
+
+  test('when called and transform `JSON` is specified as well as an explicit `K` type, it returns a result with correct type', async () => {
+
+    // Prepare
+    const provider = new SSMProvider();
+    DEFAULT_PROVIDERS.ssm = provider;
+    const parameterPath = '/foo';
+    const parameterValue = JSON.stringify(5);
+    const client = mockClient(SSMClient).on(GetParametersByPathCommand).resolves({
+      Parameters: [{
+        Name: '/foo/bar',
+        Value: parameterValue,
+      }],
+    });
+
+    // Act
+    const parameters: Record<string, Record<string, number>> | undefined = await getParameters<Record<string, number>>(parameterPath);
+
+    // Assess
+    expect(client).toReceiveCommandWith(GetParametersByPathCommand, {
+      Path: parameterPath,
+    });
+    expect(parameters).toStrictEqual({
       'bar': parameterValue,
     });
     expect(DEFAULT_PROVIDERS.ssm).toBe(provider);


### PR DESCRIPTION
<!--- 1. Make sure you follow our Contributing Guidelines: https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/CONTRIBUTING.md -->
<!--- 2. Please follow the template, and do not remove any section in the template. If something is not applicable leave it empty, but leave it in the PR. -->

## Description of your changes

> **Note**
> To aid with the review I have prepared this [TypeScript playground](https://www.typescriptlang.org/play?ssl=59&ssc=23&pln=59&pc=29#code/C4TwDgpgBAKgTgQwHYGcBmB7OBbA8mYASw1SgF4oByBAV2A0qgB8qAjQpBOERlygKxQlKAbgBQYjsAhw0CAMbQA4hGD4iJFFADeYqPqgB6AFTG9BqMagAJDAHcoAGxIBzKPSgBrCBDDuAFtAAbgiONNAcUPIKgeYGxoZxUNgIAB4Agi4QAPwAXFBINNisMkkmZhaWUADqgcCBcO4YUAAmEPLcBAHQYFwI2FBYBRjASZaJFm0d4MB5UKwYGI4QyGWmY1a1qg1N7oiomDjdUL2IA0NIIxsTBsD76FjYc-DIDzjqxKhiAL4SUjJyRRQFTAF4HR4AKSESCgEFS0iQLS0II+mh0awqFk2dR2Hjur0OA3qPT650al2AUAAFIISABKa5JfHgnBzATQyg-P5IaSyBTKVRgt7YAByzThCKRwNUqNIugszOFcyQECCpV+YlAkGlagInxQAFUkJ9yDqhYSxcwzfdCVCSFaaIiIGgOBAWuJNeBoAAlQVegA8AGlTY62i6VS0ADRQXAhp3ht0APnISVDztdLVh8IgiK0weyUDGBjTCczEpzUtjBZQdw4blyRcqMazkuRgptj0t1drSHrjabBlj5dz1oJkOhUALvvkWBa-prcDr0cdnkudiQyYbA+3lRVargSXygY9U0cXGgaEd8g0MIQYEIAGFQo4qZxsBB8gu63T8gAFOAYNghAoBA849i4iYemIM6oJSWTAL+pKqDIpoICgIBIPIUBBnGYYZtGQ7ZiOKJ6poRomiwJYZqaJE3oaxokImVJJG+H5QF+vaRkkGCkagcyxgAZDqsooGUhiwIE8wQM4DhgHAEAgXAapaMSrQYf0hBYTO2DvjyWhoABAwcA0hBEL2UD-HyihaKwdBQAglKqTONaDGgUDyQgLQIOwjimSAUBCSkUjIN5hC+aAYmDLxKD8QF1KEa2o4sqKzQFiC5qds0+QJRWbagh2OB2jCaXtmOhUTvktH6gyP5QP+gHAaBvqggGgYEcmlHxhmyZkMm8oGDBLkhGE0AUAgdgIKZ9n3k+jgvqxdIehYhBuVSPF0dkAB0iqEuQZAUOywh0ui26DZSpwgZmFAQgAyrgIqbRdEBUsN4SLRI27ycANBwDCT2ZmhUDNTArXteIFjfLCjggSdA5fT9MKvdAgPA6DMaQUkvwanCYBYJSaEYVhl6YTeUDwekc1UneYAiv0bEcS4tX1UBIH+tOs5gYunHseBiZ9eYZ0nPJLqpKaAAGhgACTaNTtPvt8YvmIY4neoQLj+JSa5k6oiFnMhcBaHYYWOO5qgI-ZMIQNgBD+RgrD8O0lIrcMKpQJgoYC5o52kloFBUxNU3wbrdO8lScnpqk0baK07SdMA+R3OE0YpBkWT5AAnJn6dQN8dLHUwLDaL8+jO1SuD247m3eCAKBhz7dKbcsvb1FAyYAAwMhY8O-fZc0AGqhOEKDpPJN3gbXpz9Cgx0FpP2BaAn-gAXYABiV43lSlA3YBwSDwpUB2DI0AUjzXMuCglB0lSndQzD9TLwUEAOAAonAAFwFSYtGt5yy7OGmZzy0GmRo0tw4iwVgyDUxNrwmmfAPEaw9R7jypKkfI7M4BzgZsuJAq57AblqqLYCQN2gcywafOs-N9DdxhOXB215NpI1rqkBuqoZAgCpFSaSVsczAGOr1dwXoMBuS4bpSk+0DoM0vlyMQ0DSb33sGvEmnwqTvhQCgBAWQ5gM2Ov1ah1I+GUNuEvewj8X5vywCohS6isg3yxhIAmmE3brxNPBMeZ9Xx00-OBJmhlGqcwobDQW8kUA0EcGI+yAc4I6yQqHBa5g9FaggEI02ISwl7QkeBRgBZgmhMpIvZeiiYEkE-t-Vgv8PDwROKSKA0tWLfGjEMOwAFzKJLFlfSBEhBbAVoY7aoIoiglANqaZiFg7b8DQSQjB-juYrjXBuB0OC5liFqmMiyWh0GYPAtGQoxQZA9WTKsgsPT6GMLWvbFh+52GcMcAYgRkBknSXSVQHZgzL5QHyHIaGEAPQOKJs4+0QcYkyBQMc4AKB+m7INnXeoXiz4+IaqzDZ0yXDbIGXswx+hlY1ECDCQ+VS1F7DKtgfIh0kCUGjKpHJaSjZzSkvZYhM4plkNmXg5MJRog0Bhnip6xx0i-gAJIpNybsZAgwK7XiSILRhqFInawQkCj+lBsAgEMHPclOhCXJRJbSMlOd3rLVWt08VwA+loqhYwvOptvo90YeDAw0k77GIcCqMx79N6ABlyS+4gNSCyCjCMa6FHHX3IBiow4kYD8t-PkbAGBOXQAwPuboMMQiLh-vvT+YAxbRjFmAAATFmqAOaADMbTdggWgJSs2PdEmiQsJKr2Yq6HyrODKyaUTm0h2BaC8FZra6UEMMq1VpIvVJEilsXFJICWirGY7AIDkoD+EBpcTVwoKU4uOFSykNKTYlHpQzeyhtoB6KmguSa6tKQGUArygV9bYJVLOLCusCy8IRlbYHaJetQ5KpVWqqOMdpgEATnAcIeqloGCxeOg+0AWjCG9lOpAttoqNtnVSIQvc0PLp2o8Oka6cwboUsKlA-hY2OEzLuhA5DzKA0PnNW9Lk54AEZH3mU6i+t0b723B3fF+wdar3p0fOhxuVXH9b+heXszeyqAC0fG7X6AEycXNQnAWfpkGzSZmyz6oshXzSTIAZPDr-VhnA2qOSgdHRYQWYAi3KY-Z2xV0nf0auM8SqgOrGC529UAA) that contains a simplified (but equivalent) version of the changes included in this PR. Use it to see the concepts described below applied to code & understand how the return types behave.

As discussed in the linked issue, the return types for the `SSMProvider` part of the Parameters utility are fairly generic and could be improved by applying some heuristics based on the method used and some of the parameters passed. In addition to that, we could also provide a way for users to explicitly set the return type when they know the shape of the values they are retrieving.

This PR introduces new types types for the `getParameter()`, `getParameters()`, and `getParametersByName()` functions as well as their class-based corespondents (i.e. `SSMProvider.get()`, etc.).

The new types [use generics](https://www.typescriptlang.org/docs/handbook/2/generics.html) and modify the return type of the functions/methods based on the arguments passed to them or based on an explicitly set type.

For instance, if users pass `transform: 'json'`, then we can assume that the return type should be an object (`Record<K, V>`). Conversely, if no transform or a `binary` (base64) transform is applied, the result will always be a string.

We can apply a similar logic to both single and multiple values retrieval, with the only difference that in the latter case the return type will always be nested inside an object: i.e. `getParameters('/my/path')` (aka no transform) will always yield an object that has strings as both keys and values (`Record<string, string>`):
```ts
{
  'my/path/a': 'foo',
  'my/path/b': 'bar',
}
```

In the case of objects (`transform: 'json'`), I have opted to use `unknown` over `any`, in an effort to nudge users to not typecast indiscriminately but instead use type guards like:

```ts
const isObjectWNumbers = (
    obj: Record<string, unknown> | unknown
): obj is Record<string, number> => obj ? Object.values(obj).every((el) => typeof el === 'number') : false;
```

which can help TypeScript to narrow down types, like:
```ts
async function getParametersObjectsNumbers(path: string): Promise<Record<string, number>> {
    const values = await getParameter('my/param', { transform: 'json' });
    if (isObjectWNumbers(values)) return values;
    else throw new Error('❌');
}
```

There are however still cases in which users might know more about the values they are retrieving than the compiler does, and for those instances this PR introduces the ability to specify the return type while using any of the SSM methods like so:
```ts
const value = getParameter<number>('my/param', { transform: 'json' });
// OR
const objValue = getParameters<Record<string, number>>('my/path', { transform: 'json' });
```

In the first example above the `value` constant will have type `number`, this is because the user has specified a type and so this will take precedence over any type-heuristic we do behind the scenes.

Likewise, in the second example, the `objValue` constant will have `Record<string, Record<string, number>>`, i.e.:
```ts
{
  'my/path/a': {
    foo: 1,
  },
  'my/path/b': {
    bar: 2
  },
}
```

Notice that in the second case we are not passing the full `Record<string, xxx>>` but only the inner type. This is because in the case of `getParameters` we are always returning an object that has keys (of type `string`) that correspond to the name/path of the parameter and as values the actual values. This allows users to specify only the type of the actual value and avoid unnecessary boilerplate. 

Once merged this PR closes #1386

> **Note**
> If this PR is merged as-is, I'll open a series of issues to apply similar changes to all Parameters providers **as well as adding a new section to the docs that explains the behavior above**.

### Related issues, RFCs

<!--- Add here the number (i.e. #42) to the Github Issue or RFC that is related to this PR. -->
<!--- If no issue is present the PR might get blocked and not be reviewed. -->
**Issue number:** #1386

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-typescript/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [ ] I have made corresponding changes to the *documentation*
- [ ] I have made corresponding changes to the *examples*
- [x] My changes generate *no new warnings*
- [x] The *code coverage* hasn't decreased
- [ ] I have *added tests* that prove my change is effective and works
- [x] New and existing *unit tests pass* locally and in Github Actions
- [x] Any *dependent changes have been merged and published*
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

***Is it a breaking change?:*** NO

- [ ] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.