### PR TITLE
chore: add new label for stale automation

### DIFF
--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -23,8 +23,8 @@ jobs:
           close-issue-reason: not_planned
           # Exempt any issue that hasn't been triaged yet, or that is clearly labeled
           exempt-issue-labels: triage,status/confirmed,status/blocked,status/on-hold,status/completed
-          # Include only issues that were labeled as `need-customer-feedback` (aka only issues that need more info from the customer)
-          only-issue-labels: need-customer-feedback
+          # Include only issues that were labeled as `need-response` (aka only issues that need a response from the customer)
+          only-issue-labels: need-response
           # Settings specific to issues
           days-before-issue-stale: 14
           days-before-issue-close: 7

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -103,7 +103,8 @@ These are the most common labels used by maintainers to triage issues, pull requ
 | good-first-issue                       | Something that is suitable for those who want to start contributing                            |                                                    |
 | help-wanted                            | Tasks you want help from anyone to move forward                                                | Bandwidth, complex topics, etc.                    |
 | need-customer-feedback                 | Tasks that need more feedback before proceeding                                                | 80/20% rule, uncertain, etc.                       |
-| need-more-information                  | Missing information before making any calls                                                    | Triggers stale automation after 2 weeks            |
+| need-more-information                  | Missing information before making any calls                                                    | Signal that investigation or answers are needed    |
+| need-response                          | Requires a response from a customer and might be automatically closed if none is received      | Marked as stale after 2 weeks, and closed after 3  |
 | need-issue                             | PR is missing a related issue for tracking change                                              |                                                    |
 
 ## Maintainer Responsibilities
@@ -269,8 +270,7 @@ In other cases, you may have constrained capacity. Use `help-wanted` label when 
 
 When in doubt, use `need-more-information` or `need-customer-feedback` labels to signal more context and feedback are necessary before proceeding. You can also use `status/on-hold` label when you expect it might take a while to gather enough information before you can decide.
 
-Note that issues marked as `need-customer-feedback` will be 
-automatically closed after 3 weeks of inactivity.
+Note that issues marked as `need-response` will be automatically closed after 3 weeks of inactivity.
 
 ### Crediting contributions
 


### PR DESCRIPTION
<!--- 1. Make sure you follow our Contributing Guidelines: https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/CONTRIBUTING.md -->
<!--- 2. Please follow the template, and do not remove any section in the template. If something is not applicable leave it empty, but leave it in the PR. -->

## Description of your changes

This PR introduces a new `need-response` label that is designed to be used exclusively for the purpose of triggering the stale automation. Issues labeled as `need-response` that haven't had any interaction in 2 weeks will be marked as stale (`status/pending-close-response-required`) and subsequently closed as `status/rejected` after an additional week without interaction.

See the linked issue for full context. Once merged, this PR closes #1389.

### Related issues, RFCs

<!--- Add here the number (i.e. #42) to the Github Issue or RFC that is related to this PR. -->
<!--- If no issue is present the PR might get blocked and not be reviewed. -->
**Issue number:** #1389

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-typescript/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [x] I have made corresponding changes to the *documentation*
- [ ] I have made corresponding changes to the *examples*
- [x] My changes generate *no new warnings*
- [x] The *code coverage* hasn't decreased
- [ ] I have *added tests* that prove my change is effective and works
- [x] New and existing *unit tests pass* locally and in Github Actions
- [x] Any *dependent changes have been merged and published*
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

***Is it a breaking change?:*** NO

- [ ] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.