### PR TITLE
chore(tests): restore parameter in e2eUtils

### DIFF
--- a/packages/commons/tests/utils/e2eUtils.ts
+++ b/packages/commons/tests/utils/e2eUtils.ts
@@ -93,7 +93,7 @@ export const invokeFunction = async (
 
   const promiseFactory = (
     index?: number,
-    includeIndex?: boolean
+    includeIndex = true
   ): Promise<void> => {
     // in some cases we need to send a payload without the index, i.e. idempotency tests
     const payloadToSend = includeIndex


### PR DESCRIPTION
<!--- 
Instructions:
1. Make sure you follow our Contributing Guidelines: https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/CONTRIBUTING.md
2. Please follow the template, and do not remove any section/item. If something is not applicable leave it empty, but leave it in the PR. 
3. -->

## Description of your changes

<!---
Include here a summary of the change.

Please include also relevant motivation and context.

Add any applicable code snippets, links, screenshots, or other resources
that can help us verify your changes.
-->

As documented in the linked issue, when adding the integration tests to the Idempotency utility we mistakenly introduced a bug in the `e2eUtils` module that caused the invocation payload to be discarded when invoking the functions deployed as part of the integration test sequentially.

This PR fixes the issue by tweaking the function to support both sequential and parallel invocations. Once merged the PR will close #1488.

### Related issues, RFCs

<!--- 
Add here the number (i.e. #42) to the Github Issue or RFC that is related to this PR.

Don't include any other text, otherwise the Github Issue will not be detected.

Note: If no issue is present the PR might get blocked and not be reviewed.
-->
**Issue number:** #1488

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-typescript/#tenets)
- [x] I have performed a *self-review* of my own code
- [ ] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [ ] I have made corresponding changes to the *documentation*
- [x] My changes generate *no new warnings*
- [ ] I have *added tests* that prove my change is effective and works
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

***Is it a breaking change?:*** NO

- [ ] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.