### PR TITLE
feat(tracer): add isTraceSampled method

### DIFF
--- a/packages/commons/src/config/EnvironmentVariablesService.ts
+++ b/packages/commons/src/config/EnvironmentVariablesService.ts
@@ -61,6 +61,20 @@ class EnvironmentVariablesService extends ConfigService {
   }
 
   /**
+   * It returns true if the Sampled flag is set in the _X_AMZN_TRACE_ID environment variable.
+   * 
+   * The AWS X-Ray Trace data available in the environment variable has this format:
+   * `Root=1-5759e988-bd862e3fe1be46a994272793;Parent=557abcec3ee5a047;Sampled=1`,
+   *
+   * @returns {string}
+   */
+  public getXrayTraceSampled(): boolean {
+    const xRayTraceData = this.getXrayTraceData();
+
+    return xRayTraceData[2] === 'Sampled=1';
+  }
+
+  /**
    * It returns true if the string value represents a boolean true value.
    *
    * @param {string} value

--- a/packages/commons/src/config/EnvironmentVariablesService.ts
+++ b/packages/commons/src/config/EnvironmentVariablesService.ts
@@ -55,9 +55,7 @@ class EnvironmentVariablesService extends ConfigService {
   public getXrayTraceId(): string | undefined {
     const xRayTraceData = this.getXrayTraceData();
 
-    if (xRayTraceData.length === 0) return undefined;
-
-    return xRayTraceData[0].replace('Root=', '');
+    return xRayTraceData?.Root;
   }
 
   /**
@@ -71,7 +69,7 @@ class EnvironmentVariablesService extends ConfigService {
   public getXrayTraceSampled(): boolean {
     const xRayTraceData = this.getXrayTraceData();
 
-    return xRayTraceData[2] === 'Sampled=1';
+    return xRayTraceData?.Sampled === '1';
   }
 
   /**
@@ -86,12 +84,27 @@ class EnvironmentVariablesService extends ConfigService {
     return truthyValues.includes(value.toLowerCase());
   }
 
-  private getXrayTraceData(): string[] {
+  /**
+   * It parses the key/value data present in the _X_AMZN_TRACE_ID environment variable
+   * and returns it as an object when available.
+   */
+  private getXrayTraceData(): Record<string, string> | undefined {
     const xRayTraceEnv = this.get(this.xRayTraceIdVariable);
 
-    if (xRayTraceEnv === '') return [];
+    if (xRayTraceEnv === '') return undefined;
 
-    return xRayTraceEnv.split(';');
+    if (!xRayTraceEnv.includes('=')) return { Root: xRayTraceEnv };
+
+    const xRayTraceData: Record<string, string> = {};
+
+    xRayTraceEnv.split(';').forEach((field) => {
+
+      const [ key, value ] = field.split('=');
+
+      xRayTraceData[key] = value;
+    });
+
+    return xRayTraceData;
   }
 }
 

