### PR TITLE
feat(logger): add `CRITICAL` log level

### DIFF
--- a/packages/logger/src/types/Log.ts
+++ b/packages/logger/src/types/Log.ts
@@ -3,8 +3,21 @@ type LogLevelInfo = 'INFO';
 type LogLevelWarn = 'WARN';
 type LogLevelError = 'ERROR';
 type LogLevelSilent = 'SILENT';
+type LogLevelCritical = 'CRITICAL';
 
-type LogLevel = LogLevelDebug | Lowercase<LogLevelDebug> | LogLevelInfo | Lowercase<LogLevelInfo> | LogLevelWarn | Lowercase<LogLevelWarn> | LogLevelError | Lowercase<LogLevelError> | LogLevelSilent | Lowercase<LogLevelSilent>;
+type LogLevel =
+  LogLevelDebug |
+  Lowercase<LogLevelDebug> |
+  LogLevelInfo |
+  Lowercase<LogLevelInfo> |
+  LogLevelWarn |
+  Lowercase<LogLevelWarn> |
+  LogLevelError |
+  Lowercase<LogLevelError> |
+  LogLevelSilent |
+  Lowercase<LogLevelSilent> |
+  LogLevelCritical |
+  Lowercase<LogLevelCritical>;
 
 type LogLevelThresholds = {
   [key in Uppercase<LogLevel>]: number;

--- a/packages/logger/src/types/Logger.ts
+++ b/packages/logger/src/types/Logger.ts
@@ -2,10 +2,15 @@ import { AsyncHandler, LambdaInterface, SyncHandler } from '@aws-lambda-powertoo
 import { Handler } from 'aws-lambda';
 import { ConfigServiceInterface } from '../config';
 import { LogFormatterInterface } from '../formatter';
-import { Environment, LogAttributes, LogAttributesWithMessage, LogLevel } from './Log';
+import {
+  Environment,
+  LogAttributes,
+  LogAttributesWithMessage,
+  LogLevel,
+} from './Log';
 
 type ClassThatLogs = {
-  [key in 'debug' | 'error' | 'info' | 'warn']: (input: LogItemMessage, ...extraInput: LogItemExtraInput) => void;
+  [key in Exclude<Lowercase<LogLevel>, 'silent'>]: (input: LogItemMessage, ...extraInput: LogItemExtraInput) => void;
 };
 
 type HandlerOptions = {

--- a/packages/logger/tests/unit/helpers.test.ts
+++ b/packages/logger/tests/unit/helpers.test.ts
@@ -17,7 +17,8 @@ describe('Helper: createLogger function', () => {
     INFO: 12,
     WARN: 16,
     ERROR: 20,
-    SILENT: 24,
+    CRITICAL: 24,
+    SILENT: 28,
   };  
 
   beforeEach(() => {


### PR DESCRIPTION
<!--- 1. Make sure you follow our Contributing Guidelines: https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/CONTRIBUTING.md -->
<!--- 2. Please follow the template, and do not remove any section in the template. If something is not applicable leave it empty, but leave it in the PR. -->

## Description of your changes

Currently the Logger utility supports only methods that are also supported by the `Console` object: `warn`, `error`, `info`, and `debug`. On the other hand, Powertools for Python also supports a `critical` method, this is because the `logging` module that is part of the Python language supports it.

When using Powertools for Python, customers can emit structured logs that contain the `"level": "CRITICAL"` key/value. As reported in the linked issue, some of these customers might have setup alarms/metrics/queries that rely on this key/value being present in their logs.

Given that Powertools for TypeScript doesn't support this method/level (yet), these customers are prevented from using both versions of Powertools interchangeably in their serverless workloads.

This PR tries to cater to these users by introducing a new `CRITICAL` log level and method (`Logger.critical`). This new level has higher cardinality than `ERROR` meaning that this is the less verbose one excluding `SILENT`. Logs emitted by calling `Logger.critical` will have `"level": "CRITICAL"` key/value.

### Notes on the implementation

As mentioned at the beginning, Node.js `Console`'s object doesn't have a `critical` method. For this reason the Logger method introduced in this PR internally maps to `console.error`. This is done so that logs emitted using this method are forwarded to `stderr` just like any other error.

Once this PR is merged it closes #1395.

### Related issues, RFCs

<!--- Add here the number (i.e. #42) to the Github Issue or RFC that is related to this PR. -->
<!--- If no issue is present the PR might get blocked and not be reviewed. -->
**Issue number:** #1395

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-typescript/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [ ] I have made corresponding changes to the *documentation*
- [ ] I have made corresponding changes to the *examples*
- [x] My changes generate *no new warnings*
- [x] The *code coverage* hasn't decreased
- [x] I have *added tests* that prove my change is effective and works
- [x] New and existing *unit tests pass* locally and in Github Actions
- [x] Any *dependent changes have been merged and published*
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

***Is it a breaking change?:*** NO

- [ ] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.