### PR TITLE
chore(ci): add versionn number normalization to docs publishing

### DIFF
--- a/.github/workflows/on_doc_merge.yml
+++ b/.github/workflows/on_doc_merge.yml
@@ -15,5 +15,5 @@ jobs:
       pages: write
     uses: ./.github/workflows/reusable-publish-docs.yml
     with:
-      version: dev
+      version: stage
       alias: stage

--- a/.github/workflows/reusable-publish-docs.yml
+++ b/.github/workflows/reusable-publish-docs.yml
@@ -3,6 +3,7 @@ name: Reusable Publish docs
 env:
   BRANCH: main
   ORIGIN: awslabs/aws-lambda-powertools-typescript
+  VERSION: ""
 
 on:
   workflow_call:
@@ -75,9 +76,10 @@ jobs:
           git config pull.rebase true
           git config remote.origin.url >&- || git remote add origin https://github.com/"$ORIGIN"
           git pull origin "$BRANCH"
+      - name: Normalize Version Number
+        run: echo "VERSION=$(echo ${{ inputs.version }} | sed 's/v//')" >> $GITHUB_ENV
       - name: Build docs website and API reference
         env:
-          VERSION: ${{ inputs.version }}
           ALIAS: ${{ inputs.alias }}
         run: |
           rm -rf site
@@ -91,8 +93,6 @@ jobs:
           npm run docs-generateApiDoc
       - name: Release API docs
         uses: peaceiris/actions-gh-pages@bd8c6b06eba6b3d25d72b7a1767993c0aeee42e7 # v3.9.2
-        env:
-          VERSION: ${{ inputs.version }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./api


### PR DESCRIPTION
<!--- 1. Make sure you follow our Contributing Guidelines: https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/CONTRIBUTING.md -->
<!--- 2. Please follow the template, and do not remove any section in the template. If something is not applicable leave it empty, but leave it in the PR. -->

## Description of your changes

As described in the linked issue, the docs publishing workflow was creating version numbers that contained a `v` prefix, which is not in line with the rest of the versions used across docs.

This PR introduces an additional step to the `reusable-publish-docs` workflow to normalize the version number and remove the prefix when previous. This way docs will always be published under the correct version/convention.

Once merged this issue closes #1421.

### Related issues, RFCs

<!--- Add here the number (i.e. #42) to the Github Issue or RFC that is related to this PR. -->
<!--- If no issue is present the PR might get blocked and not be reviewed. -->
**Issue number:** #1421

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-typescript/#tenets)
- [x] I have performed a *self-review* of my own code
- [ ] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [ ] I have made corresponding changes to the *documentation*
- [ ] I have made corresponding changes to the *examples*
- [x] My changes generate *no new warnings*
- [x] The *code coverage* hasn't decreased
- [ ] I have *added tests* that prove my change is effective and works
- [ ] New and existing *unit tests pass* locally and in Github Actions
- [ ] Any *dependent changes have been merged and published*
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

***Is it a breaking change?:*** NO

- [ ] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.