### PR TITLE
feat(parameters): add adaptive types to SecretsProvider

### DIFF
--- a/packages/parameters/src/secrets/SecretsProvider.ts
+++ b/packages/parameters/src/secrets/SecretsProvider.ts
@@ -8,6 +8,7 @@ import type {
   SecretsProviderOptions,
   SecretsGetOptions,
   SecretsGetOutput,
+  SecretsGetOptionsUnion,
 } from '../types/SecretsProvider';
 
 /**
@@ -202,7 +203,7 @@ class SecretsProvider extends BaseProvider {
    */
   public async get<
     ExplicitUserProvidedType = undefined,
-    InferredFromOptionsType extends SecretsGetOptions | undefined = SecretsGetOptions
+    InferredFromOptionsType extends SecretsGetOptionsUnion | undefined = SecretsGetOptionsUnion
   >(
     name: string,
     options?: InferredFromOptionsType & SecretsGetOptions

--- a/packages/parameters/src/secrets/SecretsProvider.ts
+++ b/packages/parameters/src/secrets/SecretsProvider.ts
@@ -6,7 +6,8 @@ import {
 import type { GetSecretValueCommandInput } from '@aws-sdk/client-secrets-manager';
 import type {
   SecretsProviderOptions,
-  SecretsGetOptionsInterface
+  SecretsGetOptions,
+  SecretsGetOutput,
 } from '../types/SecretsProvider';
 
 /**
@@ -157,7 +158,7 @@ class SecretsProvider extends BaseProvider {
    * 
    * @param {SecretsProviderOptions} config - The configuration object.
    */
-  public constructor (config?: SecretsProviderOptions) {
+  public constructor(config?: SecretsProviderOptions) {
     super();
 
     if (config?.awsSdkV3Client) {
@@ -170,7 +171,6 @@ class SecretsProvider extends BaseProvider {
       const clientConfig = config?.clientConfig || {};
       this.client = new SecretsManagerClient(clientConfig);
     }
-    
   }
 
   /**
@@ -197,14 +197,20 @@ class SecretsProvider extends BaseProvider {
    * For usage examples check {@link SecretsProvider}.
    * 
    * @param {string} name - The name of the secret
-   * @param {SecretsGetOptionsInterface} options - Options to customize the retrieval of the secret
+   * @param {SecretsGetOptions} options - Options to customize the retrieval of the secret
    * @see https://awslabs.github.io/aws-lambda-powertools-typescript/latest/utilities/parameters/
    */
-  public async get(
+  public async get<
+    ExplicitUserProvidedType = undefined,
+    InferredFromOptionsType extends SecretsGetOptions | undefined = SecretsGetOptions
+  >(
     name: string,
-    options?: SecretsGetOptionsInterface
-  ): Promise<undefined | string | Uint8Array | Record<string, unknown>> {
-    return super.get(name, options);
+    options?: InferredFromOptionsType & SecretsGetOptions
+  ): Promise<SecretsGetOutput<ExplicitUserProvidedType, InferredFromOptionsType> | undefined> {
+    return super.get(
+      name,
+      options
+    ) as Promise<SecretsGetOutput<ExplicitUserProvidedType, InferredFromOptionsType> | undefined>;
   }
 
   /**
@@ -221,11 +227,11 @@ class SecretsProvider extends BaseProvider {
    * Retrieve a configuration from AWS AppConfig.
    *
    * @param {string} name - Name of the configuration or its ID
-   * @param {SecretsGetOptionsInterface} options - SDK options to propagate to the AWS SDK v3 for JavaScript client
+   * @param {SecretsGetOptions} options - SDK options to propagate to the AWS SDK v3 for JavaScript client
    */
   protected async _get(
     name: string,
-    options?: SecretsGetOptionsInterface
+    options?: SecretsGetOptions
   ): Promise<string | Uint8Array | undefined> {
     const sdkOptions: GetSecretValueCommandInput = {
       ...(options?.sdkOptions || {}),
@@ -249,7 +255,7 @@ class SecretsProvider extends BaseProvider {
     _options?: unknown
   ): Promise<Record<string, string | undefined>> {
     throw new Error('Method not implemented.');
-  } 
+  }
 }
 
 export {

--- a/packages/parameters/src/secrets/getSecret.ts
+++ b/packages/parameters/src/secrets/getSecret.ts
@@ -3,6 +3,7 @@ import { SecretsProvider } from './SecretsProvider';
 import type {
   SecretsGetOptions,
   SecretsGetOutput,
+  SecretsGetOptionsUnion,
 } from '../types/SecretsProvider';
 
 /**
@@ -108,7 +109,7 @@ import type {
  */
 const getSecret = async <
   ExplicitUserProvidedType = undefined,
-  InferredFromOptionsType extends SecretsGetOptions | undefined = SecretsGetOptions
+  InferredFromOptionsType extends SecretsGetOptionsUnion | undefined = SecretsGetOptionsUnion
 >(
   name: string,
   options?: InferredFromOptionsType & SecretsGetOptions

--- a/packages/parameters/src/secrets/getSecret.ts
+++ b/packages/parameters/src/secrets/getSecret.ts
@@ -1,6 +1,9 @@
 import { DEFAULT_PROVIDERS } from '../BaseProvider';
 import { SecretsProvider } from './SecretsProvider';
-import type { SecretsGetOptionsInterface } from '../types/SecretsProvider';
+import type {
+  SecretsGetOptions,
+  SecretsGetOutput,
+} from '../types/SecretsProvider';
 
 /**
  * ## Intro
@@ -100,15 +103,23 @@ import type { SecretsGetOptionsInterface } from '../types/SecretsProvider';
  *
  *
  * @param {string} name - The name of the secret to retrieve
- * @param {SecretsGetOptionsInterface} options - Options to configure the provider
+ * @param {SecretsGetOptions} options - Options to configure the provider
  * @see https://awslabs.github.io/aws-lambda-powertools-typescript/latest/utilities/parameters/
  */
-const getSecret = async (name: string, options?: SecretsGetOptionsInterface): Promise<undefined | string | Uint8Array | Record<string, unknown>> => {
+const getSecret = async <
+  ExplicitUserProvidedType = undefined,
+  InferredFromOptionsType extends SecretsGetOptions | undefined = SecretsGetOptions
+>(
+  name: string,
+  options?: InferredFromOptionsType & SecretsGetOptions
+): Promise<SecretsGetOutput<ExplicitUserProvidedType, InferredFromOptionsType> | undefined> => {
   if (!DEFAULT_PROVIDERS.hasOwnProperty('secrets')) {
     DEFAULT_PROVIDERS.secrets = new SecretsProvider();
   }
-  
-  return DEFAULT_PROVIDERS.secrets.get(name, options);
+
+  return (
+    DEFAULT_PROVIDERS.secrets as SecretsProvider
+  ).get(name, options) as Promise<SecretsGetOutput<ExplicitUserProvidedType, InferredFromOptionsType> | undefined>;
 };
 
 export {

--- a/packages/parameters/src/types/SecretsProvider.ts
+++ b/packages/parameters/src/types/SecretsProvider.ts
@@ -1,5 +1,12 @@
-import type { GetOptionsInterface } from './BaseProvider';
-import type { SecretsManagerClient, SecretsManagerClientConfig, GetSecretValueCommandInput } from '@aws-sdk/client-secrets-manager';
+import type {
+  GetOptionsInterface,
+  TransformOptions
+} from './BaseProvider';
+import type {
+  SecretsManagerClient,
+  SecretsManagerClientConfig,
+  GetSecretValueCommandInput
+} from '@aws-sdk/client-secrets-manager';
 
 /**
  * Base interface for SecretsProviderOptions.
@@ -45,11 +52,39 @@ type SecretsProviderOptions = SecretsProviderOptionsWithClientConfig | SecretsPr
  * @property {GetSecretValueCommandInput} sdkOptions - Options to pass to the underlying SDK.
  * @property {TransformOptions} transform - Transform to be applied, can be 'json' or 'binary'.
  */
-interface SecretsGetOptionsInterface extends GetOptionsInterface {
+interface SecretsGetOptions extends GetOptionsInterface {
+  /**
+   * Additional options to pass to the AWS SDK v3 client. Supports all options from `GetSecretValueCommandInput`.
+   */
   sdkOptions?: Omit<Partial<GetSecretValueCommandInput>, 'SecretId'>
+  transform?: Exclude<TransformOptions, 'auto'>
 }
+
+interface SecretsGetOptionsTransformJson extends SecretsGetOptions {
+  transform: 'json'
+}
+
+interface SecretsGetOptionsTransformBinary extends SecretsGetOptions {
+  transform: 'binary'
+}
+
+interface SecretsGetOptionsTransformNone extends SecretsGetOptions {
+  transform?: never
+}
+
+/**
+ * Generic output type for the SecretsProvider get method.
+ */
+type SecretsGetOutput<ExplicitUserProvidedType = undefined, InferredFromOptionsType = undefined> =
+  undefined extends ExplicitUserProvidedType ? 
+    undefined extends InferredFromOptionsType ? string :
+      InferredFromOptionsType extends SecretsGetOptionsTransformNone | SecretsGetOptionsTransformBinary ? string :
+        InferredFromOptionsType extends SecretsGetOptionsTransformJson ? Record<string, unknown> :
+          never
+    : ExplicitUserProvidedType;
 
 export type {
   SecretsProviderOptions,
-  SecretsGetOptionsInterface,
+  SecretsGetOptions,
+  SecretsGetOutput,
 };

--- a/packages/parameters/src/types/SecretsProvider.ts
+++ b/packages/parameters/src/types/SecretsProvider.ts
@@ -72,19 +72,27 @@ interface SecretsGetOptionsTransformNone extends SecretsGetOptions {
   transform?: never
 }
 
+type SecretsGetOptionsUnion =
+  SecretsGetOptionsTransformNone | 
+  SecretsGetOptionsTransformJson |
+  SecretsGetOptionsTransformBinary |
+  undefined;
+
 /**
  * Generic output type for the SecretsProvider get method.
  */
 type SecretsGetOutput<ExplicitUserProvidedType = undefined, InferredFromOptionsType = undefined> =
   undefined extends ExplicitUserProvidedType ? 
-    undefined extends InferredFromOptionsType ? string :
-      InferredFromOptionsType extends SecretsGetOptionsTransformNone | SecretsGetOptionsTransformBinary ? string :
-        InferredFromOptionsType extends SecretsGetOptionsTransformJson ? Record<string, unknown> :
-          never
+    undefined extends InferredFromOptionsType ? string | Uint8Array :
+      InferredFromOptionsType extends SecretsGetOptionsTransformNone ? string | Uint8Array :
+        InferredFromOptionsType extends SecretsGetOptionsTransformBinary ? string :
+          InferredFromOptionsType extends SecretsGetOptionsTransformJson ? Record<string, unknown> :
+            never
     : ExplicitUserProvidedType;
 
 export type {
   SecretsProviderOptions,
   SecretsGetOptions,
   SecretsGetOutput,
+  SecretsGetOptionsUnion,
 };

--- a/packages/parameters/tests/unit/getSecret.test.ts
+++ b/packages/parameters/tests/unit/getSecret.test.ts
@@ -29,7 +29,7 @@ describe('Function: getSecret', () => {
     });
 
     // Act
-    const result: string | undefined = await getSecret(secretName);
+    const result: string | Uint8Array | undefined = await getSecret(secretName);
 
     // Assess
     expect(client).toReceiveCommandWith(GetSecretValueCommand, { SecretId: secretName });
@@ -50,7 +50,7 @@ describe('Function: getSecret', () => {
     });
 
     // Act
-    const result: string | undefined = await getSecret(secretName);
+    const result: string | Uint8Array | undefined = await getSecret(secretName);
 
     // Assess
     expect(client).toReceiveCommandWith(GetSecretValueCommand, { SecretId: secretName });

--- a/packages/parameters/tests/unit/getSecret.test.ts
+++ b/packages/parameters/tests/unit/getSecret.test.ts
@@ -29,7 +29,7 @@ describe('Function: getSecret', () => {
     });
 
     // Act
-    const result = await getSecret(secretName);
+    const result: string | undefined = await getSecret(secretName);
 
     // Assess
     expect(client).toReceiveCommandWith(GetSecretValueCommand, { SecretId: secretName });
@@ -50,12 +50,56 @@ describe('Function: getSecret', () => {
     });
 
     // Act
-    const result = await getSecret(secretName);
+    const result: string | undefined = await getSecret(secretName);
 
     // Assess
     expect(client).toReceiveCommandWith(GetSecretValueCommand, { SecretId: secretName });
     expect(result).toStrictEqual(binary);
     expect(DEFAULT_PROVIDERS.secrets).toBe(provider);
+
+  });
+
+  test('when called and transform `JSON` is specified, it returns an object with correct type', async () => {
+
+    // Prepare
+    const provider = new SecretsProvider();
+    DEFAULT_PROVIDERS.secrets = provider;
+    const secretName = 'foo';
+    const secretValue = JSON.stringify({ hello: 'world' });
+    const client = mockClient(SecretsManagerClient).on(GetSecretValueCommand).resolves({
+      SecretString: secretValue,
+    });
+
+    // Act
+    const value: Record<string, unknown> | undefined = await getSecret(secretName, { transform: 'json' });
+
+    // Assess
+    expect(client).toReceiveCommandWith(GetSecretValueCommand, {
+      SecretId: secretName,
+    });
+    expect(value).toStrictEqual(JSON.parse(secretValue));
+
+  });
+
+  test('when called and transform `JSON` is specified as well as an explicit `K` type, it returns a result with correct type', async () => {
+
+    // Prepare
+    const provider = new SecretsProvider();
+    DEFAULT_PROVIDERS.secrets = provider;
+    const secretName = 'foo';
+    const secretValue = JSON.stringify(5);
+    const client = mockClient(SecretsManagerClient).on(GetSecretValueCommand).resolves({
+      SecretString: secretValue,
+    });
+
+    // Act
+    const value: number | undefined = await getSecret<number>(secretName, { transform: 'json' });
+
+    // Assess
+    expect(client).toReceiveCommandWith(GetSecretValueCommand, {
+      SecretId: secretName,
+    });
+    expect(value).toBe(JSON.parse(secretValue));
 
   });
 


### PR DESCRIPTION
<!--- 1. Make sure you follow our Contributing Guidelines: https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/CONTRIBUTING.md -->
<!--- 2. Please follow the template, and do not remove any section in the template. If something is not applicable leave it empty, but leave it in the PR. -->

## Description of your changes

As discussed in the linked issue, the return types for the `SecretsProvider` part of the Parameters utility were fairly generic and could be improved by applying some heuristics based on the method used and some of the parameters passed. In addition to that, we could also provide a way for users to explicitly set the return type when they know the shape of the values they are retrieving.

This PR introduces new adaptive types for the `getSecret()` function as well as its class-based corespondent SecretsProvider.get()`.

The new types [use generics](https://www.typescriptlang.org/docs/handbook/2/generics.html) and modify the return type of the functions/methods based on the arguments passed to them or based on an explicitly set type.

For instance, if users pass transform: `json`, then we can assume that the return type should be an object (`Record<K, V>`). Conversely, if no transform or a `binary` (base64) transform is applied, the result will be a `string`.

Finally, if the user doesn't specify any transform then, given tht SecretsManager is able to store both `SecretString` and `SecretBinary` data types, then we can only narrow down the return type to one of `string` or `Uint8Array`.

There are however also cases in which users might know more about the values they are retrieving than the compiler does, and for those instances this PR introduces the ability to specify the return type while using either the function or method like so:

```ts
const value = getSecret<number>('my-secret', { transform: 'json' });
```

In the example above the `value` constant will have type `number`, this is because the user has specified a type and so this will take precedence over any type-heuristic we do behind the scenes.

> **Note**
> This PR is part of a series that covers the same topic for all Parameters providers. Once this work is done I'll open I'll add a new section to the docs that explains the behavior above.

Once merged this PR closes #1409

### Related issues, RFCs

<!--- Add here the number (i.e. #42) to the Github Issue or RFC that is related to this PR. -->
<!--- If no issue is present the PR might get blocked and not be reviewed. -->
**Issue number:** #1409

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-typescript/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [ ] I have made corresponding changes to the *documentation*
- [ ] I have made corresponding changes to the *examples*
- [x] My changes generate *no new warnings*
- [x] The *code coverage* hasn't decreased
- [x] I have *added tests* that prove my change is effective and works
- [x] New and existing *unit tests pass* locally and in Github Actions
- [x] Any *dependent changes have been merged and published*
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

***Is it a breaking change?:*** NO

- [ ] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.