### PR TITLE
feat(idempotency): `makeHandlerIdempotent` middy middleware

### DIFF
--- a/packages/idempotency/src/IdempotencyConfig.ts
+++ b/packages/idempotency/src/IdempotencyConfig.ts
@@ -1,3 +1,4 @@
+import { EnvironmentVariablesService } from './config';
 import type { Context } from 'aws-lambda';
 import type { IdempotencyConfigOptions } from './types';
 
@@ -10,6 +11,8 @@ class IdempotencyConfig {
   public payloadValidationJmesPath?: string;
   public throwOnNoIdempotencyKey: boolean;
   public useLocalCache: boolean;
+  readonly #envVarsService: EnvironmentVariablesService;
+  readonly #enabled: boolean = true;
 
   public constructor(config: IdempotencyConfigOptions) {
     this.eventKeyJmesPath = config.eventKeyJmesPath ?? '';
@@ -20,6 +23,17 @@ class IdempotencyConfig {
     this.maxLocalCacheSize = config.maxLocalCacheSize ?? 1000;
     this.hashFunction = config.hashFunction ?? 'md5';
     this.lambdaContext = config.lambdaContext;
+    this.#envVarsService = new EnvironmentVariablesService();
+    this.#enabled = this.#envVarsService.getIdempotencyEnabled();
+  }
+
+  /**
+   * Determines if the idempotency feature is enabled.
+   *
+   * @returns {boolean} Returns true if the idempotency feature is enabled.
+   */
+  public isEnabled(): boolean {
+    return this.#enabled;
   }
 
   public registerLambdaContext(context: Context): void {

--- a/packages/idempotency/src/IdempotencyHandler.ts
+++ b/packages/idempotency/src/IdempotencyHandler.ts
@@ -36,9 +36,9 @@ export class IdempotencyHandler<U> {
     });
   }
 
-  public determineResultFromIdempotencyRecord(
+  public static determineResultFromIdempotencyRecord(
     idempotencyRecord: IdempotencyRecord
-  ): Promise<U> | U {
+  ): Promise<unknown> | unknown {
     if (idempotencyRecord.getStatus() === IdempotencyRecordStatus.EXPIRED) {
       throw new IdempotencyInconsistentStateError(
         'Item has expired during processing and may not longer be valid.'
@@ -61,7 +61,7 @@ export class IdempotencyHandler<U> {
       }
     }
 
-    return idempotencyRecord.getResponse() as U;
+    return idempotencyRecord.getResponse();
   }
 
   public async getFunctionResult(): Promise<U> {
@@ -115,7 +115,9 @@ export class IdempotencyHandler<U> {
       }
     }
     /* istanbul ignore next */
-    throw new Error('This should never happen');
+    throw new Error(
+      'This should never happen, if you see this please open an issue.'
+    );
   }
 
   public async processIdempotency(): Promise<U> {
@@ -128,7 +130,9 @@ export class IdempotencyHandler<U> {
         const idempotencyRecord: IdempotencyRecord =
           await this.persistenceStore.getRecord(this.functionPayloadToBeHashed);
 
-        return this.determineResultFromIdempotencyRecord(idempotencyRecord);
+        return IdempotencyHandler.determineResultFromIdempotencyRecord(
+          idempotencyRecord
+        ) as U;
       } else {
         throw new IdempotencyPersistenceLayerError();
       }

--- a/packages/idempotency/src/IdempotencyHandler.ts
+++ b/packages/idempotency/src/IdempotencyHandler.ts
@@ -8,6 +8,7 @@ import {
 } from './Exceptions';
 import { BasePersistenceLayer, IdempotencyRecord } from './persistence';
 import { IdempotencyConfig } from './IdempotencyConfig';
+import { MAX_RETRIES } from './constants';
 
 export class IdempotencyHandler<U> {
   private readonly fullFunctionPayload: Record<string, unknown>;
@@ -96,28 +97,30 @@ export class IdempotencyHandler<U> {
 
   /**
    * Main entry point for the handler
-   * IdempotencyInconsistentStateError can happen under rare but expected cases
-   * when persistent state changes in the small time between put & get requests.
-   * In most cases we can retry successfully on this exception.
+   *
+   * In some rare cases, when the persistent state changes in small time
+   * window, we might get an `IdempotencyInconsistentStateError`. In such
+   * cases we can safely retry the handling a few times.
    */
   public async handle(): Promise<U> {
-    const MAX_RETRIES = 2;
-    for (let i = 1; i <= MAX_RETRIES; i++) {
+    let e;
+    for (let retryNo = 0; retryNo <= MAX_RETRIES; retryNo++) {
       try {
         return await this.processIdempotency();
-      } catch (e) {
+      } catch (error) {
         if (
-          !(e instanceof IdempotencyAlreadyInProgressError) ||
-          i === MAX_RETRIES
+          error instanceof IdempotencyInconsistentStateError &&
+          retryNo < MAX_RETRIES
         ) {
-          throw e;
+          // Retry
+          continue;
         }
+        // Retries exhausted or other error
+        e = error;
+        break;
       }
     }
-    /* istanbul ignore next */
-    throw new Error(
-      'This should never happen, if you see this please open an issue.'
-    );
+    throw e;
   }
 
   public async processIdempotency(): Promise<U> {

--- a/packages/idempotency/src/config/ConfigServiceInterface.ts
+++ b/packages/idempotency/src/config/ConfigServiceInterface.ts
@@ -4,6 +4,8 @@ interface ConfigServiceInterface {
   getServiceName(): string;
 
   getFunctionName(): string;
+
+  getIdempotencyEnabled(): boolean;
 }
 
 export { ConfigServiceInterface };

--- a/packages/idempotency/src/config/EnvironmentVariablesService.ts
+++ b/packages/idempotency/src/config/EnvironmentVariablesService.ts
@@ -21,6 +21,7 @@ class EnvironmentVariablesService
 {
   // Reserved environment variables
   private functionNameVariable = 'AWS_LAMBDA_FUNCTION_NAME';
+  private idempotencyDisabledVariable = 'POWERTOOLS_IDEMPOTENCY_DISABLED';
 
   /**
    * It returns the value of the AWS_LAMBDA_FUNCTION_NAME environment variable.
@@ -29,6 +30,17 @@ class EnvironmentVariablesService
    */
   public getFunctionName(): string {
     return this.get(this.functionNameVariable);
+  }
+
+  /**
+   * It returns whether the idempotency feature is enabled or not.
+   *
+   * Reads the value of the POWERTOOLS_IDEMPOTENCY_DISABLED environment variable.
+   *
+   * @returns {boolean}
+   */
+  public getIdempotencyEnabled(): boolean {
+    return !this.isValueTrue(this.get(this.idempotencyDisabledVariable));
   }
 }
 

--- a/packages/idempotency/src/constants.ts
+++ b/packages/idempotency/src/constants.ts
@@ -1,0 +1,10 @@
+/**
+ * Number of times to retry a request in case of `IdempotencyInconsistentStateError`
+ *
+ * Used in `IdempotencyHandler` and `makeHandlerIdempotent`
+ *
+ * @internal
+ */
+const MAX_RETRIES = 2;
+
+export { MAX_RETRIES };

--- a/packages/idempotency/src/middleware/index.ts
+++ b/packages/idempotency/src/middleware/index.ts
@@ -1,0 +1,1 @@
+export * from './makeHandlerIdempotent';

--- a/packages/idempotency/src/middleware/makeHandlerIdempotent.ts
+++ b/packages/idempotency/src/middleware/makeHandlerIdempotent.ts
@@ -165,7 +165,9 @@ const makeHandlerIdempotent = (
     };
   } else {
     return {
-      before: () => ({}),
+      before: () => {
+        return undefined;
+      },
     };
   }
 };

--- a/packages/idempotency/src/middleware/makeHandlerIdempotent.ts
+++ b/packages/idempotency/src/middleware/makeHandlerIdempotent.ts
@@ -66,6 +66,7 @@ const makeHandlerIdempotent = (
    * cases we can safely retry the handling a few times.
    *
    * @param request - The Middy request object
+   * @param retryNo - The number of times the handler has been retried
    */
   const before = async (
     request: MiddyLikeRequest,
@@ -156,11 +157,17 @@ const makeHandlerIdempotent = (
     }
   };
 
-  return {
-    before,
-    after,
-    onError,
-  };
+  if (idempotencyConfig.isEnabled()) {
+    return {
+      before,
+      after,
+      onError,
+    };
+  } else {
+    return {
+      before: () => ({}),
+    };
+  }
 };
 
 export { makeHandlerIdempotent };

--- a/packages/idempotency/src/middleware/makeHandlerIdempotent.ts
+++ b/packages/idempotency/src/middleware/makeHandlerIdempotent.ts
@@ -1,0 +1,144 @@
+import { IdempotencyHandler } from '../IdempotencyHandler';
+import { IdempotencyConfig } from '../IdempotencyConfig';
+import { cleanupMiddlewares } from '@aws-lambda-powertools/commons/lib/middleware';
+import {
+  IdempotencyItemAlreadyExistsError,
+  IdempotencyPersistenceLayerError,
+} from '../Exceptions';
+import { IdempotencyRecord } from '../persistence';
+import type {
+  MiddlewareLikeObj,
+  MiddyLikeRequest,
+} from '@aws-lambda-powertools/commons';
+import type { IdempotencyLambdaHandlerOptions } from '../types';
+
+/**
+ * A middy middleware to make your Lambda Handler idempotent.
+ *
+ * @example
+ * ```typescript
+ * import {
+ *   makeHandlerIdempotent,
+ *   DynamoDBPersistenceLayer,
+ * } from '@aws-lambda-powertools/idempotency';
+ * import middy from '@middy/core';
+ *
+ * const dynamoDBPersistenceLayer = new DynamoDBPersistenceLayer({
+ *   tableName: 'idempotencyTable',
+ * })
+ *
+ * const lambdaHandler = async (_event: unknown, _context: unknown) => {
+ *   //...
+ * };
+ *
+ * export const handler = middy(lambdaHandler)
+ *  .use(makeHandlerIdempotent({ persistenceStore: dynamoDBPersistenceLayer }));
+ * ```
+ *
+ * @param options - Options for the idempotency middleware
+ */
+const makeHandlerIdempotent = (
+  options: IdempotencyLambdaHandlerOptions
+): MiddlewareLikeObj => {
+  const idempotencyConfig = options.config
+    ? options.config
+    : new IdempotencyConfig({});
+  const persistenceStore = options.persistenceStore;
+  persistenceStore.configure({
+    config: idempotencyConfig,
+  });
+
+  /**
+   * Function called before the handler is executed.
+   *
+   * Before the handler is executed, we need to check if there is already an
+   * execution in progress for the given idempotency key. If there is, we
+   * need to determine its status and return the appropriate response or
+   * throw an error.
+   *
+   * If there is no execution in progress, we need to save a record to the
+   * idempotency store to indicate that an execution is in progress.
+   *
+   * @param request - The Middy request object
+   */
+  const before = async (request: MiddyLikeRequest): Promise<unknown | void> => {
+    try {
+      await persistenceStore.saveInProgress(
+        request.event as Record<string, unknown>,
+        request.context.getRemainingTimeInMillis()
+      );
+    } catch (error) {
+      if (error instanceof IdempotencyItemAlreadyExistsError) {
+        const idempotencyRecord: IdempotencyRecord =
+          await persistenceStore.getRecord(
+            request.event as Record<string, unknown>
+          );
+
+        const response =
+          await IdempotencyHandler.determineResultFromIdempotencyRecord(
+            idempotencyRecord
+          );
+        if (response) {
+          // Cleanup other middlewares
+          cleanupMiddlewares(request);
+
+          return response;
+        }
+      } else {
+        throw new IdempotencyPersistenceLayerError(
+          'Failed to save in progress record to idempotency store'
+        );
+      }
+    }
+  };
+
+  /**
+   * Function called after the handler has executed successfully.
+   *
+   * When the handler returns successfully, we need to update the record in the
+   * idempotency store to indicate that the execution has completed and
+   * store its result.
+   *
+   * @param request - The Middy request object
+   */
+  const after = async (request: MiddyLikeRequest): Promise<void> => {
+    try {
+      await persistenceStore.saveSuccess(
+        request.event as Record<string, unknown>,
+        request.response as Record<string, unknown>
+      );
+    } catch (e) {
+      throw new IdempotencyPersistenceLayerError(
+        'Failed to update success record to idempotency store'
+      );
+    }
+  };
+
+  /**
+   * Function called when an error occurs in the handler.
+   *
+   * When an error is thrown in the handler, we need to delete the record from the
+   * idempotency store.
+   *
+   * @param request - The Middy request object
+   */
+  const onError = async (request: MiddyLikeRequest): Promise<void> => {
+    try {
+      await persistenceStore.deleteRecord(
+        request.event as Record<string, unknown>
+      );
+    } catch (error) {
+      throw new IdempotencyPersistenceLayerError(
+        'Failed to delete record from idempotency store'
+      );
+    }
+  };
+
+  return {
+    before,
+    after,
+    onError,
+  };
+};
+
+export { makeHandlerIdempotent };

--- a/packages/idempotency/src/middleware/makeHandlerIdempotent.ts
+++ b/packages/idempotency/src/middleware/makeHandlerIdempotent.ts
@@ -25,7 +25,7 @@ import type { IdempotencyLambdaHandlerOptions } from '../types';
  *
  * const dynamoDBPersistenceLayer = new DynamoDBPersistenceLayer({
  *   tableName: 'idempotencyTable',
- * })
+ * });
  *
  * const lambdaHandler = async (_event: unknown, _context: unknown) => {
  *   //...

--- a/packages/idempotency/src/types/AnyFunction.ts
+++ b/packages/idempotency/src/types/AnyFunction.ts
@@ -2,8 +2,14 @@
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type GenericTempRecord = Record<string, any>;
 
-type AnyFunctionWithRecord<U> = (record: GenericTempRecord) => Promise<U> | U;
+type AnyFunctionWithRecord<U> = (
+  payload: GenericTempRecord,
+  ...args: unknown[]
+) => Promise<U> | U;
 
-type AnyIdempotentFunction<U> = (record: GenericTempRecord) => Promise<U>;
+type AnyIdempotentFunction<U> = (
+  payload: GenericTempRecord,
+  ...args: unknown[]
+) => Promise<U>;
 
 export { GenericTempRecord, AnyFunctionWithRecord, AnyIdempotentFunction };

--- a/packages/idempotency/tests/helpers/idempotencyUtils.ts
+++ b/packages/idempotency/tests/helpers/idempotencyUtils.ts
@@ -3,6 +3,7 @@ import { v4 } from 'uuid';
 import { AttributeType, BillingMode, Table } from 'aws-cdk-lib/aws-dynamodb';
 import { NodejsFunction } from 'aws-cdk-lib/aws-lambda-nodejs';
 import { TEST_RUNTIMES } from '../../../commons/tests/utils/e2eUtils';
+import { BasePersistenceLayer } from '../../src/persistence';
 import path from 'path';
 
 export const createIdempotencyResources = (
@@ -40,3 +41,17 @@ export const createIdempotencyResources = (
 
   ddbTable.grantReadWriteData(nodeJsFunction);
 };
+
+/**
+ * Dummy class to test the abstract class BasePersistenceLayer.
+ *
+ * This class is used in the unit tests.
+ */
+class PersistenceLayerTestClass extends BasePersistenceLayer {
+  protected _deleteRecord = jest.fn();
+  protected _getRecord = jest.fn();
+  protected _putRecord = jest.fn();
+  protected _updateRecord = jest.fn();
+}
+
+export { PersistenceLayerTestClass };

--- a/packages/idempotency/tests/unit/IdempotencyHandler.test.ts
+++ b/packages/idempotency/tests/unit/IdempotencyHandler.test.ts
@@ -56,7 +56,7 @@ describe('Class IdempotencyHandler', () => {
       expect(stubRecord.getStatus()).toBe(IdempotencyRecordStatus.INPROGRESS);
 
       try {
-        await idempotentHandler.determineResultFromIdempotencyRecord(
+        await IdempotencyHandler.determineResultFromIdempotencyRecord(
           stubRecord
         );
       } catch (e) {
@@ -78,7 +78,7 @@ describe('Class IdempotencyHandler', () => {
       expect(stubRecord.getStatus()).toBe(IdempotencyRecordStatus.INPROGRESS);
 
       try {
-        await idempotentHandler.determineResultFromIdempotencyRecord(
+        await IdempotencyHandler.determineResultFromIdempotencyRecord(
           stubRecord
         );
       } catch (e) {
@@ -100,7 +100,7 @@ describe('Class IdempotencyHandler', () => {
       expect(stubRecord.getStatus()).toBe(IdempotencyRecordStatus.EXPIRED);
 
       try {
-        await idempotentHandler.determineResultFromIdempotencyRecord(
+        await IdempotencyHandler.determineResultFromIdempotencyRecord(
           stubRecord
         );
       } catch (e) {
@@ -157,11 +157,8 @@ describe('Class IdempotencyHandler', () => {
         .spyOn(mockIdempotencyOptions.persistenceStore, 'saveInProgress')
         .mockRejectedValue(new Error('Some error'));
       const mockDetermineResultFromIdempotencyRecord = jest
-        .spyOn(
-          IdempotencyHandler.prototype,
-          'determineResultFromIdempotencyRecord'
-        )
-        .mockResolvedValue('result');
+        .spyOn(IdempotencyHandler, 'determineResultFromIdempotencyRecord')
+        .mockImplementation(() => 'result');
 
       await expect(idempotentHandler.processIdempotency()).rejects.toThrow(
         IdempotencyPersistenceLayerError
@@ -191,11 +188,8 @@ describe('Class IdempotencyHandler', () => {
         .spyOn(mockIdempotencyOptions.persistenceStore, 'getRecord')
         .mockImplementation(() => Promise.resolve(stubRecord));
       const mockDetermineResultFromIdempotencyRecord = jest
-        .spyOn(
-          IdempotencyHandler.prototype,
-          'determineResultFromIdempotencyRecord'
-        )
-        .mockResolvedValue('result');
+        .spyOn(IdempotencyHandler, 'determineResultFromIdempotencyRecord')
+        .mockImplementation(() => 'result');
 
       await expect(idempotentHandler.processIdempotency()).resolves.toBe(
         'result'

--- a/packages/idempotency/tests/unit/IdempotencyHandler.test.ts
+++ b/packages/idempotency/tests/unit/IdempotencyHandler.test.ts
@@ -13,6 +13,7 @@ import { IdempotencyRecordStatus } from '../../src/types';
 import { BasePersistenceLayer, IdempotencyRecord } from '../../src/persistence';
 import { IdempotencyHandler } from '../../src/IdempotencyHandler';
 import { IdempotencyConfig } from '../../src/IdempotencyConfig';
+import { MAX_RETRIES } from '../../src/constants';
 
 class PersistenceLayerTestClass extends BasePersistenceLayer {
   protected _deleteRecord = jest.fn();
@@ -112,7 +113,7 @@ describe('Class IdempotencyHandler', () => {
   describe('Method: handle', () => {
     afterAll(() => jest.restoreAllMocks()); // restore processIdempotency for other tests
 
-    test('when IdempotencyAlreadyInProgressError is thrown, it retries two times', async () => {
+    test('when IdempotencyAlreadyInProgressError is thrown, it retries once', async () => {
       const mockProcessIdempotency = jest
         .spyOn(IdempotencyHandler.prototype, 'processIdempotency')
         .mockRejectedValue(
@@ -123,7 +124,17 @@ describe('Class IdempotencyHandler', () => {
       await expect(idempotentHandler.handle()).rejects.toThrow(
         IdempotencyAlreadyInProgressError
       );
-      expect(mockProcessIdempotency).toHaveBeenCalledTimes(2);
+      expect(mockProcessIdempotency).toHaveBeenCalledTimes(1);
+    });
+
+    test('when IdempotencyInconsistentStateError is thrown, it retries until max retries are exhausted', async () => {
+      const mockProcessIdempotency = jest
+        .spyOn(IdempotencyHandler.prototype, 'processIdempotency')
+        .mockRejectedValue(new IdempotencyInconsistentStateError());
+      await expect(idempotentHandler.handle()).rejects.toThrow(
+        IdempotencyInconsistentStateError
+      );
+      expect(mockProcessIdempotency).toHaveBeenCalledTimes(MAX_RETRIES + 1);
     });
 
     test('when non IdempotencyAlreadyInProgressError is thrown, it rejects', async () => {

--- a/packages/idempotency/tests/unit/makeHandlerIdempotent.test.ts
+++ b/packages/idempotency/tests/unit/makeHandlerIdempotent.test.ts
@@ -7,7 +7,7 @@ import { makeHandlerIdempotent } from '../../src/middleware';
 import { helloworldContext as dummyContext } from '../../../commons/src/samples/resources/contexts';
 import { Custom as dummyEvent } from '../../../commons/src/samples/resources/events';
 import { IdempotencyRecordStatus } from '../../src/types';
-import { BasePersistenceLayer, IdempotencyRecord } from '../../src/persistence';
+import { IdempotencyRecord } from '../../src/persistence';
 import {
   IdempotencyPersistenceLayerError,
   IdempotencyItemAlreadyExistsError,
@@ -15,22 +15,16 @@ import {
 } from '../../src/Exceptions';
 import { IdempotencyConfig } from '../../src/IdempotencyConfig';
 import middy from '@middy/core';
-import type { Context } from 'aws-lambda';
 import { MAX_RETRIES } from '../../src/constants';
-
-class PersistenceLayerTestClass extends BasePersistenceLayer {
-  protected _deleteRecord = jest.fn();
-  protected _getRecord = jest.fn();
-  protected _putRecord = jest.fn();
-  protected _updateRecord = jest.fn();
-}
+import { PersistenceLayerTestClass } from '../helpers/idempotencyUtils';
+import type { Context } from 'aws-lambda';
 
 const mockIdempotencyOptions = {
   persistenceStore: new PersistenceLayerTestClass(),
 };
 const remainingTImeInMillis = 10000;
 
-describe('Middy middleware', () => {
+describe('Middleware: makeHandlerIdempotent', () => {
   const ENVIRONMENT_VARIABLES = process.env;
   const context = dummyContext;
   context.getRemainingTimeInMillis = jest
@@ -50,229 +44,228 @@ describe('Middy middleware', () => {
   afterAll(() => {
     process.env = ENVIRONMENT_VARIABLES;
   });
-  describe('Middleware: captureLambdaHandler', () => {
-    it('handles a successful execution', async () => {
-      // Prepare
-      const handler = middy(
-        async (_event: unknown, _context: Context): Promise<boolean> => true
-      ).use(
-        makeHandlerIdempotent({
-          ...mockIdempotencyOptions,
-          config: new IdempotencyConfig({}),
-        })
-      );
-      const saveInProgressSpy = jest.spyOn(
-        mockIdempotencyOptions.persistenceStore,
-        'saveInProgress'
-      );
-      const saveSuccessSpy = jest.spyOn(
-        mockIdempotencyOptions.persistenceStore,
-        'saveSuccess'
-      );
 
-      // Act
-      const result = await handler(event, context);
+  it('handles a successful execution', async () => {
+    // Prepare
+    const handler = middy(
+      async (_event: unknown, _context: Context): Promise<boolean> => true
+    ).use(
+      makeHandlerIdempotent({
+        ...mockIdempotencyOptions,
+        config: new IdempotencyConfig({}),
+      })
+    );
+    const saveInProgressSpy = jest.spyOn(
+      mockIdempotencyOptions.persistenceStore,
+      'saveInProgress'
+    );
+    const saveSuccessSpy = jest.spyOn(
+      mockIdempotencyOptions.persistenceStore,
+      'saveSuccess'
+    );
 
-      // Assess
-      expect(result).toBe(true);
-      expect(saveInProgressSpy).toHaveBeenCalledTimes(1);
-      expect(saveInProgressSpy).toHaveBeenCalledWith(
-        event,
-        remainingTImeInMillis
-      );
-      expect(saveSuccessSpy).toHaveBeenCalledTimes(1);
-      expect(saveSuccessSpy).toHaveBeenCalledWith(event, true);
+    // Act
+    const result = await handler(event, context);
+
+    // Assess
+    expect(result).toBe(true);
+    expect(saveInProgressSpy).toHaveBeenCalledTimes(1);
+    expect(saveInProgressSpy).toHaveBeenCalledWith(
+      event,
+      remainingTImeInMillis
+    );
+    expect(saveSuccessSpy).toHaveBeenCalledTimes(1);
+    expect(saveSuccessSpy).toHaveBeenCalledWith(event, true);
+  });
+  it('handles an execution that throws an error', async () => {
+    // Prepare
+    const handler = middy(
+      async (_event: unknown, _context: Context): Promise<boolean> => {
+        throw new Error('Something went wrong');
+      }
+    ).use(makeHandlerIdempotent(mockIdempotencyOptions));
+    const saveInProgressSpy = jest.spyOn(
+      mockIdempotencyOptions.persistenceStore,
+      'saveInProgress'
+    );
+    const deleteRecordSpy = jest.spyOn(
+      mockIdempotencyOptions.persistenceStore,
+      'deleteRecord'
+    );
+
+    // Act && Assess
+    await expect(handler(event, context)).rejects.toThrow();
+    expect(saveInProgressSpy).toHaveBeenCalledTimes(1);
+    expect(saveInProgressSpy).toHaveBeenCalledWith(
+      event,
+      remainingTImeInMillis
+    );
+    expect(deleteRecordSpy).toHaveBeenCalledTimes(1);
+    expect(deleteRecordSpy).toHaveBeenCalledWith(event);
+  });
+  it('thows an error if the persistence layer throws an error when saving in progress', async () => {
+    // Prepare
+    const handler = middy(
+      async (_event: unknown, _context: Context): Promise<boolean> => true
+    ).use(makeHandlerIdempotent(mockIdempotencyOptions));
+    jest
+      .spyOn(mockIdempotencyOptions.persistenceStore, 'saveInProgress')
+      .mockRejectedValue(new Error('Something went wrong'));
+
+    // Act && Assess
+    await expect(handler(event, context)).rejects.toThrowError(
+      new IdempotencyPersistenceLayerError(
+        'Failed to save in progress record to idempotency store'
+      )
+    );
+  });
+  it('thows an error if the persistence layer throws an error when saving a successful operation', async () => {
+    // Prepare
+    const handler = middy(
+      async (_event: unknown, _context: Context): Promise<boolean> => true
+    ).use(makeHandlerIdempotent(mockIdempotencyOptions));
+    jest
+      .spyOn(mockIdempotencyOptions.persistenceStore, 'saveSuccess')
+      .mockRejectedValue(new Error('Something went wrong'));
+
+    // Act && Assess
+    await expect(handler(event, context)).rejects.toThrowError(
+      new IdempotencyPersistenceLayerError(
+        'Failed to update success record to idempotency store'
+      )
+    );
+  });
+  it('thows an error if the persistence layer throws an error when deleting a record', async () => {
+    // Prepare
+    const handler = middy(
+      async (_event: unknown, _context: Context): Promise<boolean> => {
+        throw new Error('Something went wrong');
+      }
+    ).use(makeHandlerIdempotent(mockIdempotencyOptions));
+    jest
+      .spyOn(mockIdempotencyOptions.persistenceStore, 'deleteRecord')
+      .mockRejectedValue(new Error('Something went wrong'));
+
+    // Act && Assess
+    await expect(handler(event, context)).rejects.toThrow(
+      new IdempotencyPersistenceLayerError(
+        'Failed to delete record from idempotency store'
+      )
+    );
+  });
+  it('returns the stored response if the operation has already been executed', async () => {
+    // Prepare
+    const handler = middy(
+      async (_event: unknown, _context: Context): Promise<boolean> => true
+    ).use(makeHandlerIdempotent(mockIdempotencyOptions));
+    jest
+      .spyOn(mockIdempotencyOptions.persistenceStore, 'saveInProgress')
+      .mockRejectedValue(new IdempotencyItemAlreadyExistsError());
+    const stubRecord = new IdempotencyRecord({
+      idempotencyKey: 'idempotencyKey',
+      expiryTimestamp: Date.now() + 10000,
+      inProgressExpiryTimestamp: 0,
+      responseData: { response: false },
+      payloadHash: 'payloadHash',
+      status: IdempotencyRecordStatus.COMPLETED,
     });
-    it('handles an execution that throws an error', async () => {
-      // Prepare
-      const handler = middy(
-        async (_event: unknown, _context: Context): Promise<boolean> => {
-          throw new Error('Something went wrong');
-        }
-      ).use(makeHandlerIdempotent(mockIdempotencyOptions));
-      const saveInProgressSpy = jest.spyOn(
-        mockIdempotencyOptions.persistenceStore,
-        'saveInProgress'
-      );
-      const deleteRecordSpy = jest.spyOn(
-        mockIdempotencyOptions.persistenceStore,
-        'deleteRecord'
-      );
+    const getRecordSpy = jest
+      .spyOn(mockIdempotencyOptions.persistenceStore, 'getRecord')
+      .mockResolvedValue(stubRecord);
 
-      // Act && Assess
-      await expect(handler(event, context)).rejects.toThrow();
-      expect(saveInProgressSpy).toHaveBeenCalledTimes(1);
-      expect(saveInProgressSpy).toHaveBeenCalledWith(
-        event,
-        remainingTImeInMillis
-      );
-      expect(deleteRecordSpy).toHaveBeenCalledTimes(1);
-      expect(deleteRecordSpy).toHaveBeenCalledWith(event);
+    // Act
+    const result = await handler(event, context);
+
+    // Assess
+    expect(result).toStrictEqual({ response: false });
+    expect(getRecordSpy).toHaveBeenCalledTimes(1);
+    expect(getRecordSpy).toHaveBeenCalledWith(event);
+  });
+  it('retries if the record is in an inconsistent state', async () => {
+    // Prepare
+    const handler = middy(
+      async (_event: unknown, _context: Context): Promise<boolean> => true
+    ).use(makeHandlerIdempotent(mockIdempotencyOptions));
+    jest
+      .spyOn(mockIdempotencyOptions.persistenceStore, 'saveInProgress')
+      .mockRejectedValue(new IdempotencyItemAlreadyExistsError());
+    const stubRecordInconsistent = new IdempotencyRecord({
+      idempotencyKey: 'idempotencyKey',
+      expiryTimestamp: Date.now() + 10000,
+      inProgressExpiryTimestamp: 0,
+      responseData: { response: false },
+      payloadHash: 'payloadHash',
+      status: IdempotencyRecordStatus.EXPIRED,
     });
-    it('thows an error if the persistence layer throws an error when saving in progress', async () => {
-      // Prepare
-      const handler = middy(
-        async (_event: unknown, _context: Context): Promise<boolean> => true
-      ).use(makeHandlerIdempotent(mockIdempotencyOptions));
-      jest
-        .spyOn(mockIdempotencyOptions.persistenceStore, 'saveInProgress')
-        .mockRejectedValue(new Error('Something went wrong'));
-
-      // Act && Assess
-      await expect(handler(event, context)).rejects.toThrowError(
-        new IdempotencyPersistenceLayerError(
-          'Failed to save in progress record to idempotency store'
-        )
-      );
+    const stubRecord = new IdempotencyRecord({
+      idempotencyKey: 'idempotencyKey',
+      expiryTimestamp: Date.now() + 10000,
+      inProgressExpiryTimestamp: 0,
+      responseData: { response: false },
+      payloadHash: 'payloadHash',
+      status: IdempotencyRecordStatus.COMPLETED,
     });
-    it('thows an error if the persistence layer throws an error when saving a successful operation', async () => {
-      // Prepare
-      const handler = middy(
-        async (_event: unknown, _context: Context): Promise<boolean> => true
-      ).use(makeHandlerIdempotent(mockIdempotencyOptions));
-      jest
-        .spyOn(mockIdempotencyOptions.persistenceStore, 'saveSuccess')
-        .mockRejectedValue(new Error('Something went wrong'));
+    const getRecordSpy = jest
+      .spyOn(mockIdempotencyOptions.persistenceStore, 'getRecord')
+      .mockResolvedValueOnce(stubRecordInconsistent)
+      .mockResolvedValueOnce(stubRecord);
 
-      // Act && Assess
-      await expect(handler(event, context)).rejects.toThrowError(
-        new IdempotencyPersistenceLayerError(
-          'Failed to update success record to idempotency store'
-        )
-      );
+    // Act
+    const result = await handler(event, context);
+
+    // Assess
+    expect(result).toStrictEqual({ response: false });
+    expect(getRecordSpy).toHaveBeenCalledTimes(2);
+  });
+  it('throws after all the retries have been exhausted if the record is in an inconsistent state', async () => {
+    // Prepare
+    const handler = middy(
+      async (_event: unknown, _context: Context): Promise<boolean> => true
+    ).use(makeHandlerIdempotent(mockIdempotencyOptions));
+    jest
+      .spyOn(mockIdempotencyOptions.persistenceStore, 'saveInProgress')
+      .mockRejectedValue(new IdempotencyItemAlreadyExistsError());
+    const stubRecordInconsistent = new IdempotencyRecord({
+      idempotencyKey: 'idempotencyKey',
+      expiryTimestamp: Date.now() + 10000,
+      inProgressExpiryTimestamp: 0,
+      responseData: { response: false },
+      payloadHash: 'payloadHash',
+      status: IdempotencyRecordStatus.EXPIRED,
     });
-    it('thows an error if the persistence layer throws an error when deleting a record', async () => {
-      // Prepare
-      const handler = middy(
-        async (_event: unknown, _context: Context): Promise<boolean> => {
-          throw new Error('Something went wrong');
-        }
-      ).use(makeHandlerIdempotent(mockIdempotencyOptions));
-      jest
-        .spyOn(mockIdempotencyOptions.persistenceStore, 'deleteRecord')
-        .mockRejectedValue(new Error('Something went wrong'));
+    const getRecordSpy = jest
+      .spyOn(mockIdempotencyOptions.persistenceStore, 'getRecord')
+      .mockResolvedValue(stubRecordInconsistent);
 
-      // Act && Assess
-      await expect(handler(event, context)).rejects.toThrow(
-        new IdempotencyPersistenceLayerError(
-          'Failed to delete record from idempotency store'
-        )
-      );
-    });
-    it('returns the stored response if the operation has already been executed', async () => {
-      // Prepare
-      const handler = middy(
-        async (_event: unknown, _context: Context): Promise<boolean> => true
-      ).use(makeHandlerIdempotent(mockIdempotencyOptions));
-      jest
-        .spyOn(mockIdempotencyOptions.persistenceStore, 'saveInProgress')
-        .mockRejectedValue(new IdempotencyItemAlreadyExistsError());
-      const stubRecord = new IdempotencyRecord({
-        idempotencyKey: 'idempotencyKey',
-        expiryTimestamp: Date.now() + 10000,
-        inProgressExpiryTimestamp: 0,
-        responseData: { response: false },
-        payloadHash: 'payloadHash',
-        status: IdempotencyRecordStatus.COMPLETED,
-      });
-      const getRecordSpy = jest
-        .spyOn(mockIdempotencyOptions.persistenceStore, 'getRecord')
-        .mockResolvedValue(stubRecord);
+    // Act & Assess
+    await expect(handler(event, context)).rejects.toThrowError(
+      new IdempotencyInconsistentStateError(
+        'Item has expired during processing and may not longer be valid.'
+      )
+    );
+    expect(getRecordSpy).toHaveBeenCalledTimes(MAX_RETRIES + 1);
+  });
+  it('does not do anything if idempotency is disabled', async () => {
+    // Prepare
+    process.env.POWERTOOLS_IDEMPOTENCY_DISABLED = 'true';
+    const handler = middy(
+      async (_event: unknown, _context: Context): Promise<boolean> => true
+    ).use(makeHandlerIdempotent(mockIdempotencyOptions));
+    const saveInProgressSpy = jest.spyOn(
+      mockIdempotencyOptions.persistenceStore,
+      'saveInProgress'
+    );
+    const saveSuccessSpy = jest.spyOn(
+      mockIdempotencyOptions.persistenceStore,
+      'saveSuccess'
+    );
 
-      // Act
-      const result = await handler(event, context);
+    // Act
+    const result = await handler(event, context);
 
-      // Assess
-      expect(result).toStrictEqual({ response: false });
-      expect(getRecordSpy).toHaveBeenCalledTimes(1);
-      expect(getRecordSpy).toHaveBeenCalledWith(event);
-    });
-    it('retries if the record is in an inconsistent state', async () => {
-      // Prepare
-      const handler = middy(
-        async (_event: unknown, _context: Context): Promise<boolean> => true
-      ).use(makeHandlerIdempotent(mockIdempotencyOptions));
-      jest
-        .spyOn(mockIdempotencyOptions.persistenceStore, 'saveInProgress')
-        .mockRejectedValue(new IdempotencyItemAlreadyExistsError());
-      const stubRecordInconsistent = new IdempotencyRecord({
-        idempotencyKey: 'idempotencyKey',
-        expiryTimestamp: Date.now() + 10000,
-        inProgressExpiryTimestamp: 0,
-        responseData: { response: false },
-        payloadHash: 'payloadHash',
-        status: IdempotencyRecordStatus.EXPIRED,
-      });
-      const stubRecord = new IdempotencyRecord({
-        idempotencyKey: 'idempotencyKey',
-        expiryTimestamp: Date.now() + 10000,
-        inProgressExpiryTimestamp: 0,
-        responseData: { response: false },
-        payloadHash: 'payloadHash',
-        status: IdempotencyRecordStatus.COMPLETED,
-      });
-      const getRecordSpy = jest
-        .spyOn(mockIdempotencyOptions.persistenceStore, 'getRecord')
-        .mockResolvedValueOnce(stubRecordInconsistent)
-        .mockResolvedValueOnce(stubRecord);
-
-      // Act
-      const result = await handler(event, context);
-
-      // Assess
-      expect(result).toStrictEqual({ response: false });
-      expect(getRecordSpy).toHaveBeenCalledTimes(2);
-    });
-    it('throws after all the retries have been exhausted if the record is in an inconsistent state', async () => {
-      // Prepare
-      const handler = middy(
-        async (_event: unknown, _context: Context): Promise<boolean> => true
-      ).use(makeHandlerIdempotent(mockIdempotencyOptions));
-      jest
-        .spyOn(mockIdempotencyOptions.persistenceStore, 'saveInProgress')
-        .mockRejectedValue(new IdempotencyItemAlreadyExistsError());
-      const stubRecordInconsistent = new IdempotencyRecord({
-        idempotencyKey: 'idempotencyKey',
-        expiryTimestamp: Date.now() + 10000,
-        inProgressExpiryTimestamp: 0,
-        responseData: { response: false },
-        payloadHash: 'payloadHash',
-        status: IdempotencyRecordStatus.EXPIRED,
-      });
-      const getRecordSpy = jest
-        .spyOn(mockIdempotencyOptions.persistenceStore, 'getRecord')
-        .mockResolvedValue(stubRecordInconsistent);
-
-      // Act & Assess
-      await expect(handler(event, context)).rejects.toThrowError(
-        new IdempotencyInconsistentStateError(
-          'Item has expired during processing and may not longer be valid.'
-        )
-      );
-      expect(getRecordSpy).toHaveBeenCalledTimes(MAX_RETRIES + 1);
-    });
-    it('does not do anything if idempotency is disabled', async () => {
-      // Prepare
-      process.env.POWERTOOLS_IDEMPOTENCY_DISABLED = 'true';
-      const handler = middy(
-        async (_event: unknown, _context: Context): Promise<boolean> => true
-      ).use(makeHandlerIdempotent(mockIdempotencyOptions));
-      const saveInProgressSpy = jest.spyOn(
-        mockIdempotencyOptions.persistenceStore,
-        'saveInProgress'
-      );
-      const saveSuccessSpy = jest.spyOn(
-        mockIdempotencyOptions.persistenceStore,
-        'saveSuccess'
-      );
-
-      // Act
-      const result = await handler(event, context);
-
-      // Assess
-      expect(result).toBe(true);
-      expect(saveInProgressSpy).toHaveBeenCalledTimes(0);
-      expect(saveSuccessSpy).toHaveBeenCalledTimes(0);
-    });
+    // Assess
+    expect(result).toBe(true);
+    expect(saveInProgressSpy).toHaveBeenCalledTimes(0);
+    expect(saveSuccessSpy).toHaveBeenCalledTimes(0);
   });
 });

--- a/packages/idempotency/tests/unit/makeHandlerIdempotent.test.ts
+++ b/packages/idempotency/tests/unit/makeHandlerIdempotent.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Test Idempotency middleware
+ *
+ * @group unit/idempotency/makeHandlerIdempotent
+ */
+
+import { makeHandlerIdempotent } from '../../src/middleware';
+import { helloworldContext as dummyContext } from '../../../commons/src/samples/resources/contexts';
+import { Custom as dummyEvent } from '../../../commons/src/samples/resources/events';
+import { IdempotencyRecordStatus } from '../../src/types';
+import { BasePersistenceLayer, IdempotencyRecord } from '../../src/persistence';
+import {
+  IdempotencyPersistenceLayerError,
+  IdempotencyItemAlreadyExistsError,
+} from '../../src/Exceptions';
+import { IdempotencyConfig } from '../../src/IdempotencyConfig';
+import middy from '@middy/core';
+import type { Context } from 'aws-lambda';
+
+jest.spyOn(console, 'debug').mockImplementation(() => null);
+jest.spyOn(console, 'warn').mockImplementation(() => null);
+jest.spyOn(console, 'error').mockImplementation(() => null);
+
+class PersistenceLayerTestClass extends BasePersistenceLayer {
+  protected _deleteRecord = jest.fn();
+  protected _getRecord = jest.fn();
+  protected _putRecord = jest.fn();
+  protected _updateRecord = jest.fn();
+}
+
+const mockIdempotencyOptions = {
+  persistenceStore: new PersistenceLayerTestClass(),
+};
+const remainingTImeInMillis = 10000;
+
+describe('Middy middleware', () => {
+  const ENVIRONMENT_VARIABLES = process.env;
+  const context = dummyContext;
+  context.getRemainingTimeInMillis = jest
+    .fn()
+    .mockReturnValue(remainingTImeInMillis);
+  const event = dummyEvent.CustomEvent;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
+    process.env = { ...ENVIRONMENT_VARIABLES };
+  });
+
+  afterAll(() => {
+    process.env = ENVIRONMENT_VARIABLES;
+  });
+  describe('Middleware: captureLambdaHandler', () => {
+    it('handles a successful execution', async () => {
+      // Prepare
+      const handler = middy(
+        async (_event: unknown, _context: Context): Promise<boolean> => true
+      ).use(
+        makeHandlerIdempotent({
+          ...mockIdempotencyOptions,
+          config: new IdempotencyConfig({}),
+        })
+      );
+      const saveInProgressSpy = jest.spyOn(
+        mockIdempotencyOptions.persistenceStore,
+        'saveInProgress'
+      );
+      const saveSuccessSpy = jest.spyOn(
+        mockIdempotencyOptions.persistenceStore,
+        'saveSuccess'
+      );
+
+      // Act
+      const result = await handler(event, context);
+
+      // Assess
+      expect(result).toBe(true);
+      expect(saveInProgressSpy).toHaveBeenCalledTimes(1);
+      expect(saveInProgressSpy).toHaveBeenCalledWith(
+        event,
+        remainingTImeInMillis
+      );
+      expect(saveSuccessSpy).toHaveBeenCalledTimes(1);
+      expect(saveSuccessSpy).toHaveBeenCalledWith(event, true);
+    });
+    it('handles an execution that throws an error', async () => {
+      // Prepare
+      const handler = middy(
+        async (_event: unknown, _context: Context): Promise<boolean> => {
+          throw new Error('Something went wrong');
+        }
+      ).use(makeHandlerIdempotent(mockIdempotencyOptions));
+      const saveInProgressSpy = jest.spyOn(
+        mockIdempotencyOptions.persistenceStore,
+        'saveInProgress'
+      );
+      const deleteRecordSpy = jest.spyOn(
+        mockIdempotencyOptions.persistenceStore,
+        'deleteRecord'
+      );
+
+      // Act && Assess
+      await expect(handler(event, context)).rejects.toThrow();
+      expect(saveInProgressSpy).toHaveBeenCalledTimes(1);
+      expect(saveInProgressSpy).toHaveBeenCalledWith(
+        event,
+        remainingTImeInMillis
+      );
+      expect(deleteRecordSpy).toHaveBeenCalledTimes(1);
+      expect(deleteRecordSpy).toHaveBeenCalledWith(event);
+    });
+    it('thows an error if the persistence layer throws an error when saving in progress', async () => {
+      // Prepare
+      const handler = middy(
+        async (_event: unknown, _context: Context): Promise<boolean> => true
+      ).use(makeHandlerIdempotent(mockIdempotencyOptions));
+      jest
+        .spyOn(mockIdempotencyOptions.persistenceStore, 'saveInProgress')
+        .mockRejectedValue(new Error('Something went wrong'));
+
+      // Act && Assess
+      await expect(handler(event, context)).rejects.toThrowError(
+        new IdempotencyPersistenceLayerError(
+          'Failed to save in progress record to idempotency store'
+        )
+      );
+    });
+    it('thows an error if the persistence layer throws an error when saving a successful operation', async () => {
+      // Prepare
+      const handler = middy(
+        async (_event: unknown, _context: Context): Promise<boolean> => true
+      ).use(makeHandlerIdempotent(mockIdempotencyOptions));
+      jest
+        .spyOn(mockIdempotencyOptions.persistenceStore, 'saveSuccess')
+        .mockRejectedValue(new Error('Something went wrong'));
+
+      // Act && Assess
+      await expect(handler(event, context)).rejects.toThrowError(
+        new IdempotencyPersistenceLayerError(
+          'Failed to update success record to idempotency store'
+        )
+      );
+    });
+    it('thows an error if the persistence layer throws an error when deleting a record', async () => {
+      // Prepare
+      const handler = middy(
+        async (_event: unknown, _context: Context): Promise<boolean> => {
+          throw new Error('Something went wrong');
+        }
+      ).use(makeHandlerIdempotent(mockIdempotencyOptions));
+      jest
+        .spyOn(mockIdempotencyOptions.persistenceStore, 'deleteRecord')
+        .mockRejectedValue(new Error('Something went wrong'));
+
+      // Act && Assess
+      await expect(handler(event, context)).rejects.toThrow(
+        new IdempotencyPersistenceLayerError(
+          'Failed to delete record from idempotency store'
+        )
+      );
+    });
+    it('returns the stored response if the operation has already been executed', async () => {
+      // Prepare
+      const handler = middy(
+        async (_event: unknown, _context: Context): Promise<boolean> => true
+      ).use(makeHandlerIdempotent(mockIdempotencyOptions));
+      jest
+        .spyOn(mockIdempotencyOptions.persistenceStore, 'saveInProgress')
+        .mockRejectedValue(new IdempotencyItemAlreadyExistsError());
+      const stubRecord = new IdempotencyRecord({
+        idempotencyKey: 'idempotencyKey',
+        expiryTimestamp: Date.now() + 10000,
+        inProgressExpiryTimestamp: 0,
+        responseData: { response: false },
+        payloadHash: 'payloadHash',
+        status: IdempotencyRecordStatus.COMPLETED,
+      });
+      const getRecordSpy = jest
+        .spyOn(mockIdempotencyOptions.persistenceStore, 'getRecord')
+        .mockResolvedValue(stubRecord);
+
+      // Act
+      const result = await handler(event, context);
+
+      // Assess
+      expect(result).toStrictEqual({ response: false });
+      expect(getRecordSpy).toHaveBeenCalledTimes(1);
+      expect(getRecordSpy).toHaveBeenCalledWith(event);
+    });
+  });
+});

--- a/packages/idempotency/tests/unit/makeHandlerIdempotent.test.ts
+++ b/packages/idempotency/tests/unit/makeHandlerIdempotent.test.ts
@@ -3,7 +3,6 @@
  *
  * @group unit/idempotency/makeHandlerIdempotent
  */
-
 import { makeHandlerIdempotent } from '../../src/middleware';
 import { helloworldContext as dummyContext } from '../../../commons/src/samples/resources/contexts';
 import { Custom as dummyEvent } from '../../../commons/src/samples/resources/events';
@@ -16,10 +15,6 @@ import {
 import { IdempotencyConfig } from '../../src/IdempotencyConfig';
 import middy from '@middy/core';
 import type { Context } from 'aws-lambda';
-
-jest.spyOn(console, 'debug').mockImplementation(() => null);
-jest.spyOn(console, 'warn').mockImplementation(() => null);
-jest.spyOn(console, 'error').mockImplementation(() => null);
 
 class PersistenceLayerTestClass extends BasePersistenceLayer {
   protected _deleteRecord = jest.fn();
@@ -45,6 +40,9 @@ describe('Middy middleware', () => {
     jest.clearAllMocks();
     jest.restoreAllMocks();
     process.env = { ...ENVIRONMENT_VARIABLES };
+    jest.spyOn(console, 'debug').mockImplementation(() => null);
+    jest.spyOn(console, 'warn').mockImplementation(() => null);
+    jest.spyOn(console, 'error').mockImplementation(() => null);
   });
 
   afterAll(() => {

--- a/packages/idempotency/tests/unit/makeHandlerIdempotent.test.ts
+++ b/packages/idempotency/tests/unit/makeHandlerIdempotent.test.ts
@@ -251,5 +251,28 @@ describe('Middy middleware', () => {
       );
       expect(getRecordSpy).toHaveBeenCalledTimes(MAX_RETRIES + 1);
     });
+    it('does not do anything if idempotency is disabled', async () => {
+      // Prepare
+      process.env.POWERTOOLS_IDEMPOTENCY_DISABLED = 'true';
+      const handler = middy(
+        async (_event: unknown, _context: Context): Promise<boolean> => true
+      ).use(makeHandlerIdempotent(mockIdempotencyOptions));
+      const saveInProgressSpy = jest.spyOn(
+        mockIdempotencyOptions.persistenceStore,
+        'saveInProgress'
+      );
+      const saveSuccessSpy = jest.spyOn(
+        mockIdempotencyOptions.persistenceStore,
+        'saveSuccess'
+      );
+
+      // Act
+      const result = await handler(event, context);
+
+      // Assess
+      expect(result).toBe(true);
+      expect(saveInProgressSpy).toHaveBeenCalledTimes(0);
+      expect(saveSuccessSpy).toHaveBeenCalledTimes(0);
+    });
   });
 });


### PR DESCRIPTION
<!--- 
Instructions:
1. Make sure you follow our Contributing Guidelines: https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/CONTRIBUTING.md
2. Please follow the template, and do not remove any section/item. If something is not applicable leave it empty, but leave it in the PR. 
3. -->

## Description of your changes

<!---
Include here a summary of the change.

Please include also relevant motivation and context.

Add any applicable code snippets, links, screenshots, or other resources
that can help us verify your changes.
-->

This PR introduces a new Middy middleware that allows to wrap a Lambda handler and make it idempotent.

The middleware can be used like this:

```ts
import {
  makeHandlerIdempotent,
  DynamoDBPersistenceLayer,
} from '@aws-lambda-powertools/idempotency';
import middy from '@middy/core';

const dynamoDBPersistenceLayer = new DynamoDBPersistenceLayer({
  tableName: 'idempotencyTable',
});

const lambdaHandler = async (_event: unknown, _context: unknown) => {
  //...
};

export const handler = middy(lambdaHandler)
  .use(makeHandlerIdempotent({ persistenceStore: dynamoDBPersistenceLayer }));
```

#### Implementation details

The first detail to notice is that contrary to the function wrapper and the class method decorator, this middleware doesn't leverage fully the `IdempotencyHandler` class. The reason for this is that Middy has a specific lifecycle when it comes to logic running before, after, and in case of error thrown by the handler. The current implementation of the `IdempotencyHandler` groups certain actions together and expects certain signatures and a class instantiation and as such it's not possible for the middleware to use the same method all the time.

As a result, the middleware interacts with the persistence store directly and is in charge of handling/throwing the errors. This allows the middleware to follow its own patterns, however moving forward we will need to make sure we keep the two implementations in sync.

### Related issues, RFCs

<!--- 
Add here the number (i.e. #42) to the Github Issue or RFC that is related to this PR.

Don't include any other text, otherwise the Github Issue will not be detected.

Note: If no issue is present the PR might get blocked and not be reviewed.
-->
**Issue number:** #1293

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-typescript/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [ ] I have made corresponding changes to the *documentation*
- [x] My changes generate *no new warnings*
- [x] I have *added tests* that prove my change is effective and works
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

***Is it a breaking change?:*** NO

- [ ] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.