### PR TITLE
feat(idempotency): add local cache to `BasePersistenceLayer`

### DIFF
--- a/packages/idempotency/src/IdempotencyConfig.ts
+++ b/packages/idempotency/src/IdempotencyConfig.ts
@@ -6,6 +6,7 @@ class IdempotencyConfig {
   public expiresAfterSeconds: number;
   public hashFunction: string;
   public lambdaContext?: Context;
+  public maxLocalCacheSize: number;
   public payloadValidationJmesPath?: string;
   public throwOnNoIdempotencyKey: boolean;
   public useLocalCache: boolean;
@@ -16,6 +17,7 @@ class IdempotencyConfig {
     this.throwOnNoIdempotencyKey = config.throwOnNoIdempotencyKey ?? false;
     this.expiresAfterSeconds = config.expiresAfterSeconds ?? 3600; // 1 hour default
     this.useLocalCache = config.useLocalCache ?? false;
+    this.maxLocalCacheSize = config.maxLocalCacheSize ?? 1000;
     this.hashFunction = config.hashFunction ?? 'md5';
     this.lambdaContext = config.lambdaContext;
   }

--- a/packages/idempotency/src/persistence/IdempotencyRecord.ts
+++ b/packages/idempotency/src/persistence/IdempotencyRecord.ts
@@ -15,7 +15,7 @@ class IdempotencyRecord {
   public responseData?: Record<string, unknown>;
   private status: IdempotencyRecordStatus;
 
-  public constructor(config: IdempotencyRecordOptions) { 
+  public constructor(config: IdempotencyRecordOptions) {
     this.idempotencyKey = config.idempotencyKey;
     this.expiryTimestamp = config.expiryTimestamp;
     this.inProgressExpiryTimestamp = config.inProgressExpiryTimestamp;
@@ -38,7 +38,7 @@ class IdempotencyRecord {
     }
   }
 
-  private isExpired(): boolean {
+  public isExpired(): boolean {
     return this.expiryTimestamp !== undefined && ((Date.now() / 1000) > this.expiryTimestamp);
   }
 }

--- a/packages/idempotency/src/persistence/LRUCache.ts
+++ b/packages/idempotency/src/persistence/LRUCache.ts
@@ -145,6 +145,44 @@ class LRUCache<K, V>{
   }
 
   /**
+   * Returns `true` if the key exists in the cache, `false` otherwise.
+   * 
+   * @param key - The key to check for in the cache
+   */
+  public has(key: K): boolean {
+    return this.map.has(key);
+  }
+
+  /**
+   * Removes an item from the cache, while doing so it also reconciles the linked list.
+   * 
+   * @param key - The key to remove from the cache
+   */
+  public remove(key: K): void {
+    const item = this.map.get(key);
+    if (!item) return;
+
+    this.map.delete(key);
+    if (item[NEWER] && item[OLDER]) {
+      // relink the older entry with the newer entry
+      item[OLDER][NEWER] = item[NEWER];
+      item[NEWER][OLDER] = item[OLDER];
+    } else if (item[NEWER]) {
+      // remove the link to us
+      item[NEWER][OLDER] = undefined;
+      // link the newer entry to head
+      this.leastRecentlyUsed = item[NEWER];
+    } else if (item[OLDER]) {
+      // remove the link to us
+      item[OLDER][NEWER] = undefined;
+      // link the newer entry to head
+      this.mostRecentlyUsed = item[OLDER];
+    } else {
+      this.leastRecentlyUsed = this.mostRecentlyUsed = undefined;
+    }
+  }
+
+  /**
    * Returns the current size of the cache.
    */
   public size(): number {

--- a/packages/idempotency/src/persistence/LRUCache.ts
+++ b/packages/idempotency/src/persistence/LRUCache.ts
@@ -1,0 +1,204 @@
+import type { LRUCacheOptions } from '../types';
+
+const DEFAULT_MAX_SIZE = 100;
+const NEWER = Symbol('newer');
+const OLDER = Symbol('older');
+
+class Item<K, V>{
+  public readonly key: K;
+  public value: V;
+  private [NEWER]: Item<K, V> | undefined;
+  private [OLDER]: Item<K, V> | undefined;
+
+  public constructor(key: K, value: V) {
+    this.key = key;
+    this.value = value;
+    this[NEWER] = undefined;
+    this[OLDER] = undefined;
+  }
+}
+
+/**
+ * A simple LRU cache implementation that uses a doubly linked list to track the order of items in
+ * an hash map.
+ * 
+ * Illustration of the design:
+ *```text
+ *   oldest                                                   newest
+ *    entry             entry             entry             entry
+ *    ______            ______            ______            ______
+ *   | head |.newer => |      |.newer => |      |.newer => | tail |
+ *   |  A   |          |  B   |          |  C   |          |  D   |
+ *   |______| <= older.|______| <= older.|______| <= older.|______|
+ *
+ *  removed  <--  <--  <--  <--  <--  <--  <--  <--  <--  <--  added
+ * ```
+ * 
+ * Items are added to the cache using the `add()` method. When an item is added, it's marked
+ * as the most recently used item. If the cache is full, the oldest item is removed from the
+ * cache.
+ * 
+ * Each item also tracks the item that was added before it, and the item that was added after
+ * it. This allows us to quickly remove the oldest item from the cache without having to
+ * iterate through the entire cache.
+ * 
+ * **Note**: This implementation is loosely based on the implementation found in the lru_map package
+ * which is licensed under the MIT license and [recommends users to copy the code into their
+ * own projects](https://github.com/rsms/js-lru/tree/master#usage).
+ * 
+ * @typeparam K - The type of the key
+ * @typeparam V - The type of the value
+ */
+class LRUCache<K, V>{
+  private leastRecentlyUsed?: Item<K, V>;
+  private readonly map: Map<K, Item<K, V>>;
+  private readonly maxSize: number;
+  private mostRecentlyUsed?: Item<K, V>;
+
+  /**
+   * A simple LRU cache implementation that uses a doubly linked list to track the order of items in
+   * an hash map.
+   * 
+   * When instatiating the cache, you can optionally specify the type of the key and value, as well
+   * as the maximum size of the cache. If no maximum size is specified, the cache will default to
+   * a size of 100.
+   * 
+   * @example
+   * ```typescript
+   * const cache = new LRUCache<string, number>({ maxSize: 100 });
+   * // or
+   * // const cache = new LRUCache();
+   * 
+   * cache.add('a', 1);
+   * cache.add('b', 2);
+   * 
+   * cache.get('a');
+   * 
+   * console.log(cache.size()); // 2
+   * ```
+   * 
+   * @param config - The configuration options for the cache
+   */
+  public constructor(config?: LRUCacheOptions) {
+    this.maxSize = config?.maxSize !== undefined ?
+      config.maxSize :
+      DEFAULT_MAX_SIZE;
+    this.map = new Map();
+  }
+
+  /**
+   * Adds a new item to the cache.
+   * 
+   * If the key already exists, it updates the value and marks the item as the most recently used.
+   * If inserting the new item would exceed the max size, the oldest item is removed from the cache.
+   * 
+   * @param key - The key to add to the cache
+   * @param value - The value to add to the cache
+   */
+  public add(key: K, value: V): void {
+    // If the key already exists, we just update the value and mark it as the most recently used
+    if (this.map.has(key)) {
+      // At this point, we know that the key exists in the map, so we can safely use the non-null
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const item = this.map.get(key)!;
+      item.value = value;
+      this.trackItemUse(item);
+
+      return;
+    }
+
+    // If the key doesn't exist, we add it to the map
+    const item = new Item(key, value);
+    this.map.set(key, item);
+
+    // If there's an existing newest item, link it to the new item
+    if (this.mostRecentlyUsed) {
+      this.mostRecentlyUsed[NEWER] = item;
+      item[OLDER] = this.mostRecentlyUsed;
+      // If there's no existing newest item, this is the first item (oldest and newest)
+    } else {
+      this.leastRecentlyUsed = item;
+    }
+
+    // The new item is now the newest item
+    this.mostRecentlyUsed = item;
+
+    // If the map is full, we remove the oldest entry
+    if (this.map.size > this.maxSize) {
+      this.shift();
+    }
+  }
+
+  /**
+   * Returns a value from the cache, or undefined if it's not in the cache.
+   * 
+   * When a value is returned, it's marked as the most recently used item in the cache.
+   * 
+   * @param key - The key to retrieve from the cache
+   */
+  public get(key: K): V | undefined {
+    const item = this.map.get(key);
+    if (!item) return;
+    this.trackItemUse(item);
+
+    return item.value;
+  }
+
+  /**
+   * Returns the current size of the cache.
+   */
+  public size(): number {
+    return this.map.size;
+  }
+
+  /**
+   * Removes the oldest item from the cache and unlinks it from the linked list.
+   */
+  private shift(): void {
+    // If this function is called, we know that the least recently used item exists
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const item = this.leastRecentlyUsed!;
+
+    // If there's a newer item, make it the oldest
+    if (item[NEWER]) {
+      this.leastRecentlyUsed = item[NEWER];
+      this.leastRecentlyUsed[OLDER] = undefined;
+    }
+
+    // Remove the item from the map
+    this.map.delete(item.key);
+    item[NEWER] = undefined;
+    item[OLDER] = undefined;
+  }
+
+  /**
+   * Marks an item as the most recently used item in the cache.
+   * 
+   * @param item - The item to mark as the most recently used
+   */
+  private trackItemUse(item: Item<K, V>): void {
+    // If the item is already the newest, we don't need to do anything
+    if (this.mostRecentlyUsed === item) return; // TODO: check this
+
+    // If the item is not the newest, we need to mark it as the newest
+    if (item[NEWER]) {
+      if (item === this.leastRecentlyUsed) {
+        this.leastRecentlyUsed = item[NEWER];
+      }
+      item[NEWER][OLDER] = item[OLDER];
+    }
+    if (item[OLDER]) {
+      item[OLDER][NEWER] = item[NEWER];
+    }
+    item[NEWER] = undefined;
+    item[OLDER] = this.mostRecentlyUsed;
+    if (this.mostRecentlyUsed) {
+      this.mostRecentlyUsed[NEWER] = item;
+    }
+    this.mostRecentlyUsed = item;
+  }
+}
+
+export {
+  LRUCache,
+};

--- a/packages/idempotency/src/types/IdempotencyOptions.ts
+++ b/packages/idempotency/src/types/IdempotencyOptions.ts
@@ -19,19 +19,23 @@ type IdempotencyConfigOptions = {
    */
   payloadValidationJmesPath?: string
   /**
-   * Throw an error if no idempotency key was found in the request, defaults to false
+   * Throw an error if no idempotency key was found in the request, defaults to `false`
    */
   throwOnNoIdempotencyKey?: boolean
   /**
-   * The number of seconds to wait before a record is expired, defaults to 3600 (1 hour)
+   * The number of seconds to wait before a record is expired, defaults to `3600` (1 hour)
    */
   expiresAfterSeconds?: number
   /**
-   * Wheter to locally cache idempotency results, defaults to false
+   * Wheter to locally cache idempotency results, defaults to `false`
    */
   useLocalCache?: boolean
   /**
-   * Function to use for calculating hashes, defaults to md5
+   * Number of records to keep in the local cache, defaults to `256`
+   */
+  maxLocalCacheSize?: number
+  /**
+   * Function to use for calculating hashes, defaults to `md5`
    */
   hashFunction?: string
   /**

--- a/packages/idempotency/src/types/LRUCache.ts
+++ b/packages/idempotency/src/types/LRUCache.ts
@@ -1,0 +1,10 @@
+type LRUCacheOptions = {
+  /**
+   * The maximum number of items to store in the cache.
+   */
+  maxSize: number
+};
+
+export {
+  LRUCacheOptions
+};

--- a/packages/idempotency/src/types/index.ts
+++ b/packages/idempotency/src/types/index.ts
@@ -3,3 +3,4 @@ export * from './IdempotencyRecord';
 export * from './BasePersistenceLayer';
 export * from './IdempotencyOptions';
 export * from './DynamoDBPersistence';
+export * from './LRUCache';

--- a/packages/idempotency/tests/unit/persistence/LRUCache.test.ts
+++ b/packages/idempotency/tests/unit/persistence/LRUCache.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Test LRUCache class
+ *
+ * @group unit/idempotency/persistence/lru-cache
+ */
+import {
+  LRUCache,
+} from '../../../src/persistence/LRUCache';
+
+describe('Class: LRUMap', () => {
+
+  describe('Method: add', () => {
+
+    test('when called it adds items to the cache', () => {
+
+      // Prepare
+      const cache = new LRUCache();
+
+      // Act
+      cache.add('a', 1);
+      cache.add('b', 2);
+
+      // Assess
+      expect(cache.size()).toBe(2);
+      expect(cache.get('a')).toBe(1);
+      expect(cache.get('b')).toBe(2);
+
+    });
+
+    test('when called it updates the value of an existing key', () => {
+
+      // Prepare
+      const cache = new LRUCache();
+      cache.add('a', 1);
+
+      // Act
+      cache.add('a', 2);
+
+      // Assess
+      expect(cache.size()).toBe(1);
+      expect(cache.get('a')).toBe(2);
+
+    });
+
+    test('when called it removes the oldest item when the cache is full', () => {
+
+      // Prepare
+      const cache = new LRUCache({ maxSize: 2 });
+      cache.add('a', 1);
+      cache.add('b', 2);
+
+      // Act
+      cache.add('c', 3);
+
+      // Assess
+      expect(cache.size()).toBe(2);
+      expect(cache.get('a')).toBeUndefined();
+      expect(cache.get('b')).toBe(2);
+      expect(cache.get('c')).toBe(3);
+
+    });
+
+    test('when called and maxSize is 0, it skips cache', () => {
+
+      // Prepare
+      const cache = new LRUCache({ maxSize: 0 });
+
+      // Act
+      cache.add('a', 1);
+
+      // Assess
+      expect(cache.size()).toBe(0);
+
+    });
+
+  });
+
+  describe('Method: get', () => {
+
+    test('when called it returns the value of an existing key', () => {
+
+      // Prepare
+      const cache = new LRUCache();
+      cache.add('a', 1);
+
+      // Act
+      const value = cache.get('a');
+
+      // Assess
+      expect(value).toBe(1);
+
+    });
+
+    test('when called it returns undefined for a non-existing key', () => {
+
+      // Prepare
+      const cache = new LRUCache();
+
+      // Act
+      const value = cache.get('a');
+
+      // Assess
+      expect(value).toBeUndefined();
+
+    });
+
+    test('when called it marks the item as the most recently used', () => {
+
+      // Prepare
+      const cache = new LRUCache();
+      cache.add('a', 1);
+      cache.add('b', 2);
+      cache.add('c', 3);
+
+      // Act
+      cache.get('b');
+
+      // Assess
+      expect(cache.get('a')).toBe(1);
+      expect(cache.get('b')).toBe(2);
+      expect(cache.get('c')).toBe(3);
+
+    });
+
+  });
+
+});

--- a/packages/idempotency/tests/unit/persistence/LRUCache.test.ts
+++ b/packages/idempotency/tests/unit/persistence/LRUCache.test.ts
@@ -124,4 +124,75 @@ describe('Class: LRUMap', () => {
 
   });
 
+  describe('Method: has', () => {
+
+    test('when called it returns true for an existing key', () => {
+
+      // Prepare
+      const cache = new LRUCache();
+      cache.add('a', 1);
+
+      // Act
+      const hasKey = cache.has('a');
+
+      // Assess
+      expect(hasKey).toBe(true);
+
+    });
+
+    test('when called it returns false for a non-existing key', () => {
+
+      // Prepare
+      const cache = new LRUCache();
+
+      // Act
+      const hasKey = cache.has('a');
+
+      // Assess
+      expect(hasKey).toBe(false);
+
+    });
+
+  });
+
+  describe('Method: remove', () => {
+
+    test('when called it removes the item from the cache', () => {
+
+      // Prepare
+      const cache = new LRUCache();
+      cache.add('a', 1);
+      cache.add('b', 2);
+      cache.add('c', 3);
+
+      // Act
+      cache.remove('b');
+      cache.remove('c');
+      cache.remove('a');
+
+      // Assess
+      expect(cache.size()).toBe(0);
+      expect(cache.get('a')).toBeUndefined();
+
+    });
+
+    test('when called on an empty cache it does nothing', () => {
+
+      // Prepare
+      const cache = new LRUCache();
+      cache.add('a', 1);
+      cache.add('b', 2);
+
+      // Act
+      cache.remove('a');
+      cache.remove('b');
+      cache.remove('a');
+
+      // Assess
+      expect(cache.size()).toBe(0);
+
+    });
+
+  });
+
 });


### PR DESCRIPTION
<!--- 1. Make sure you follow our Contributing Guidelines: https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/CONTRIBUTING.md -->
<!--- 2. Please follow the template, and do not remove any section in the template. If something is not applicable leave it empty, but leave it in the PR. -->

## Description of your changes

This PR introduces a [Least Recently Used (LRU)](http://en.wikipedia.org/wiki/Cache_algorithms#Least_Recently_Used) cache to the `BasePersistenceLayer` of the upcoming Idempotency utility. In this type of cache the most recently-used items are kept in the cache while older ones, that have been accessed less recently are evicted as new items come in.

Users can configure any persistence layer that extends the `BasePersistenceLayer` to use this cache, and in doing so they can also specify the maximum amount of items that are kept in the cache:

```ts
const persistenceLayer = new MyPersistenceLayer(); // i.e. DynamoDB
persistenceLayer.configure({
  config: new IdempotencyConfig({
    useLocalCache: true, // defaults to `false`
    maxLocalCacheSize: 50, // defaults to `256`
  }),
});
```

When caching is enabled, the persistence layer stores, retrieves, and deletes idempotency records from the cache.

### Notes on the LRUCache implementation

As discussed in the linked issue, contrary to Python, Node.js doesn't have any LRU Cache implementation in its standard library. Prior to working the PR I have researched popular modules and found two: [`lru-cache`](https://www.npmjs.com/package/lru-cache) (123M weekly downloads) and [`lru_map`](https://www.npmjs.com/package/lru_map) (3.7M weekly downloads).

While both libraries are popular, the `lru-cache` one offers a wide range of features like TTL, retrieval functions from remote, and a host of other features that we weren't going to be using in this utility. This, in addition to the module size (638 kB unpacked - vs ~150 kB on average on our side), made me opt for the less popular one.

When looking at the `lru_map` module, I realized that the [recommended usage](https://github.com/rsms/js-lru/tree/master#usage) stated this:
> **Recommended**: Copy the code in lru.js or copy the lru.js and lru.d.ts files into your source directory. For minimal functionality, you only need the lines up until the comment that says "Following code is optional".

For this reason I have opted for reimplementing the module directly in our repo. The resulting implementation follows loosely the one found in the `lru_map` module in terms of flow, but adds type annotations, comments, unit tests and retains only the bare minimum methods/features that are needed for Idempotency to work.

The result of this work can be found at `packages/idempotency/src/persistence/LRUCache.ts` and the license as well as a direct mention to the original implementation and recommended usage are included in the docstring of the class.

For now I have opted for putting the class in the Idempotency utility, however in the future we might consider extracting it in the `commons` package so that it can be used by other modules, as well as customers in their own code.

Once merged this PR closes #1299

### Related issues, RFCs

<!--- Add here the number (i.e. #42) to the Github Issue or RFC that is related to this PR. -->
<!--- If no issue is present the PR might get blocked and not be reviewed. -->
**Issue number:** #1299

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-typescript/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [ ] I have made corresponding changes to the *documentation*
- [ ] I have made corresponding changes to the *examples*
- [x] My changes generate *no new warnings*
- [x] The *code coverage* hasn't decreased
- [x] I have *added tests* that prove my change is effective and works
- [x] New and existing *unit tests pass* locally and in Github Actions
- [x] Any *dependent changes have been merged and published*
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

***Is it a breaking change?:*** NO

- [ ] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.