### PR TITLE
feat(metrics): log warning on empty metrics

### DIFF
--- a/packages/metrics/src/Metrics.ts
+++ b/packages/metrics/src/Metrics.ts
@@ -330,6 +330,12 @@ class Metrics extends Utility implements MetricsInterface {
    * ```
    */
   public publishStoredMetrics(): void {
+    if (!this.shouldThrowOnEmptyMetrics && Object.keys(this.storedMetrics).length === 0) {
+      console.warn(
+        'No application metrics to publish. The cold-start metric may be published if enabled. ' +
+        'If application metrics should never be empty, consider using \'throwOnEmptyMetrics\'',
+      );
+    }
     const target = this.serializeMetrics();
     console.log(JSON.stringify(target));
     this.clearMetrics();


### PR DESCRIPTION
<!--- 1. Make sure you follow our Contributing Guidelines: https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/CONTRIBUTING.md -->
<!--- 2. Please follow the template, and do not remove any section in the template. If something is not applicable leave it empty, but leave it in the PR. -->

## Description of your changes

When using the `logMetrics` decorator or middleware users can pass a `throwOnEmptyMetrics` parameter to set the Metrics utility to throw an error when metrics are being flushed but no metric is actually present. In those cases when `throwOnEmptyMetrics` is set to `false` and no metric is added however the utility "fails silently" giving the user no way of detecting potentially missing metrics.

This PR introduces a new warning log that reads:
> No application metrics to publish. The cold-start metric may be published if enabled. If application metrics should never be empty, consider using 'throwOnEmptyMetrics',

This warning will be logged whenever the user tries to flush metrics but no metric was stored and `throwOnEmptyMetrics` is set to `false` or not set.

Once merged this PR closes #1291.

### Related issues, RFCs

<!--- Add here the number (i.e. #42) to the Github Issue or RFC that is related to this PR. -->
<!--- If no issue is present the PR might get blocked and not be reviewed. -->
**Issue number:** #1291

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-typescript/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [ ] I have made corresponding changes to the *documentation*
- [ ] I have made corresponding changes to the *examples*
- [x] My changes generate *no new warnings*
- [x] The *code coverage* hasn't decreased
- [x] I have *added tests* that prove my change is effective and works
- [x] New and existing *unit tests pass* locally and in Github Actions
- [x] Any *dependent changes have been merged and published*
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

***Is it a breaking change?:*** NO

- [ ] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.