--- a/packages/commons/src/config/EnvironmentVariablesService.ts
+++ b/packages/commons/src/config/EnvironmentVariablesService.ts
@@ -66,7 +66,7 @@ class EnvironmentVariablesService extends ConfigService {
    * The AWS X-Ray Trace data available in the environment variable has this format:
    * `Root=1-5759e988-bd862e3fe1be46a994272793;Parent=557abcec3ee5a047;Sampled=1`,
    *
-   * @returns {string}
+   * @returns {boolean}
    */
   public getXrayTraceSampled(): boolean {
     const xRayTraceData = this.getXrayTraceData();

--- a/packages/commons/src/config/EnvironmentVariablesService.ts
+++ b/packages/commons/src/config/EnvironmentVariablesService.ts
@@ -53,11 +53,11 @@ class EnvironmentVariablesService extends ConfigService {
    * @returns {string}
    */
   public getXrayTraceId(): string | undefined {
-    const xRayTraceId = this.get(this.xRayTraceIdVariable);
+    const xRayTraceData = this.getXrayTraceData();
 
-    if (xRayTraceId === '') return undefined;
+    if (xRayTraceData.length === 0) return undefined;
 
-    return xRayTraceId.split(';')[0].replace('Root=', '');
+    return xRayTraceData[0].replace('Root=', '');
   }
 
   /**
@@ -72,6 +72,13 @@ class EnvironmentVariablesService extends ConfigService {
     return truthyValues.includes(value.toLowerCase());
   }
 
+  private getXrayTraceData(): string[] {
+    const xRayTraceEnv = this.get(this.xRayTraceIdVariable);
+
+    if (xRayTraceEnv === '') return [];
+
+    return xRayTraceEnv.split(';');
+  }
 }
 
 export {

--- a/packages/commons/tests/unit/config/EnvironmentVariablesService.test.ts
+++ b/packages/commons/tests/unit/config/EnvironmentVariablesService.test.ts
@@ -110,6 +110,48 @@ describe('Class: EnvironmentVariablesService', () => {
 
   });
 
+  describe('Method: getXrayTraceSampled', () => {
+    
+    test('It returns true if the Sampled flag is set in the _X_AMZN_TRACE_ID environment variable', () => {
+
+      // Prepare
+      process.env._X_AMZN_TRACE_ID = 'Root=1-5759e988-bd862e3fe1be46a994272793;Parent=557abcec3ee5a047;Sampled=1';
+      const service = new EnvironmentVariablesService();
+
+      // Act
+      const value = service.getXrayTraceSampled();
+
+      // Assess
+      expect(value).toEqual(true);
+    });
+
+    test('It returns false if the Sampled flag is not set in the _X_AMZN_TRACE_ID environment variable', () => {
+
+      // Prepare
+      process.env._X_AMZN_TRACE_ID = 'Root=1-5759e988-bd862e3fe1be46a994272793;Parent=557abcec3ee5a047';
+      const service = new EnvironmentVariablesService();
+
+      // Act
+      const value = service.getXrayTraceSampled();
+
+      // Assess
+      expect(value).toEqual(false);
+    });
+
+    it('It returns false when no _X_AMZN_TRACE_ID environment variable is present', () => {
+
+      // Prepare
+      delete process.env._X_AMZN_TRACE_ID;
+      const service = new EnvironmentVariablesService();
+
+      // Act
+      const value = service.getXrayTraceSampled();
+
+      // Assess
+      expect(value).toEqual(false);
+    });
+  });
+
   describe('Method: isValueTrue', () => {
 
     const valuesToTest: Array<Array<string | boolean>> = [

--- a/packages/tracer/src/Tracer.ts
+++ b/packages/tracer/src/Tracer.ts
@@ -508,6 +508,10 @@ class Tracer extends Utility implements TracerInterface {
    * @returns string - The root X-Ray trace id.
    */
   public getRootXrayTraceId(): string | undefined {
+    if (!this.isTracingEnabled()) {
+      return undefined;
+    }
+
     return this.envVarsService.getXrayTraceId();
   }
   

--- a/packages/tracer/src/Tracer.ts
+++ b/packages/tracer/src/Tracer.ts
@@ -557,6 +557,8 @@ class Tracer extends Utility implements TracerInterface {
    * @returns boolean - `true` if the trace is sampled, `false` otherwise.
    */
   public isTraceSampled(): boolean {
+    if (!this.isTracingEnabled()) return false;
+
     return this.envVarsService.getXrayTraceSampled();
   }
 

--- a/packages/tracer/src/Tracer.ts
+++ b/packages/tracer/src/Tracer.ts
@@ -508,9 +508,7 @@ class Tracer extends Utility implements TracerInterface {
    * @returns string - The root X-Ray trace id.
    */
   public getRootXrayTraceId(): string | undefined {
-    if (!this.isTracingEnabled()) {
-      return undefined;
-    }
+    if (!this.isTracingEnabled()) return undefined;
 
     return this.envVarsService.getXrayTraceId();
   }

--- a/packages/tracer/src/Tracer.ts
+++ b/packages/tracer/src/Tracer.ts
@@ -554,7 +554,7 @@ class Tracer extends Utility implements TracerInterface {
    *
    * @see https://docs.aws.amazon.com/xray/latest/devguide/xray-concepts.html#xray-concepts-traces
    * 
-   * @returns boolean - `true` if the trace is sampled, `false` otherwise.
+   * @returns boolean - `true` if the trace is sampled, `false` if tracing is disabled or the trace is not sampled.
    */
   public isTraceSampled(): boolean {
     if (!this.isTracingEnabled()) return false;

--- a/packages/tracer/src/Tracer.ts
+++ b/packages/tracer/src/Tracer.ts
@@ -510,6 +510,10 @@ class Tracer extends Utility implements TracerInterface {
   public getRootXrayTraceId(): string | undefined {
     return this.envVarsService.getXrayTraceId();
   }
+
+  public isTraceSampled(): boolean {
+    return this.envVarsService.getXrayTraceSampled();
+  }
   
   /**
    * Get the active segment or subsegment (if any) in the current scope.

--- a/packages/tracer/src/Tracer.ts
+++ b/packages/tracer/src/Tracer.ts
@@ -510,10 +510,6 @@ class Tracer extends Utility implements TracerInterface {
   public getRootXrayTraceId(): string | undefined {
     return this.envVarsService.getXrayTraceId();
   }
-
-  public isTraceSampled(): boolean {
-    return this.envVarsService.getXrayTraceSampled();
-  }
   
   /**
    * Get the active segment or subsegment (if any) in the current scope.
@@ -549,6 +545,19 @@ class Tracer extends Utility implements TracerInterface {
     }
  
     return segment;
+  }
+
+  /**
+   * Get the current value of the AWS X-Ray Sampled flag.
+   * 
+   * Utility method that returns the current AWS X-Ray Sampled flag.
+   *
+   * @see https://docs.aws.amazon.com/xray/latest/devguide/xray-concepts.html#xray-concepts-traces
+   * 
+   * @returns boolean - `true` if the trace is sampled, `false` otherwise.
+   */
+  public isTraceSampled(): boolean {
+    return this.envVarsService.getXrayTraceSampled();
   }
 
   /**

--- a/packages/tracer/src/TracerInterface.ts
+++ b/packages/tracer/src/TracerInterface.ts
@@ -13,6 +13,7 @@ interface TracerInterface {
   captureMethod(options?: CaptureMethodOptions): MethodDecorator
   getSegment(): Segment | Subsegment | undefined
   getRootXrayTraceId(): string | undefined
+  isTraceSampled(): boolean
   isTracingEnabled(): boolean
   putAnnotation: (key: string, value: string | number | boolean) => void
   putMetadata: (key: string, value: unknown, namespace?: string | undefined) => void

--- a/packages/tracer/tests/unit/Tracer.test.ts
+++ b/packages/tracer/tests/unit/Tracer.test.ts
@@ -277,6 +277,18 @@ describe('Class: Tracer', () => {
 
     });
 
+    test('when called and Tracer is disabled, it returns undefined', () => {
+
+      // Prepare
+      const tracer: Tracer = new Tracer({ enabled: false });
+
+      // Act
+      const xRayTraceId = tracer.getRootXrayTraceId();
+
+      // Assess
+      expect(xRayTraceId).toBe(undefined);
+    });
+
   });
 
   describe('Method: isTraceSampled', () => {
@@ -285,6 +297,19 @@ describe('Class: Tracer', () => {
 
       // Prepare
       const tracer: Tracer = new Tracer();
+
+      // Act
+      const xRayTraceSampled = tracer.isTraceSampled();
+
+      // Assess
+      expect(xRayTraceSampled).toBe(false);
+
+    });
+
+    test('when called and Trace is disabled, it returns false', () => {
+
+      // Prepare
+      const tracer: Tracer = new Tracer({ enabled: false });
 
       // Act
       const xRayTraceSampled = tracer.isTraceSampled();

--- a/packages/tracer/tests/unit/Tracer.test.ts
+++ b/packages/tracer/tests/unit/Tracer.test.ts
@@ -287,7 +287,7 @@ describe('Class: Tracer', () => {
       const tracer: Tracer = new Tracer();
 
       // Act
-      const xRayTraceSampled = tracer.getRootXrayTraceId();
+      const xRayTraceSampled = tracer.isTraceSampled();
 
       // Assess
       expect(xRayTraceSampled).toBe(true);

--- a/packages/tracer/tests/unit/Tracer.test.ts
+++ b/packages/tracer/tests/unit/Tracer.test.ts
@@ -279,6 +279,23 @@ describe('Class: Tracer', () => {
 
   });
 
+  describe('Method: isTraceSampled', () => {
+
+    test('when called, it returns true if the Sampled flag is set', () => {
+
+      // Prepare
+      const tracer: Tracer = new Tracer();
+
+      // Act
+      const xRayTraceSampled = tracer.getRootXrayTraceId();
+
+      // Assess
+      expect(xRayTraceSampled).toBe(true);
+
+    });
+
+  });
+
   describe('Method: getSegment', () => {
 
     test('when called and no segment is returned, it logs a warning', () => {

--- a/packages/tracer/tests/unit/Tracer.test.ts
+++ b/packages/tracer/tests/unit/Tracer.test.ts
@@ -290,7 +290,7 @@ describe('Class: Tracer', () => {
       const xRayTraceSampled = tracer.isTraceSampled();
 
       // Assess
-      expect(xRayTraceSampled).toBe(true);
+      expect(xRayTraceSampled).toBe(false);
 
     });
 


### PR DESCRIPTION
## Description of your changes

This change adds a new `isTraceSampled` method to `Tracer`. It lets users find out if the current trace is sampled or not. This information may be included in structured logs along with the Trace ID.

### How to verify this change

Set the `Sampled=1` flag in the `_X_AMZN_TRACE_ID` environment variable and assert that `isTraceSampled` returns `true`.
Example:    `Root=1-5759e988-bd862e3fe1be46a994272793;Parent=557abcec3ee5a047;Sampled=1`

### Related issues, RFCs

**Issue number:** #1378

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-typescript/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [ ] I have made corresponding changes to the *documentation*
- [ ] I have made corresponding changes to the *examples*
- [x] My changes generate *no new warnings*
- [x] The *code coverage* hasn't decreased
- [x] I have *added tests* that prove my change is effective and works
- [x] New and existing *unit tests pass* locally and in Github Actions
- [x] Any *dependent changes have been merged and published*
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

***Is it a breaking change?:*** NO

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.