### PR TITLE
chore(ci): convert deprecated `set-output` command

### DIFF
--- a/.github/workflows/measure-packages-size.yml
+++ b/.github/workflows/measure-packages-size.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           ref: ${{ steps.extract_PR_details.outputs.headSHA }}
       - name: Packages size report
-        uses: flochaz/pkg-size-action@e41584e9396375027c8a3c68909e3eca55719e47 # v.2.0.0
+        uses: flochaz/pkg-size-action@1f56793682d897eb0860d98637fa4ea8fe7d37b8 # v.2.0.1
         with:
           build-command: mkdir dist && npm run package -w packages/logger -w packages/tracer -w packages/metrics -w packages/commons -w packages/parameters && npm run package-bundle -w packages/logger -w packages/tracer -w packages/metrics -w packages/commons -w packages/parameters && bash -c "mv ./packages/*/dist/* dist/" && ls dist
           dist-directory: /dist

--- a/.github/workflows/reusable_export_pr_details.yml
+++ b/.github/workflows/reusable_export_pr_details.yml
@@ -68,19 +68,19 @@ jobs:
       # otherwise the parent caller won't see them regardless on how outputs are set.
       - name: "Export Pull Request Number"
         id: prNumber
-        run: echo ::set-output name=prNumber::$(jq -c '.number' ${FILENAME})
+        run: echo "prNumber=$(jq -c '.number' ${FILENAME})" >> $GITHUB_OUTPUT
       - name: "Export Pull Request Title"
         id: prTitle
-        run: echo ::set-output name=prTitle::$(jq -c '.pull_request.title' ${FILENAME})
+        run: echo "prTitle=$(jq -c '.pull_request.title' ${FILENAME})" >> $GITHUB_OUTPUT
       - name: "Export Pull Request Body"
         id: prBody
-        run: echo ::set-output name=prBody::$(jq -c '.pull_request.body' ${FILENAME})
+        run: echo "prBody=$(jq -c '.pull_request.body' ${FILENAME})" >> $GITHUB_OUTPUT
       - name: "Export Pull Request Author"
         id: prAuthor
-        run: echo ::set-output name=prAuthor::$(jq -c '.pull_request.user.login' ${FILENAME})
+        run: echo "prAuthor=$(jq -c '.pull_request.user.login' ${FILENAME})" >> $GITHUB_OUTPUT
       - name: "Export Pull Request Action"
         id: prAction
-        run: echo ::set-output name=prAction::$(jq -c '.action' ${FILENAME})
+        run: echo "prAction=$(jq -c '.action' ${FILENAME})" >> $GITHUB_OUTPUT
       - name: "Export Pull Request Merged status"
         id: prIsMerged
-        run: echo ::set-output name=prIsMerged::$(jq -c '.pull_request.merged' ${FILENAME})
+        run: echo "prIsMerged=$(jq -c '.pull_request.merged' ${FILENAME})" >> $GITHUB_OUTPUT


### PR DESCRIPTION
<!--- 1. Make sure you follow our Contributing Guidelines: https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/CONTRIBUTING.md -->
<!--- 2. Please follow the template, and do not remove any section in the template. If something is not applicable leave it empty, but leave it in the PR. -->

## Description of your changes

In preparation of the `set-output` [deprecation](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) from GitHub, this PR removes all its remaining usages from the workflows in this repo.

The PR applies similar changes to the ones already merged weeks ago in the Python repo awslabs/aws-lambda-powertools-python#1957, as well as updating the commit `sha` for one of the custom actions that was using the deprecated action and that was updated in the meanwhile.

Once merged this PR fixes #1127.

### Related issues, RFCs

<!--- Add here the number (i.e. #42) to the Github Issue or RFC that is related to this PR. -->
<!--- If no issue is present the PR might get blocked and not be reviewed. -->
**Issue number:** #1127

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-typescript/#tenets)
- [x] I have performed a *self-review* of my own code
- [ ] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [ ] I have made corresponding changes to the *documentation*
- [ ] I have made corresponding changes to the *examples*
- [x] My changes generate *no new warnings*
- [x] The *code coverage* hasn't decreased
- [ ] I have *added tests* that prove my change is effective and works
- [x] New and existing *unit tests pass* locally and in Github Actions
- [x] Any *dependent changes have been merged and published*
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

***Is it a breaking change?:*** NO

- [ ] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.