### PR TITLE
fix(idempotency): record validation not using hash

### DIFF
--- a/packages/idempotency/src/persistence/BasePersistenceLayer.ts
+++ b/packages/idempotency/src/persistence/BasePersistenceLayer.ts
@@ -132,7 +132,7 @@ abstract class BasePersistenceLayer implements BasePersistenceLayerInterface {
       idempotencyKey: this.getHashedIdempotencyKey(data),
       status: IdempotencyRecordStatus.INPROGRESS,
       expiryTimestamp: this.getExpiryTimestamp(),
-      payloadHash: this.generateHash(JSON.stringify(data)),
+      payloadHash: this.getHashedPayload(data),
     });
 
     if (remainingTimeInMillis) {
@@ -167,7 +167,7 @@ abstract class BasePersistenceLayer implements BasePersistenceLayerInterface {
       status: IdempotencyRecordStatus.COMPLETED,
       expiryTimestamp: this.getExpiryTimestamp(),
       responseData: result,
-      payloadHash: this.generateHash(JSON.stringify(data)),
+      payloadHash: this.getHashedPayload(data),
     });
 
     await this._updateRecord(idempotencyRecord);
@@ -264,13 +264,13 @@ abstract class BasePersistenceLayer implements BasePersistenceLayerInterface {
    * @param data payload
    */
   private getHashedPayload(data: Record<string, unknown>): string {
-    // This method is only called when payload validation is enabled.
-    // For payload validation to be enabled, the validation key jmespath must be set.
-    // Therefore, the assertion is safe.
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    data = search(data, this.validationKeyJmesPath!);
+    if (this.isPayloadValidationEnabled() && this.validationKeyJmesPath) {
+      data = search(data, this.validationKeyJmesPath);
 
-    return this.generateHash(JSON.stringify(data));
+      return this.generateHash(JSON.stringify(data));
+    } else {
+      return '';
+    }
   }
 
   private static isMissingIdempotencyKey(

--- a/packages/idempotency/src/persistence/DynamoDBPersistenceLayer.ts
+++ b/packages/idempotency/src/persistence/DynamoDBPersistenceLayer.ts
@@ -48,7 +48,7 @@ class DynamoDBPersistenceLayer extends BasePersistenceLayer {
     this.statusAttr = config.statusAttr ?? 'status';
     this.expiryAttr = config.expiryAttr ?? 'expiration';
     this.inProgressExpiryAttr =
-      config.inProgressExpiryAttr ?? 'in_progress_expiry_attr';
+      config.inProgressExpiryAttr ?? 'in_progress_expiration';
     this.dataAttr = config.dataAttr ?? 'data';
     this.validationKeyAttr = config.validationKeyAttr ?? 'validation';
     if (config.sortKeyAttr === this.keyAttr) {
@@ -106,6 +106,7 @@ class DynamoDBPersistenceLayer extends BasePersistenceLayer {
       expiryTimestamp: item[this.expiryAttr],
       inProgressExpiryTimestamp: item[this.inProgressExpiryAttr],
       responseData: item[this.dataAttr],
+      payloadHash: item[this.validationKeyAttr],
     });
   }
 

--- a/packages/idempotency/tests/unit/persistence/BasePersistenceLayer.test.ts
+++ b/packages/idempotency/tests/unit/persistence/BasePersistenceLayer.test.ts
@@ -369,7 +369,7 @@ describe('Class: BasePersistenceLayer', () => {
           idempotencyKey: 'my-lambda-function#mocked-hash',
           status: IdempotencyRecordStatus.INPROGRESS,
           expiryTimestamp: Date.now() / 1000 + 3600,
-          payloadHash: 'mocked-hash',
+          payloadHash: '',
           inProgressExpiryTimestamp: Date.now() + remainingTimeInMs,
           responseData: undefined,
         })
@@ -455,7 +455,7 @@ describe('Class: BasePersistenceLayer', () => {
           idempotencyKey: 'my-lambda-function#mocked-hash',
           status: IdempotencyRecordStatus.COMPLETED,
           expiryTimestamp: Date.now() / 1000 + 3600,
-          payloadHash: 'mocked-hash',
+          payloadHash: '',
           inProgressExpiryTimestamp: undefined,
           responseData: result,
         })


### PR DESCRIPTION
<!--- 
Instructions:
1. Make sure you follow our Contributing Guidelines: https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/CONTRIBUTING.md
2. Please follow the template, and do not remove any section/item. If something is not applicable leave it empty, but leave it in the PR. 
3. -->

## Description of your changes

<!---
Include here a summary of the change.

Please include also relevant motivation and context.

Add any applicable code snippets, links, screenshots, or other resources
that can help us verify your changes.
-->

As reported in the linked issue, the persistence layer for the Idempotency utility was not using the payload hash when payload validation was enabled. This was caused by two issues:
- While the hash for the payload was saved in DynamoDB under the attribute `validation`, on subsequent requests the value was discarded at runtime and not used when instantiating the `IdempotencyRecord`
- The hash being generated and stored was using the full payload even when a JMESPath expression was specified, instead of using the expression to identify a subset of the payload. This would have caused the validation to always fail since the JMESPath expression was used in the control item but not in the stored one.

Both issues have been fixed in this PR. The PR also contains an unrelated change that aligns the name of the in progress expiry attribute with the reference implementation (`in_progress_expiration`).

### Related issues, RFCs

<!--- 
Add here the number (i.e. #42) to the Github Issue or RFC that is related to this PR.

Don't include any other text, otherwise the Github Issue will not be detected.

Note: If no issue is present the PR might get blocked and not be reviewed.
-->
**Issue number:** #1499

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-typescript/#tenets)
- [x] I have performed a *self-review* of my own code
- [ ] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [ ] I have made corresponding changes to the *documentation*
- [x] My changes generate *no new warnings*
- [x] I have *added tests* that prove my change is effective and works
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

***Is it a breaking change?:*** NO

- [ ] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.