### PR TITLE
fix(parameters): fix import path to use relative paths

### DIFF
--- a/packages/parameters/src/types/AppConfigProvider.ts
+++ b/packages/parameters/src/types/AppConfigProvider.ts
@@ -3,7 +3,7 @@ import type {
   AppConfigDataClientConfig,
   StartConfigurationSessionCommandInput,
 } from '@aws-sdk/client-appconfigdata';
-import type { GetOptionsInterface } from 'types/BaseProvider';
+import type { GetOptionsInterface } from './BaseProvider';
 
 /**
  * Base interface for AppConfigProviderOptions.


### PR DESCRIPTION
## Description of your changes

package: parameters

`AppConfigProvider.ts` uses incorrect import path for `GetOptionsInterface`.  This fix will use the correct relative path for the import.

This fix is for the issue [#1385](https://github.com/awslabs/aws-lambda-powertools-typescript/issues/1385)


### Related issues, RFCs

**Issue number:** #1385

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
